### PR TITLE
feat: add token bucket rate limiter for LLM API calls

### DIFF
--- a/daemon/pilot/config.py
+++ b/daemon/pilot/config.py
@@ -49,8 +49,8 @@ class ModelConfig:
     cloud_model: str = ""
     # Rate limiting — applied to every LLM call via ModelRouter
     rate_limit_enabled: bool = True
-    rate_limit_rpm: int = 60    # sustained requests per minute
-    rate_limit_burst: int = 5   # token bucket burst capacity
+    rate_limit_rpm: int = 60  # sustained requests per minute
+    rate_limit_burst: int = 5  # token bucket burst capacity
 
 
 @dataclass

--- a/daemon/pilot/config.py
+++ b/daemon/pilot/config.py
@@ -47,6 +47,10 @@ class ModelConfig:
     idle_unload_seconds: int = 60
     cloud_provider: str = ""  # "openai" | "claude" | "gemini"
     cloud_model: str = ""
+    # Rate limiting — applied to every LLM call via ModelRouter
+    rate_limit_enabled: bool = True
+    rate_limit_rpm: int = 60    # sustained requests per minute
+    rate_limit_burst: int = 5   # token bucket burst capacity
 
 
 @dataclass

--- a/daemon/pilot/models/rate_limiter.py
+++ b/daemon/pilot/models/rate_limiter.py
@@ -1,0 +1,81 @@
+"""Token bucket rate limiter for LLM API calls."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pilot.config import ModelConfig
+
+logger = logging.getLogger("pilot.models.rate_limiter")
+
+
+class TokenBucketRateLimiter:
+    """Async token bucket rate limiter.
+
+    Tokens refill continuously at ``rate_limit_rpm / 60`` per second up to
+    ``rate_limit_burst`` capacity.  Each call to :meth:`acquire` consumes one
+    token, waiting if the bucket is empty.  Sleep happens outside the lock so
+    other coroutines can still acquire concurrently.
+    """
+
+    def __init__(self, config: ModelConfig) -> None:
+        self._enabled = config.rate_limit_enabled
+        self._rate = config.rate_limit_rpm / 60.0  # tokens per second
+        self._capacity = float(config.rate_limit_burst)
+        self._tokens = float(config.rate_limit_burst)
+        self._last_refill = time.monotonic()
+        self._lock = asyncio.Lock()
+        self._total_calls = 0
+        self._total_waits = 0
+        self._total_wait_ms = 0.0
+
+    def _refill(self) -> None:
+        now = time.monotonic()
+        self._tokens = min(
+            self._capacity,
+            self._tokens + (now - self._last_refill) * self._rate,
+        )
+        self._last_refill = now
+
+    async def acquire(self) -> None:
+        """Block until a token is available, then consume it."""
+        if not self._enabled:
+            return
+        while True:
+            async with self._lock:
+                self._refill()
+                if self._tokens >= 1.0:
+                    self._tokens -= 1.0
+                    self._total_calls += 1
+                    return
+                # Compute wait outside the lock to avoid blocking other callers
+                wait_time = (1.0 - self._tokens) / self._rate
+
+            t0 = time.monotonic()
+            logger.warning("Rate limit reached — waiting %.2fs before next LLM call", wait_time)
+            await asyncio.sleep(wait_time)
+            elapsed = time.monotonic() - t0
+            self._total_waits += 1
+            self._total_wait_ms += elapsed * 1000
+
+    def reconfigure(self, config: ModelConfig) -> None:
+        """Update rate/burst settings at runtime (e.g. after config change)."""
+        self._enabled = config.rate_limit_enabled
+        self._rate = config.rate_limit_rpm / 60.0
+        self._capacity = float(config.rate_limit_burst)
+
+    def get_stats(self) -> dict:
+        """Return current limiter state and lifetime counters."""
+        return {
+            "enabled": self._enabled,
+            "rpm": self._rate * 60,
+            "burst": self._capacity,
+            "available_tokens": round(self._tokens, 2),
+            "total_calls": self._total_calls,
+            "total_waits": self._total_waits,
+            "avg_wait_ms": round(self._total_wait_ms / max(self._total_waits, 1), 1),
+        }

--- a/daemon/pilot/models/router.py
+++ b/daemon/pilot/models/router.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 
 from pilot.models.cloud import CloudClient
 from pilot.models.ollama import OllamaClient
+from pilot.models.rate_limiter import TokenBucketRateLimiter
 
 if TYPE_CHECKING:
     from pilot.config import PilotConfig
@@ -35,6 +36,8 @@ class ModelRouter:
         if config.model.cloud_provider:
             self._cloud = CloudClient(config, vault)
 
+        self._rate_limiter = TokenBucketRateLimiter(config.model)
+
     async def generate(
         self,
         prompt: str,
@@ -44,6 +47,7 @@ class ModelRouter:
         temperature: float = 0.1,
     ) -> str:
         """Generate a completion from the best available model."""
+        await self._rate_limiter.acquire()
         provider = self._config.model.provider
 
         if provider == "cloud" and self._cloud:
@@ -128,6 +132,10 @@ class ModelRouter:
 
         client: LlamaCppClient = self._llamacpp  # type: ignore[assignment]
         return await client.generate(prompt, system=system, temperature=temperature)
+
+    def rate_limit_stats(self) -> dict:
+        """Return current rate limiter state and lifetime counters."""
+        return self._rate_limiter.get_stats()
 
     async def check_health(self) -> dict[str, bool]:
         """Check which backends are available."""

--- a/daemon/tests/test_rate_limiter.py
+++ b/daemon/tests/test_rate_limiter.py
@@ -1,0 +1,149 @@
+"""Unit tests for pilot.models.rate_limiter.TokenBucketRateLimiter.
+
+Run with:
+    cd daemon
+    pytest tests/test_rate_limiter.py -v --tb=short
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from pilot.models.rate_limiter import TokenBucketRateLimiter
+
+
+# ---------------------------------------------------------------------------
+# Minimal ModelConfig stub
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class FakeModelConfig:
+    rate_limit_enabled: bool = True
+    rate_limit_rpm: int = 60
+    rate_limit_burst: int = 3
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def make_limiter(**kwargs) -> TokenBucketRateLimiter:
+    return TokenBucketRateLimiter(FakeModelConfig(**kwargs))
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_acquire_within_burst_does_not_wait():
+    """Calls within burst capacity complete immediately (no sleep)."""
+    limiter = make_limiter(rate_limit_burst=3)
+    with patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+        for _ in range(3):
+            await limiter.acquire()
+        mock_sleep.assert_not_called()
+    assert limiter.get_stats()["total_calls"] == 3
+    assert limiter.get_stats()["total_waits"] == 0
+
+
+@pytest.mark.asyncio
+async def test_acquire_beyond_burst_triggers_wait():
+    """Exhausting the bucket causes a sleep on the next call.
+
+    We must also advance the simulated clock by the sleep duration so that
+    _refill() adds enough tokens after the sleep returns, preventing an
+    infinite retry loop.
+    """
+    import time as _real_time
+
+    _offset = [0.0]
+    _real_mono = _real_time.monotonic
+
+    def fake_monotonic():
+        return _real_mono() + _offset[0]
+
+    async def advancing_sleep(seconds: float) -> None:
+        _offset[0] += seconds + 0.001  # advance simulated clock past the wait
+
+    limiter = make_limiter(rate_limit_burst=1, rate_limit_rpm=60)
+    with (
+        patch("pilot.models.rate_limiter.time") as mock_time,
+        patch("asyncio.sleep", side_effect=advancing_sleep),
+    ):
+        mock_time.monotonic.side_effect = fake_monotonic
+        await limiter.acquire()  # consumes the single token
+        await limiter.acquire()  # bucket empty → waits once then succeeds
+
+    assert limiter.get_stats()["total_waits"] == 1
+
+
+@pytest.mark.asyncio
+async def test_disabled_limiter_never_waits():
+    """When rate_limit_enabled=False, acquire() returns immediately every time."""
+    limiter = make_limiter(rate_limit_enabled=False, rate_limit_burst=1, rate_limit_rpm=60)
+    with patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+        for _ in range(10):
+            await limiter.acquire()
+        mock_sleep.assert_not_called()
+    # total_calls is not incremented when disabled
+    assert limiter.get_stats()["total_calls"] == 0
+
+
+@pytest.mark.asyncio
+async def test_tokens_depleted_after_burst():
+    """Available tokens reach ~0 after consuming the full burst."""
+    limiter = make_limiter(rate_limit_burst=3, rate_limit_rpm=60)
+    with patch("asyncio.sleep", new_callable=AsyncMock):
+        for _ in range(3):
+            await limiter.acquire()
+        # One more call empties bucket; tokens should be < 1 (possibly negative mid-wait)
+        await limiter.acquire()
+    stats = limiter.get_stats()
+    assert stats["total_calls"] == 4
+
+
+@pytest.mark.asyncio
+async def test_reconfigure_updates_rate_and_burst():
+    """reconfigure() changes the rate and burst without resetting stats."""
+    limiter = make_limiter(rate_limit_rpm=60, rate_limit_burst=5)
+    with patch("asyncio.sleep", new_callable=AsyncMock):
+        await limiter.acquire()
+
+    new_config = FakeModelConfig(rate_limit_rpm=120, rate_limit_burst=10)
+    limiter.reconfigure(new_config)
+
+    stats = limiter.get_stats()
+    assert stats["rpm"] == 120
+    assert stats["burst"] == 10
+    assert stats["total_calls"] == 1  # previous call still counted
+
+
+@pytest.mark.asyncio
+async def test_get_stats_shape():
+    """get_stats() returns all expected keys."""
+    limiter = make_limiter()
+    stats = limiter.get_stats()
+    for key in ("enabled", "rpm", "burst", "available_tokens", "total_calls", "total_waits", "avg_wait_ms"):
+        assert key in stats, f"Missing key: {key}"
+
+
+@pytest.mark.asyncio
+async def test_reconfigure_disable():
+    """Disabling via reconfigure stops waits on subsequent calls."""
+    limiter = make_limiter(rate_limit_burst=1, rate_limit_rpm=60)
+    with patch("asyncio.sleep", new_callable=AsyncMock):
+        await limiter.acquire()  # consume token
+
+    limiter.reconfigure(FakeModelConfig(rate_limit_enabled=False))
+    with patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+        for _ in range(5):
+            await limiter.acquire()
+        mock_sleep.assert_not_called()


### PR DESCRIPTION
## Summary

- Adds `daemon/pilot/models/rate_limiter.py` with a `TokenBucketRateLimiter` class (token bucket algorithm, async-safe, lock outside sleep)
- Wires the limiter into `ModelRouter.generate()` — the single chokepoint all agents go through — so **no agent code changes are required**
- Adds 3 config fields to `ModelConfig` in `config.py`: `rate_limit_enabled` (default `True`), `rate_limit_rpm` (default `60`), `rate_limit_burst` (default `5`)
- Exposes `ModelRouter.rate_limit_stats()` for observability
- Adds 7 unit tests in `daemon/tests/test_rate_limiter.py` covering: burst headroom, wait triggering, disabled mode, reconfigure, and stats shape

## How it works

Tokens refill at `rate_limit_rpm / 60` per second up to `rate_limit_burst` capacity. Each `generate()` call consumes one token; if the bucket is empty the call waits (sleeping **outside** the lock so other coroutines remain unblocked). A `WARNING` log is emitted on each wait.

Rate limiting can be disabled entirely by setting `rate_limit_enabled = false` in `~/.config/pilot/config.toml`.

## Note on test file

The root `.gitignore` has a `test_*.py` pattern listed under "Test artifacts" which would normally exclude the test file. Since `daemon/tests/test_decomposer.py` was already tracked via force-add, I've done the same for `daemon/tests/test_rate_limiter.py` (`git add -f`). You may want to update the `.gitignore` to explicitly allow `daemon/tests/test_*.py`.

## Test plan

- [x] `pytest tests/test_rate_limiter.py` — 7 passed
- [x] `pytest tests/test_decomposer.py` — 42 passed (no regressions)

Closes #22