### PR TITLE
Migrate memory and audit disk I/O to async paths

### DIFF
--- a/daemon/pilot/agents/executor.py
+++ b/daemon/pilot/agents/executor.py
@@ -327,7 +327,7 @@ class Executor:
                 logger.warning("Snapshot creation failed: %s", e)
 
         for i, action in enumerate(plan.actions):
-            self._audit.log_action_start(action, plan_id)
+            await self._audit.log_action_start(action, plan_id)
 
             if on_action_start:
                 await on_action_start(action)
@@ -336,7 +336,7 @@ class Executor:
             action = self._inject_previous_output(action)
 
             result = await self._execute_single(action, snapshot_id)
-            self._audit.log_action_result(result, plan_id)
+            await self._audit.log_action_result(result, plan_id)
 
             if on_action_complete:
                 await on_action_complete(result)
@@ -372,7 +372,7 @@ class Executor:
         report = self._simulation_sandbox.simulate(plan)
 
         for index, action in enumerate(plan.actions):
-            self._audit.log_action_start(action, plan_id, dry_run=True)
+            await self._audit.log_action_start(action, plan_id, dry_run=True)
 
             if on_action_start:
                 await on_action_start(action)
@@ -387,7 +387,7 @@ class Executor:
                 output = f"(dry run) Would execute {action.action_type.value} on {action.target or 'target'}"
 
             result = ActionResult(action=action, success=True, output=output)
-            self._audit.log_action_result(result, plan_id, dry_run=True)
+            await self._audit.log_action_result(result, plan_id, dry_run=True)
 
             if on_action_complete:
                 await on_action_complete(result)

--- a/daemon/pilot/memory/store.py
+++ b/daemon/pilot/memory/store.py
@@ -5,11 +5,13 @@ Memory updates are asynchronous and never block the main execution pipeline.
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
+import aiofiles.os
 import aiosqlite
 
 from pilot.config import DATA_DIR, DB_FILE
@@ -51,11 +53,11 @@ class MemoryStore:
         self._chroma_collection: Any = None
 
     async def initialize(self) -> None:
-        DATA_DIR.mkdir(parents=True, exist_ok=True)
+        await aiofiles.os.makedirs(DATA_DIR, exist_ok=True)
         self._db = await aiosqlite.connect(str(DB_FILE))
         await self._db.executescript(SCHEMA_SQL)
         await self._db.commit()
-        self._init_chroma()
+        await asyncio.to_thread(self._init_chroma)
 
     def _init_chroma(self) -> None:
         """Initialize ChromaDB for semantic search (best-effort)."""
@@ -100,7 +102,8 @@ class MemoryStore:
 
         if self._chroma_collection is not None:
             try:
-                self._chroma_collection.add(
+                await asyncio.to_thread(
+                    self._chroma_collection.add,
                     documents=[user_input],
                     metadatas=[
                         {
@@ -120,7 +123,11 @@ class MemoryStore:
 
         if self._chroma_collection is not None:
             try:
-                results = self._chroma_collection.query(query_texts=[query], n_results=n_results)
+                results = await asyncio.to_thread(
+                    self._chroma_collection.query,
+                    query_texts=[query],
+                    n_results=n_results,
+                )
                 if results["documents"] and results["documents"][0]:
                     parts.append("Related past requests:")
                     for doc, meta in zip(results["documents"][0], results["metadatas"][0], strict=False):

--- a/daemon/pilot/security/audit.py
+++ b/daemon/pilot/security/audit.py
@@ -6,11 +6,15 @@ This log is tamper-evident and can be shipped to external SIEM systems.
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
+
+import aiofiles
+import aiofiles.os
 
 from pilot.actions import Action, ActionResult
 from pilot.config import AUDIT_FILE, DATA_DIR
@@ -52,9 +56,9 @@ class AuditLogger:
 
     def __init__(self, audit_file: Path | None = None) -> None:
         self._file = audit_file or AUDIT_FILE
-        DATA_DIR.mkdir(parents=True, exist_ok=True)
+        self._lock = asyncio.Lock()
 
-    def log_action_start(self, action: Action, plan_id: str, dry_run: bool = False) -> None:
+    async def log_action_start(self, action: Action, plan_id: str, dry_run: bool = False) -> None:
         action_type = action.action_type.value
         if dry_run:
             action_type = f"(dry run) {action_type}"
@@ -70,9 +74,9 @@ class AuditLogger:
                 "dry_run": dry_run,
             },
         )
-        self._write(entry)
+        await self._write(entry)
 
-    def log_action_result(self, result: ActionResult, plan_id: str, dry_run: bool = False) -> None:
+    async def log_action_result(self, result: ActionResult, plan_id: str, dry_run: bool = False) -> None:
         action_type = result.action.action_type.value
         if dry_run:
             action_type = f"(dry run) {action_type}"
@@ -89,9 +93,9 @@ class AuditLogger:
                 "dry_run": dry_run,
             },
         )
-        self._write(entry)
+        await self._write(entry)
 
-    def log_rollback(self, snapshot_id: str, plan_id: str, reason: str) -> None:
+    async def log_rollback(self, snapshot_id: str, plan_id: str, reason: str) -> None:
         entry = AuditEntry(
             event_type="rollback",
             details={
@@ -100,9 +104,9 @@ class AuditLogger:
                 "reason": reason,
             },
         )
-        self._write(entry)
+        await self._write(entry)
 
-    def log_config_change(self, section: str, key: str, old_value: Any, new_value: Any) -> None:
+    async def log_config_change(self, section: str, key: str, old_value: Any, new_value: Any) -> None:
         entry = AuditEntry(
             event_type="config_change",
             details={
@@ -112,19 +116,20 @@ class AuditLogger:
                 "new_value": str(new_value),
             },
         )
-        self._write(entry)
+        await self._write(entry)
 
-    def log_security_event(self, event: str, details: dict[str, Any] | None = None) -> None:
+    async def log_security_event(self, event: str, details: dict[str, Any] | None = None) -> None:
         entry = AuditEntry(
             event_type="security",
             details={"event": event, **(details or {})},
         )
-        self._write(entry)
+        await self._write(entry)
 
-    def _write(self, entry: AuditEntry) -> None:
+    async def _write(self, entry: AuditEntry) -> None:
         line = json.dumps(entry.to_dict(), separators=(",", ":")) + "\n"
         try:
-            with open(self._file, "a", encoding="utf-8") as f:
-                f.write(line)
+            await aiofiles.os.makedirs(self._file.parent, exist_ok=True)
+            async with self._lock, aiofiles.open(self._file, "a", encoding="utf-8") as f:
+                await f.write(line)
         except OSError:
             logger.exception("Failed to write audit log")

--- a/daemon/pyproject.toml
+++ b/daemon/pyproject.toml
@@ -13,6 +13,7 @@ license = "MIT"
 dependencies = [
     "websockets>=13.0",
     "pydantic>=2.6",
+    "aiofiles>=24.1",
     "aiosqlite>=0.20",
     "httpx>=0.27",
     "tomli>=2.0; python_version < '3.12'",

--- a/daemon/tests/test_async_audit_logger.py
+++ b/daemon/tests/test_async_audit_logger.py
@@ -1,0 +1,55 @@
+"""Tests for non-blocking audit log writes."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+
+from pilot.actions import Action, ActionResult, ActionType, EmptyParams
+from pilot.security.audit import AuditLogger
+
+
+def _action() -> Action:
+    return Action(
+        action_type=ActionType.SYSTEM_INFO,
+        target="system",
+        parameters=EmptyParams(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_audit_logger_writes_action_events_as_jsonl(tmp_path):
+    audit_file = tmp_path / "nested" / "audit.jsonl"
+    logger = AuditLogger(audit_file)
+    action = _action()
+
+    await logger.log_action_start(action, "plan-1")
+    await logger.log_action_result(ActionResult(action=action, success=True, output="ok"), "plan-1")
+
+    lines = audit_file.read_text(encoding="utf-8").splitlines()
+    entries = [json.loads(line) for line in lines]
+
+    assert [entry["event_type"] for entry in entries] == ["action_start", "action_complete"]
+    assert entries[0]["details"]["plan_id"] == "plan-1"
+    assert entries[1]["success"] is True
+
+
+@pytest.mark.asyncio
+async def test_audit_logger_serializes_concurrent_writes(tmp_path):
+    audit_file = tmp_path / "audit.jsonl"
+    logger = AuditLogger(audit_file)
+
+    await asyncio.gather(
+        logger.log_security_event("one"),
+        logger.log_security_event("two"),
+        logger.log_security_event("three"),
+    )
+
+    events = [
+        json.loads(line)["details"]["event"]
+        for line in audit_file.read_text(encoding="utf-8").splitlines()
+    ]
+
+    assert sorted(events) == ["one", "three", "two"]


### PR DESCRIPTION
## Summary
- Move memory-store directory creation to `aiofiles.os.makedirs` and keep SQLite on `aiosqlite`
- Offload ChromaDB initialization, writes, and queries from the FastAPI event loop using `asyncio.to_thread`
- Convert audit logging to awaitable `aiofiles` JSONL writes and await those calls from the executor
- Add async audit logger tests covering JSONL output, parent directory creation, and concurrent writes

## Why
This addresses #97 by removing blocking disk work from the daemon's memory and audit logging paths while preserving ordered action audit records.

## Testing
- `python3.12 -m ruff check pilot/security/audit.py pilot/memory/store.py pilot/agents/executor.py tests/test_async_audit_logger.py`
- `python3.12 -m pytest tests/test_async_audit_logger.py tests/test_react_latency.py tests/test_directory_summary.py -q` -> 7 passed
- `python3.12 -m pytest -q` -> 65 passed

Closes #97