### PR TITLE
feat: validate config.toml structure on daemon startup (Fixes #60)

### DIFF
--- a/daemon/pilot/config.py
+++ b/daemon/pilot/config.py
@@ -120,47 +120,41 @@ class PilotConfig:
 logger = logging.getLogger("pilot.config")
 
 def _validate_config_types(raw: dict) -> None:
-    """Validate the data types of the loaded TOML configuration."""
+    """Validate that the user's config has no typos and uses correct types."""
     expected_types = {
         "model": {
-            "provider": str,
-            "ollama_base_url": str,
-            "ollama_model": str,
-            "mode": str,
-            "gpu_memory_limit_mb": int,
-            "idle_unload_seconds": int,
-            "cloud_provider": str,
-            "cloud_model": str,
-            "rate_limit_enabled": bool,
-            "rate_limit_rpm": int,
-            "rate_limit_burst": int,
+            "provider": str, "ollama_base_url": str, "ollama_model": str,
+            "mode": str, "gpu_memory_limit_mb": int, "idle_unload_seconds": int,
+            "cloud_provider": str, "cloud_model": str, "rate_limit_enabled": bool,
+            "rate_limit_rpm": int, "rate_limit_burst": int,
         },
         "security": {
-            "root_enabled": bool,
-            "confirm_tier2": bool,
-            "dry_run": bool,
-            "snapshot_on_destructive": bool,
-            "snapshot_backend": str,
-            "snapshot_retention_count": int,
-            "snapshot_retention_days": int,
+            "root_enabled": bool, "confirm_tier2": bool, "dry_run": bool,
+            "snapshot_on_destructive": bool, "snapshot_backend": str,
+            "snapshot_retention_count": int, "snapshot_retention_days": int,
             "unrestricted_shell": bool,
         },
         "server": {
-            "host": str,
-            "port": int,
-            "auth_token": str,
+            "host": str, "port": int, "auth_token": str,
         }
     }
 
-    for section, keys in expected_types.items():
+    for section, expected_keys in expected_types.items():
         if section in raw and isinstance(raw[section], dict):
-            for key, expected_type in keys.items():
-                if key in raw[section]:
-                    value = raw[section][key]
-                    if not isinstance(value, expected_type):
-                        error_msg = f"Invalid config: '{section}.{key}' must be {expected_type.__name__}, got {type(value).__name__}."
-                        logger.error(error_msg)
-                        raise ValueError(error_msg)
+            # We iterate over the USER'S keys to find typos
+            for actual_key, actual_value in raw[section].items():
+                # 1. Catch Typos (Unknown Keys)
+                if actual_key not in expected_keys:
+                    error_msg = f"Invalid config key found: '{section}.{actual_key}'. Please check for typos."
+                    logger.error(error_msg)
+                    raise ValueError(error_msg)
+                
+                # 2. Catch Wrong Types
+                expected_type = expected_keys[actual_key]
+                if not isinstance(actual_value, expected_type):
+                    error_msg = f"Invalid type: '{section}.{actual_key}' must be {expected_type.__name__}, got {type(actual_value).__name__}."
+                    logger.error(error_msg)
+                    raise ValueError(error_msg)
 
 def _merge_config(config: PilotConfig, raw: dict[str, Any]) -> PilotConfig:
     if "model" in raw:

--- a/daemon/pilot/config.py
+++ b/daemon/pilot/config.py
@@ -127,6 +127,8 @@ def _validate_config_types(raw: dict) -> None:
             "mode": str, "gpu_memory_limit_mb": int, "idle_unload_seconds": int,
             "cloud_provider": str, "cloud_model": str, "rate_limit_enabled": bool,
             "rate_limit_rpm": int, "rate_limit_burst": int,
+            # NEW: PR #98 Budget Keys
+            "budget_enabled": bool, "budget_monthly_limit_usd": float,
         },
         "security": {
             "root_enabled": bool, "confirm_tier2": bool, "dry_run": bool,

--- a/daemon/pilot/config.py
+++ b/daemon/pilot/config.py
@@ -7,6 +7,7 @@ import sys
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
+import logging
 
 if sys.version_info >= (3, 12):
     import tomllib
@@ -91,12 +92,17 @@ class PilotConfig:
     first_run_complete: bool = False
 
     @classmethod
-    def load(cls) -> PilotConfig:
+    def load(cls) -> "PilotConfig":
         """Load config from disk, creating defaults if missing."""
         config = cls()
         if CONFIG_FILE.exists():
-            raw = tomllib.loads(CONFIG_FILE.read_text(encoding="utf-8"))
-            config = _merge_config(config, raw)
+            try:
+                raw = tomllib.loads(CONFIG_FILE.read_text(encoding="utf-8"))
+                _validate_config_types(raw)  # <-- Our new validation check
+                config = _merge_config(config, raw)
+            except Exception as e:
+                logger.error(f"Failed to load config.toml: {e}. Falling back to safe defaults.")
+                
         if RESTRICTIONS_FILE.exists():
             raw = tomllib.loads(RESTRICTIONS_FILE.read_text(encoding="utf-8"))
             config.restrictions = _parse_restrictions(raw)
@@ -111,6 +117,50 @@ class PilotConfig:
         if restrictions:
             RESTRICTIONS_FILE.write_text(tomli_w.dumps(restrictions), encoding="utf-8")
 
+logger = logging.getLogger("pilot.config")
+
+def _validate_config_types(raw: dict) -> None:
+    """Validate the data types of the loaded TOML configuration."""
+    expected_types = {
+        "model": {
+            "provider": str,
+            "ollama_base_url": str,
+            "ollama_model": str,
+            "mode": str,
+            "gpu_memory_limit_mb": int,
+            "idle_unload_seconds": int,
+            "cloud_provider": str,
+            "cloud_model": str,
+            "rate_limit_enabled": bool,
+            "rate_limit_rpm": int,
+            "rate_limit_burst": int,
+        },
+        "security": {
+            "root_enabled": bool,
+            "confirm_tier2": bool,
+            "dry_run": bool,
+            "snapshot_on_destructive": bool,
+            "snapshot_backend": str,
+            "snapshot_retention_count": int,
+            "snapshot_retention_days": int,
+            "unrestricted_shell": bool,
+        },
+        "server": {
+            "host": str,
+            "port": int,
+            "auth_token": str,
+        }
+    }
+
+    for section, keys in expected_types.items():
+        if section in raw and isinstance(raw[section], dict):
+            for key, expected_type in keys.items():
+                if key in raw[section]:
+                    value = raw[section][key]
+                    if not isinstance(value, expected_type):
+                        error_msg = f"Invalid config: '{section}.{key}' must be {expected_type.__name__}, got {type(value).__name__}."
+                        logger.error(error_msg)
+                        raise ValueError(error_msg)
 
 def _merge_config(config: PilotConfig, raw: dict[str, Any]) -> PilotConfig:
     if "model" in raw:


### PR DESCRIPTION
### Problem Statement
The daemon previously used `setattr()` to blindly merge the loaded `config.toml` dictionary into the configuration dataclasses. If a user provided incorrect data types (e.g., a string for the port), the daemon would crash unpredictably later in the execution cycle.

### What Changed
- Implemented `_validate_config_types()` during the initialization phase in `config.py`.
- Enforces strict type checking against a predefined dictionary of expected `model`, `security`, and `server` parameter types.
- Placed the validation right before `_merge_config()` inside `PilotConfig.load()`.
- Invalid configurations now cleanly throw an error to the logger and fall back to safe defaults, preventing catastrophic runtime crashes.

### Testing
- [x] Verified local daemon startup with a valid `config.toml`.
- [x] Verified graceful fallback and accurate error logging when intentionally supplying incorrect data types.
- [x] Tested on Windows 11 environment.

Fixes #60