### PR TITLE
fix(ui): improve disabled button contrast in SettingsPanel #39

### DIFF
--- a/tauri-app/ui/src/lib/components/SettingsPanel.svelte
+++ b/tauri-app/ui/src/lib/components/SettingsPanel.svelte
@@ -435,7 +435,15 @@
   }
 
   .btn-save:disabled {
-    opacity: 0.6;
-    cursor: not-allowed;
-  }
+  cursor: not-allowed;
+  background: var(--bg-tertiary);
+  color: var(--text-secondary);
+  border: 1px solid var(--border);
+}
+
+  .btn-group button:disabled {
+  cursor: not-allowed;
+  color: var(--text-secondary);
+  background: var(--bg-tertiary);
+}
 </style>


### PR DESCRIPTION
## Summary
Fixes disabled button contrast in SettingsPanel to meet WCAG AA 
accessibility standards.

Closes #39

---

## Type of change
- [x] Bug fix

---

## Changes made
- `tauri-app/ui/src/lib/components/SettingsPanel.svelte`
  - Replaced `opacity: 0.6` on `.btn-save:disabled` with explicit 
    background and text colors using existing design system variables
  - Added `.btn-group button:disabled` styling (was previously unstyled)

---

## How to test
1. cd tauri-app/ui && npm install && npm run dev
2. Open http://localhost:1420/ in browser
3. Click the Settings tab
4. Observe the "Save" button before typing in the API key field — 
   It should show muted styling (not just faded purple)
5. Observe the provider toggle buttons styling

---

## Checklist
- [x] I have read the CONTRIBUTING.md
- [x] My code follows the existing code style
- [x] I have added/updated tests where applicable
- [x] All existing tests pass (`pytest` for backend, `npm run test` for frontend)
- [x] I have updated documentation if needed
- [x] I have tested on at least one platform (Windows / macOS / Linux)

---

## Screenshots/recordings (if UI change)

**WCAG Contrast Check — text-secondary (#9090A8) on bg-tertiary (#1E1E2A):**

<img width="1589" height="583" alt="Screenshot 2026-05-12 121932" src="https://github.com/user-attachments/assets/98a3683e-26cd-474b-8169-377a57ff9797" />

---

## GSSoC declaration
- [x] This contribution is made under the GSSoC 2026 program
- [x] I have not plagiarised code from other repositories