### PR TITLE
feat: add session usage tracking and estimated cost display

### DIFF
--- a/tauri-app/ui/src/lib/components/SettingsPanel.svelte
+++ b/tauri-app/ui/src/lib/components/SettingsPanel.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { settings } from "../stores/settings";
+  import { session } from "../stores/session";
   import { call } from "../api/daemon";
 
   let apiKeyInput = $state("");
@@ -54,7 +55,9 @@
       await call("store_api_key", { provider, api_key: apiKeyInput.trim() });
       apiKeySaved = true;
       apiKeyInput = "";
-      setTimeout(() => { apiKeySaved = false; }, 3000);
+      setTimeout(() => {
+        apiKeySaved = false;
+      }, 3000);
     } catch (err) {
       console.error("Failed to save API key:", err);
     } finally {
@@ -78,6 +81,8 @@
         class="toggle"
         class:active={$settings.security.root_enabled}
         onclick={toggleRoot}
+        aria-label="Toggle Root Access"
+        title="Toggle Root Access"
       >
         <span class="toggle-knob"></span>
       </button>
@@ -91,9 +96,12 @@
       <button
         class="toggle"
         class:active={$settings.security.snapshot_on_destructive}
-        onclick={() => settings.updateSection("security", {
-          snapshot_on_destructive: !$settings.security.snapshot_on_destructive
-        })}
+        onclick={() =>
+          settings.updateSection("security", {
+            snapshot_on_destructive: !$settings.security.snapshot_on_destructive,
+          })}
+        aria-label="Toggle Auto Snapshot"
+        title="Toggle Auto Snapshot"
       >
         <span class="toggle-knob"></span>
       </button>
@@ -108,6 +116,8 @@
         class="toggle"
         class:active={$settings.security.dry_run}
         onclick={toggleDryRun}
+        aria-label="Toggle Dry Run Mode"
+        title="Toggle Dry Run Mode"
       >
         <span class="toggle-knob"></span>
       </button>
@@ -130,6 +140,33 @@
   </section>
 
   <section class="settings-group">
+    <h3>Usage</h3>
+
+    <div class="setting-row">
+      <div class="setting-info">
+        <span class="setting-label">Total Tokens</span>
+        <span class="setting-desc">Estimated session token usage</span>
+      </div>
+      <span>{$session.totalTokens}</span>
+    </div>
+
+    <div class="setting-row">
+      <div class="setting-info">
+        <span class="setting-label">Estimated Cost</span>
+        <span class="setting-desc">Approximate API usage cost</span>
+      </div>
+
+      <span>
+        {$settings.model.provider === "ollama" ? "Free (local)" : `$${$session.estimatedCost.toFixed(4)}`}
+      </span>
+    </div>
+
+    <div class="setting-row">
+      <button class="btn-save" onclick={() => session.resetUsage()}> Reset Session Usage </button>
+    </div>
+  </section>
+
+  <section class="settings-group">
     <h3>Model</h3>
 
     <div class="setting-row">
@@ -138,14 +175,10 @@
         <span class="setting-desc">Primary model backend</span>
       </div>
       <div class="btn-group">
-        <button
-          class:active={$settings.model.provider === "ollama"}
-          onclick={() => setProvider("ollama")}
-        >Ollama</button>
-        <button
-          class:active={$settings.model.provider === "cloud"}
-          onclick={() => setProvider("cloud")}
-        >Cloud</button>
+        <button class:active={$settings.model.provider === "ollama"} onclick={() => setProvider("ollama")}
+          >Ollama</button
+        >
+        <button class:active={$settings.model.provider === "cloud"} onclick={() => setProvider("cloud")}>Cloud</button>
       </div>
     </div>
 
@@ -155,14 +188,10 @@
         <span class="setting-desc">Trade speed for accuracy</span>
       </div>
       <div class="btn-group">
-        <button
-          class:active={$settings.model.mode === "lightweight"}
-          onclick={() => setMode("lightweight")}
-        >Light</button>
-        <button
-          class:active={$settings.model.mode === "full"}
-          onclick={() => setMode("full")}
-        >Full</button>
+        <button class:active={$settings.model.mode === "lightweight"} onclick={() => setMode("lightweight")}
+          >Light</button
+        >
+        <button class:active={$settings.model.mode === "full"} onclick={() => setMode("full")}>Full</button>
       </div>
     </div>
 
@@ -205,18 +234,15 @@
         <span class="setting-desc">Select your cloud LLM provider</span>
       </div>
       <div class="btn-group">
-        <button
-          class:active={$settings.model.cloud_provider === "gemini"}
-          onclick={() => setCloudProvider("gemini")}
-        >Gemini</button>
-        <button
-          class:active={$settings.model.cloud_provider === "openai"}
-          onclick={() => setCloudProvider("openai")}
-        >OpenAI</button>
-        <button
-          class:active={$settings.model.cloud_provider === "claude"}
-          onclick={() => setCloudProvider("claude")}
-        >Claude</button>
+        <button class:active={$settings.model.cloud_provider === "gemini"} onclick={() => setCloudProvider("gemini")}
+          >Gemini</button
+        >
+        <button class:active={$settings.model.cloud_provider === "openai"} onclick={() => setCloudProvider("openai")}
+          >OpenAI</button
+        >
+        <button class:active={$settings.model.cloud_provider === "claude"} onclick={() => setCloudProvider("claude")}
+          >Claude</button
+        >
       </div>
     </div>
 
@@ -240,12 +266,7 @@
         <span class="setting-desc">Stored securely in system keyring</span>
       </div>
       <div class="api-key-row">
-        <input
-          type="password"
-          class="input-md"
-          bind:value={apiKeyInput}
-          placeholder="Paste API key..."
-        />
+        <input type="password" class="input-md" bind:value={apiKeyInput} placeholder="Paste API key..." />
         <button class="btn-save" onclick={saveApiKey} disabled={apiKeySaving}>
           {apiKeySaved ? "✓ Saved!" : apiKeySaving ? "Saving..." : "Save"}
         </button>
@@ -256,16 +277,16 @@
   <section class="settings-group">
     <h3>Restrictions</h3>
     <div class="restriction-info">
-      <p>Protected folders: {$settings.restrictions.protected_folders.length} configured</p>
-      <p>Protected packages: {$settings.restrictions.protected_packages.length} configured</p>
-      <p>Blocked commands: {$settings.restrictions.blocked_commands.length} configured</p>
+      <p>Protected folders: {$settings.restrictions?.protected_folders?.length || 0} configured</p>
+      <p>Protected packages: {$settings.restrictions?.protected_packages?.length || 0} configured</p>
+      <p>Blocked commands: {$settings.restrictions?.blocked_commands?.length || 0} configured</p>
     </div>
   </section>
 </div>
 
 <style>
   .settings-panel {
-    height: 100%;
+    height: 100%; 
     overflow-y: auto;
     padding: 16px;
   }
@@ -435,15 +456,15 @@
   }
 
   .btn-save:disabled {
-  cursor: not-allowed;
-  background: var(--bg-tertiary);
-  color: var(--text-secondary);
-  border: 1px solid var(--border);
-}
+    cursor: not-allowed;
+    background: var(--bg-tertiary);
+    color: var(--text-secondary);
+    border: 1px solid var(--border);
+  }
 
   .btn-group button:disabled {
-  cursor: not-allowed;
-  color: var(--text-secondary);
-  background: var(--bg-tertiary);
-}
+    cursor: not-allowed;
+    color: var(--text-secondary);
+    background: var(--bg-tertiary);
+  }
 </style>

--- a/tauri-app/ui/src/lib/stores/session.ts
+++ b/tauri-app/ui/src/lib/stores/session.ts
@@ -1,5 +1,6 @@
-import { writable } from "svelte/store";
+import { writable, get } from "svelte/store";
 import { call, connect, isConnected, onNotification } from "../api/daemon";
+import { settings } from "./settings";
 
 export type MessageType = "user" | "system" | "error" | "plan" | "result";
 
@@ -59,6 +60,8 @@ interface SessionState {
   confirmActions: PlanAction[];
   phase: string;
   liveActions: LiveActionState[];
+  totalTokens: number;
+  estimatedCost: number;
 }
 
 const initialState: SessionState = {
@@ -71,7 +74,19 @@ const initialState: SessionState = {
   confirmActions: [],
   phase: "",
   liveActions: [],
+  totalTokens: 0,
+  estimatedCost: 0,
 };
+
+const MODEL_RATES: Record<string, number> = {
+  "gemini-1.5-pro": 0.000003,
+  "gpt-4o": 0.000005,
+  "claude-sonnet": 0.000004,
+};
+
+function estimateTokens(text: string): number {
+  return Math.ceil(text.length / 4);
+}
 
 function createSession() {
   const { subscribe, update, set } = writable<SessionState>(initialState);
@@ -112,7 +127,7 @@ function createSession() {
         }));
         break;
       }
-      
+
       case "action_start": {
         update(s => {
           const nextIdx = s.liveActions.findIndex(a => a.status === "pending");
@@ -125,7 +140,7 @@ function createSession() {
         });
         break;
       }
-      
+
       case "action_complete": {
         const resultObj = p.result as Record<string, unknown>;
         const success = Boolean(resultObj.success);
@@ -133,8 +148,8 @@ function createSession() {
           const runningIdx = s.liveActions.findIndex(a => a.status === "running");
           if (runningIdx !== -1) {
             const live = [...s.liveActions];
-            live[runningIdx] = { 
-              ...live[runningIdx], 
+            live[runningIdx] = {
+              ...live[runningIdx],
               status: success ? "success" : "error",
               output: String(resultObj.output || ""),
               error: String(resultObj.error || "")
@@ -201,9 +216,9 @@ function createSession() {
       const rawVerification = result.verification as Record<string, unknown> | undefined;
       const verification: VerificationData | undefined = rawVerification
         ? {
-            passed: Boolean(rawVerification.passed),
-            details: ((rawVerification.details ?? []) as string[]),
-          }
+          passed: Boolean(rawVerification.passed),
+          details: ((rawVerification.details ?? []) as string[]),
+        }
         : undefined;
 
       if (result.status === "error") {
@@ -238,19 +253,46 @@ function createSession() {
           ],
         }));
       } else {
+        const responseText = isDryRun
+          ? String(result.explanation || "(dry run) No changes were made.")
+          : String(result.explanation ?? "");
+
+        const estimatedTokens = estimateTokens(responseText);
+
+        const settingsState = get(settings);
+        const model =
+          settingsState?.model?.cloud_model ||
+          settingsState?.model?.cloud_provider ||
+          "ollama";
+
+        const normalizedModel = model.toLowerCase();
+
+        let rate = 0;
+
+        if (normalizedModel.includes("gemini")) {
+          rate = MODEL_RATES["gemini-1.5-pro"];
+        } else if (normalizedModel.includes("gpt-4o")) {
+          rate = MODEL_RATES["gpt-4o"];
+        } else if (normalizedModel.includes("claude")) {
+          rate = MODEL_RATES["claude-sonnet"];
+        }
+        const estimatedCost = Number((estimatedTokens * rate).toFixed(6));
+
         update((s) => ({
           ...s,
           loading: false,
           phase: "",
           currentPlan: null,
           confirmRequired: false,
+
+          totalTokens: s.totalTokens + estimatedTokens,
+          estimatedCost: s.estimatedCost + estimatedCost,
+
           messages: [
             ...s.messages,
             {
               type: "result" as MessageType,
-              text: isDryRun
-                ? String(result.explanation || "(dry run) No changes were made.")
-                : String(result.explanation ?? ""),
+              text: responseText,
               timestamp: Date.now(),
               actionResults,
               verification,
@@ -297,7 +339,7 @@ function createSession() {
       }));
     }
 
-    call("confirm", { plan_id: planId, confirmed: accepted }).catch(() => {});
+    call("confirm", { plan_id: planId, confirmed: accepted }).catch(() => { });
   }
 
   function addSystemMessage(text: string) {
@@ -314,6 +356,14 @@ function createSession() {
     update((s) => ({ ...s, messages: [] }));
   }
 
+  function resetUsage() {
+    update((s) => ({
+      ...s,
+      totalTokens: 0,
+      estimatedCost: 0,
+    }));
+  }
+
   init();
 
   return {
@@ -322,6 +372,7 @@ function createSession() {
     confirm,
     addSystemMessage,
     clearMessages,
+    resetUsage,
   };
 }
 


### PR DESCRIPTION
## Summary

Adds a new **Usage** section to the Settings panel for tracking estimated session token usage and API costs.

## Features Added

* Tracks estimated token usage per session
* Displays estimated session API cost
* Added model-based pricing support for:

  * Gemini 1.5 Pro
  * GPT-4o
  * Claude Sonnet
* Displays `Free (local)` for Ollama usage
* Added "Reset Session Usage" button
* Usage values update after successful agent responses

## Implementation Details

* Added client-side session usage state in `session.ts`
* Implemented estimated token calculation using character-based approximation
* Added hardcoded per-token pricing logic for supported cloud models
* Added Usage section UI in `SettingsPanel.svelte`

## Additional Improvements

* Added accessibility labels for toggle buttons
* Added safer optional chaining for restrictions rendering to prevent runtime crashes
* Fixed minor alignment and indentation issues for improved readability and maintainability

## Testing

Tested locally by:

* verifying Usage UI rendering
* validating session state updates
* validating reset functionality
* checking provider-specific cost display behavior

## Screenshots

### Usage Section

<img width="1521" height="709" alt="image" src="https://github.com/user-attachments/assets/60323ffa-e53d-4219-9d80-548f31eacfad" />

### Ollama Local Usage Display

<img width="1536" height="713" alt="image" src="https://github.com/user-attachments/assets/38e46c50-3301-4794-994d-a816d4120aef" />

## Notes

* Token and pricing values are estimates calculated client-side
* Live response testing depends on configured backend/API provider availability



