### PR TITLE
Add collapsible agent thoughts panel

### DIFF
--- a/tauri-app/ui/src/lib/components/ReActPipeline.svelte
+++ b/tauri-app/ui/src/lib/components/ReActPipeline.svelte
@@ -28,6 +28,14 @@
     children?: PipelineStage[];
   }
 
+  interface ThoughtEntry {
+    seq: number;
+    stage: string;
+    stageId: string;
+    text: string;
+    type: string;
+  }
+
   // ── State ──
 
   let isVisible = $state(false);
@@ -49,24 +57,25 @@
   let executionActions = $state<{ type: string; target: string; status: string }[]>([]);
   let pipelineStartTime = 0;
   let showThoughts = $state(false);
+  let expandedThoughtStages = $state<Record<string, boolean>>({});
   let collapsed = $state(false);
   let autoCollapseTimer: ReturnType<typeof setTimeout> | null = null;
 
   // Reasoning event state
-  let stageThoughts = $state<Record<string, string>>({});
   let stageDecisions = $state<Record<string, string>>({});
   let stageTiming = $state<Record<string, number>>({});
-  let thoughtStream = $state<{ seq: number; stage: string; text: string; type: string }[]>([]);
+  let thoughtStream = $state<ThoughtEntry[]>([]);
 
   function resetPipeline() {
     stages = stages.map(s => ({ ...s, status: "idle" as StageStatus, detail: "", startTime: 0, endTime: 0 }));
     executionActions = [];
     totalDuration = 0;
     agentRouting = null;
-    stageThoughts = {};
     stageDecisions = {};
     stageTiming = {};
     thoughtStream = [];
+    showThoughts = false;
+    expandedThoughtStages = {};
     collapsed = false;
     if (autoCollapseTimer) { clearTimeout(autoCollapseTimer); autoCollapseTimer = null; }
   }
@@ -244,17 +253,16 @@
           setStage(stageId, "error", errText);
           thoughtStream = [
             ...thoughtStream.slice(-19),
-            { seq: evt.sequence, stage: evt.stage, text: `❌ ${errText}`, type: "error" },
+            { seq: evt.sequence, stage: evt.stage, stageId, text: `❌ ${errText}`, type: "error" },
           ];
         }
 
         // ── Thoughts, decisions, progress, metrics ──
         if (evt.event_type === "thought") {
           const text = evt.data?.text || "";
-          stageThoughts = { ...stageThoughts, [stageId]: text };
           thoughtStream = [
             ...thoughtStream.slice(-19),
-            { seq: evt.sequence, stage: evt.stage, text, type: "thought" },
+            { seq: evt.sequence, stage: evt.stage, stageId, text, type: "thought" },
           ];
         }
 
@@ -264,7 +272,7 @@
           stageDecisions = { ...stageDecisions, [stageId]: `${desc}: ${chosen}` };
           thoughtStream = [
             ...thoughtStream.slice(-19),
-            { seq: evt.sequence, stage: evt.stage, text: `Decision: ${desc} → ${chosen}`, type: "decision" },
+            { seq: evt.sequence, stage: evt.stage, stageId, text: `Decision: ${desc} → ${chosen}`, type: "decision" },
           ];
         }
 
@@ -277,7 +285,13 @@
         if (evt.event_type === "metric") {
           thoughtStream = [
             ...thoughtStream.slice(-19),
-            { seq: evt.sequence, stage: evt.stage, text: `📊 ${evt.data?.name}: ${evt.data?.value}${evt.data?.unit || ""}`, type: "metric" },
+            {
+              seq: evt.sequence,
+              stage: evt.stage,
+              stageId,
+              text: `📊 ${evt.data?.name}: ${evt.data?.value}${evt.data?.unit || ""}`,
+              type: "metric",
+            },
           ];
         }
 
@@ -342,6 +356,29 @@
 
   let dismiss = () => { isVisible = false; };
   let toggleCollapse = () => { collapsed = !collapsed; };
+  let toggleThoughts = () => { showThoughts = !showThoughts; };
+  let toggleThoughtStage = (stageId: string) => {
+    expandedThoughtStages = {
+      ...expandedThoughtStages,
+      [stageId]: !expandedThoughtStages[stageId],
+    };
+  };
+
+  const thoughtStageLabels: Record<string, string> = {
+    user_input: "User Request",
+    memory_recall: "Memory Recall",
+    agent_routing: "Agent Routing",
+    planning: "Planning",
+    confirmation: "Confirmation",
+    executing: "Execution",
+    verifying: "Verification",
+    reflection: "Reflection",
+    memory_update: "Memory Update",
+  };
+
+  function thoughtTypeLabel(type: string) {
+    return type.replace(/_/g, " ");
+  }
 
   // Computed: progress percentage
   let progress = $derived(
@@ -349,6 +386,20 @@
       (stages.filter(s => s.status === "success" || s.status === "skipped").length / stages.length) * 100
     )
   );
+
+  let thoughtGroups = $derived.by(() => {
+    const grouped = new Map<string, ThoughtEntry[]>();
+    for (const thought of thoughtStream) {
+      const key = thought.stageId || thought.stage;
+      grouped.set(key, [...(grouped.get(key) || []), thought]);
+    }
+    return [...grouped.entries()].map(([stageId, entries]) => ({
+      stageId,
+      label: thoughtStageLabels[stageId] || stageId.replace(/_/g, " "),
+      entries,
+      latest: entries[entries.length - 1],
+    }));
+  });
 </script>
 
 {#if isVisible}
@@ -373,8 +424,15 @@
         <button class="collapse-toggle" onclick={(e) => { e.stopPropagation(); toggleCollapse(); }} title={collapsed ? 'Expand' : 'Collapse'}>
           {collapsed ? '▼' : '▲'}
         </button>
-        <button class="thought-toggle" class:active={showThoughts} onclick={(e) => { e.stopPropagation(); showThoughts = !showThoughts; }} title="Toggle thought stream">
-          🧠
+        <button
+          class="thought-toggle"
+          class:active={showThoughts}
+          onclick={(e) => { e.stopPropagation(); toggleThoughts(); }}
+          title={showThoughts ? "Hide agent thoughts" : "Show agent thoughts"}
+          aria-label={showThoughts ? "Hide agent thoughts" : "Show agent thoughts"}
+          aria-expanded={showThoughts}
+        >
+          ◫
         </button>
         <button class="dismiss-btn" onclick={(e) => { e.stopPropagation(); dismiss(); }} title="Dismiss">✕</button>
       </div>
@@ -401,15 +459,8 @@
               {#if stage.detail}
                 <div class="stage-detail" transition:fade={{ duration: 150 }}>{stage.detail}</div>
               {/if}
-              <!-- Thought bubble for this stage -->
-              {#if showThoughts && stageThoughts[stage.id]}
-                <div class="thought-bubble" transition:fade={{ duration: 200 }}>
-                  <span class="thought-icon">💭</span>
-                  <span class="thought-text">{stageThoughts[stage.id]}</span>
-                </div>
-              {/if}
               <!-- Decision badge -->
-              {#if stageDecisions[stage.id]}
+              {#if showThoughts && stageDecisions[stage.id]}
                 <div class="decision-badge" transition:fade={{ duration: 200 }}>
                   <span class="decision-icon">⚖️</span>
                   <span class="decision-text">{stageDecisions[stage.id]}</span>
@@ -453,24 +504,65 @@
       {/each}
     </div>
 
-    <!-- Live Thought Stream -->
+    <!-- Collapsible Thought Stream -->
     {#if showThoughts && thoughtStream.length > 0}
       <div class="thought-stream" transition:slide={{ duration: 200 }}>
         <div class="thought-stream-header">
-          <span class="thought-stream-icon">🧠</span>
-          <span class="thought-stream-title">Live Reasoning</span>
+          <span class="thought-stream-icon">◫</span>
+          <span class="thought-stream-title">Agent Thoughts</span>
           <span class="thought-count">{thoughtStream.length}</span>
         </div>
-        <div class="thought-stream-list">
-          {#each thoughtStream as thought, k}
-            <div class="thought-entry {thought.type}" transition:fade={{ duration: 150 }}>
-              <span class="thought-seq">#{thought.seq}</span>
-              <span class="thought-stage-chip">{thought.stage}</span>
-              <span class="thought-content">{thought.text}</span>
-            </div>
+        <div class="thought-accordion-list">
+          {#each thoughtGroups as group (group.stageId)}
+            <section class="thought-accordion" class:open={expandedThoughtStages[group.stageId]}>
+              <button
+                type="button"
+                class="thought-accordion-header"
+                onclick={() => toggleThoughtStage(group.stageId)}
+                aria-expanded={Boolean(expandedThoughtStages[group.stageId])}
+              >
+                <span class="thought-stage-chip">{group.label}</span>
+                <span class="thought-preview">{group.latest.text}</span>
+                <span class="thought-count">{group.entries.length}</span>
+                <span class="thought-chevron">{expandedThoughtStages[group.stageId] ? "▲" : "▼"}</span>
+              </button>
+              {#if expandedThoughtStages[group.stageId]}
+                <div class="thought-stream-list" transition:slide={{ duration: 160 }}>
+                  {#each group.entries as thought (thought.seq)}
+                    <div class="thought-entry {thought.type}" transition:fade={{ duration: 120 }}>
+                      <span class="thought-seq">#{thought.seq}</span>
+                      <span class="thought-type">{thoughtTypeLabel(thought.type)}</span>
+                      <span class="thought-content">{thought.text}</span>
+                    </div>
+                  {/each}
+                </div>
+              {/if}
+            </section>
           {/each}
         </div>
       </div>
+    {:else if showThoughts}
+      <div class="thought-stream empty" transition:fade={{ duration: 160 }}>
+        <div class="thought-stream-header">
+          <span class="thought-stream-icon">◫</span>
+          <span class="thought-stream-title">Agent Thoughts</span>
+        </div>
+        <div class="thought-empty">
+          Intermediate agent thoughts will appear here.
+        </div>
+      </div>
+    {/if}
+
+    {#if !showThoughts && thoughtStream.length > 0}
+      <button
+        type="button"
+        class="thought-summary"
+        onclick={toggleThoughts}
+        aria-label="Show grouped agent thoughts"
+      >
+        <span>Agent thoughts hidden</span>
+        <span class="thought-count">{thoughtStream.length}</span>
+      </button>
     {/if}
 
     <!-- Agent routing info -->
@@ -890,23 +982,6 @@
     border-color: rgba(120, 100, 255, 0.4);
   }
 
-  .thought-bubble {
-    display: flex;
-    align-items: flex-start;
-    gap: 0.3rem;
-    margin-top: 4px;
-    padding: 0.25rem 0.5rem;
-    background: rgba(120, 100, 255, 0.06);
-    border-left: 2px solid rgba(120, 100, 255, 0.3);
-    border-radius: 0 4px 4px 0;
-    font-size: 0.65rem;
-    color: rgba(180, 160, 255, 0.8);
-    font-style: italic;
-  }
-
-  .thought-icon { font-size: 0.7rem; flex-shrink: 0; }
-  .thought-text { line-height: 1.3; }
-
   .decision-badge {
     display: flex;
     align-items: center;
@@ -929,15 +1004,19 @@
     font-family: 'JetBrains Mono', monospace;
   }
 
-  /* Live Thought Stream */
+  /* Collapsible Thought Stream */
   .thought-stream {
     margin-top: 0.75rem;
     padding: 0.5rem;
     background: rgba(0, 0, 0, 0.2);
     border: 1px solid rgba(120, 100, 255, 0.15);
     border-radius: 8px;
-    max-height: 200px;
+    max-height: 260px;
     overflow-y: auto;
+  }
+
+  .thought-stream.empty {
+    max-height: none;
   }
 
   .thought-stream-header {
@@ -968,10 +1047,64 @@
     font-weight: 600;
   }
 
+  .thought-accordion-list {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+  }
+
+  .thought-accordion {
+    border: 1px solid rgba(120, 100, 255, 0.12);
+    border-radius: 6px;
+    overflow: hidden;
+    background: rgba(255, 255, 255, 0.02);
+  }
+
+  .thought-accordion.open {
+    border-color: rgba(120, 100, 255, 0.28);
+    background: rgba(120, 100, 255, 0.05);
+  }
+
+  .thought-accordion-header {
+    width: 100%;
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr) auto auto;
+    align-items: center;
+    gap: 0.45rem;
+    padding: 0.4rem 0.5rem;
+    border: 0;
+    background: transparent;
+    color: inherit;
+    cursor: pointer;
+    text-align: left;
+  }
+
+  .thought-accordion-header:hover {
+    background: rgba(120, 100, 255, 0.08);
+  }
+
+  .thought-preview {
+    min-width: 0;
+    color: rgba(255, 255, 255, 0.52);
+    font-size: 0.64rem;
+    line-height: 1.3;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .thought-chevron {
+    color: rgba(180, 160, 255, 0.65);
+    font-size: 0.55rem;
+    width: 12px;
+    text-align: center;
+  }
+
   .thought-stream-list {
     display: flex;
     flex-direction: column;
     gap: 3px;
+    padding: 0.2rem 0.45rem 0.45rem;
   }
 
   .thought-entry {
@@ -1010,9 +1143,43 @@
     flex-shrink: 0;
   }
 
+  .thought-type {
+    color: rgba(255, 255, 255, 0.35);
+    font-size: 0.55rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    min-width: 48px;
+    flex-shrink: 0;
+  }
+
   .thought-content {
     flex: 1;
     min-width: 0;
     word-break: break-word;
+  }
+
+  .thought-empty {
+    color: rgba(255, 255, 255, 0.42);
+    font-size: 0.68rem;
+    padding: 0.2rem 0.1rem;
+  }
+
+  .thought-summary {
+    margin-top: 0.65rem;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.45rem;
+    border: 1px solid rgba(120, 100, 255, 0.16);
+    border-radius: 999px;
+    background: rgba(120, 100, 255, 0.06);
+    color: rgba(180, 160, 255, 0.72);
+    padding: 0.25rem 0.55rem;
+    font-size: 0.66rem;
+    cursor: pointer;
+  }
+
+  .thought-summary:hover {
+    border-color: rgba(120, 100, 255, 0.35);
+    background: rgba(120, 100, 255, 0.1);
   }
 </style>


### PR DESCRIPTION
## Summary
- Groups intermediate reasoning events by pipeline stage in a collapsible Agent Thoughts panel.
- Keeps thoughts hidden by default with a compact summary/count so final responses and stage progress stay prominent.
- Adds per-stage accordions with previews, counts, expanded detail rows, and accessible toggle state.
- Keeps decision badges behind the same thoughts toggle to reduce visual noise during multi-agent runs.

Closes #91

## Verification
- `npm run check` passed with 0 errors; existing warnings remain in `SetupWizard.svelte`, `NeuralBackground.svelte`, and `App.svelte`.
- `npm run build` passed; same existing accessibility warnings remain.
- Browser smoke test on `http://127.0.0.1:3010/` loaded Heliox OS without page errors. The only console errors were expected local daemon WebSocket connection failures because `127.0.0.1:8785` was not running during UI-only verification.

## Screenshot
- Local smoke screenshot captured at `artifacts/heliox-91-ui-load.png`.