### PR TITLE
fix: add tooltips to icon-only buttons

### DIFF
--- a/tauri-app/ui/src/App.svelte
+++ b/tauri-app/ui/src/App.svelte
@@ -177,9 +177,9 @@
       </span>
     </div>
     <nav class="tabs">
-      <button class="tab" class:active={activeTab === "chat"} onclick={() => activeTab = "chat"}>Command</button>
-      <button class="tab" class:active={activeTab === "log"} onclick={() => activeTab = "log"}>Activity</button>
-      <button class="tab" class:active={activeTab === "settings"} onclick={() => activeTab = "settings"}>Settings</button>
+      <button class="tab" class:active={activeTab === "chat"} title="Open Command Panel" onclick={() => activeTab = "chat"}>Command</button>
+      <button class="tab" class:active={activeTab === "log"} title="Open activity log" onclick={() => activeTab = "log"}>Activity</button>
+      <button class="tab" class:active={activeTab === "settings"} title="Open Settings" onclick={() => activeTab = "settings"}>Settings</button>
     </nav>
     <div class="titlebar-right">
       <AmbientHUD />
@@ -282,7 +282,7 @@
           </div>
         {/each}
       </div>
-      <button class="copy-button" type="button" aria-label="Copy message" onclick={() => copyMessage(msg)}>
+      <button class="copy-button" type="button" aria-label="Copy message" title="Copy" onclick={() => copyMessage(msg)}>
         <Copy size={14} />
       </button>
       <span
@@ -341,7 +341,7 @@
           {/each}
         </div>
       {/if}
-      <button class="copy-button" type="button" aria-label="Copy message" onclick={() => copyMessage(msg)}>
+      <button class="copy-button" type="button" aria-label="Copy message" title="Copy" onclick={() => copyMessage(msg)}>
         <Copy size={14} />
       </button>
       <span
@@ -359,7 +359,7 @@
     <div class="message error-msg has-copy">
       <span class="msg-label">ERROR</span>
       <span class="msg-text">{msg.text}</span>
-      <button class="copy-button" type="button" aria-label="Copy message" onclick={() => copyMessage(msg)}>
+      <button class="copy-button" type="button" aria-label="Copy message" title="Copy" onclick={() => copyMessage(msg)}>
         <Copy size={14} />
       </button>
       <span
@@ -377,7 +377,7 @@
     <div class="message system-msg has-copy">
       <span class="msg-label">HELIOX</span>
       <span class="msg-text">{msg.text}</span>
-      <button class="copy-button" type="button" aria-label="Copy message" onclick={() => copyMessage(msg)}>
+      <button class="copy-button" type="button" aria-label="Copy message" title="Copy" onclick={() => copyMessage(msg)}>
         <Copy size={14} />
       </button>
       <span

--- a/tauri-app/ui/src/lib/components/CommandInput.svelte
+++ b/tauri-app/ui/src/lib/components/CommandInput.svelte
@@ -29,7 +29,7 @@
       autocomplete="off"
       spellcheck="false"
     />
-    <button type="submit" class="send-btn" disabled={!input.trim()}>
+    <button type="submit" class="send-btn" title="Send" disabled={!input.trim()}>
       Send
     </button>
   </div>

--- a/tauri-app/ui/src/lib/components/ConfirmDialog.svelte
+++ b/tauri-app/ui/src/lib/components/ConfirmDialog.svelte
@@ -37,8 +37,8 @@
     </ul>
 
     <div class="confirm-actions">
-      <button class="btn-deny" onclick={ondeny}>Deny</button>
-      <button class="btn-confirm" onclick={onconfirm}>Approve & Execute</button>
+      <button class="btn-deny" title="Deny" onclick={ondeny}>Deny</button>
+      <button class="btn-confirm" title="Confirm" onclick={onconfirm}>Approve & Execute</button>
     </div>
   </div>
 </div>

--- a/tauri-app/ui/src/lib/components/GestureControl.svelte
+++ b/tauri-app/ui/src/lib/components/GestureControl.svelte
@@ -810,7 +810,7 @@
       <video bind:this={videoEl} class="cam-video" playsinline muted autoplay></video>
       <canvas bind:this={canvasEl} class="cam-overlay" width="320" height="240"></canvas>
       <canvas bind:this={trailCanvas} class="cam-trail" width="320" height="240"></canvas>
-      <button class="pip-close" onclick={stopGestures}>×</button>
+      <button class="pip-close" title="Close Camera" onclick={stopGestures}>×</button>
       {#if currentGesture}
         <div class="pip-gesture-tag">
           <span>{GESTURE_EMOJIS[currentGesture] || ""}</span>


### PR DESCRIPTION
## Description

Added native `title` attributes to icon-only buttons across the Svelte frontend to improve accessibility and provide hover tooltips for users.

## Changes Made

* Added tooltip/title support for copy buttons
* Added tooltip/title support for settings and other icon-only controls
* Improved accessibility and overall user experience

## Testing

* Set up the project locally
* Tested tooltip visibility on hover
* Verified that the UI works without regressions
