### PR TITLE
feat: add secure isolated sandbox environment for code execution(fixes #64)

### DIFF
--- a/daemon/pilot/agents/executor.py
+++ b/daemon/pilot/agents/executor.py
@@ -1457,9 +1457,18 @@ class Executor:
         import tempfile
 
         from pilot.system.code_exec import execute_code
+        from pilot.system.sandbox_exec import SandboxConfig
 
         p: CodeExecParams = action.parameters  # type: ignore[assignment]
         code = p.code
+
+        # Build sandbox config from live security settings
+        sandbox_cfg = SandboxConfig(
+            mode=getattr(self._config.security, "sandbox_mode", "auto"),
+            memory_mb=getattr(self._config.security, "sandbox_memory_mb", 128),
+            timeout=getattr(self._config.security, "sandbox_timeout", p.timeout),
+            network=getattr(self._config.security, "sandbox_network", False),
+        )
 
         # If there's previous output available, inject it as Python variables
         if p.language.lower().strip() in ("python", "py", "python3"):
@@ -1492,7 +1501,7 @@ class Executor:
             code = sanitize_python_code(code)
 
         logger.info("Code execute: running %d chars of code", len(code))
-        result = await execute_code(code, p.language, p.timeout)
+        result = await execute_code(code, p.language, p.timeout, sandbox_cfg=sandbox_cfg)
         logger.info("Code execute result (%d chars): %s", len(result), result[:200] if result else "(empty)")
 
         # --- Auto-retry on failure: ask LLM to fix the code ---
@@ -1532,7 +1541,7 @@ class Executor:
                     fixed_code = sanitize_python_code(fixed_code)
 
                 logger.info("Auto-fix: retrying with LLM-fixed code (%d chars)", len(fixed_code))
-                retry_result = await execute_code(fixed_code, p.language, p.timeout)
+                retry_result = await execute_code(fixed_code, p.language, p.timeout, sandbox_cfg=sandbox_cfg)
 
                 # Only use the retry if it's better (no error)
                 if "[STDERR]" not in retry_result and "[EXIT CODE:" not in retry_result:
@@ -1551,9 +1560,17 @@ class Executor:
 
     async def _exec_code_generate(self, action: Action) -> str:
         from pilot.system.code_exec import generate_and_execute
+        from pilot.system.sandbox_exec import SandboxConfig
 
         p: CodeExecParams = action.parameters  # type: ignore[assignment]
-        return await generate_and_execute(p.task_description, p.language, p.timeout)
+
+        sandbox_cfg = SandboxConfig(
+            mode=getattr(self._config.security, "sandbox_mode", "auto"),
+            memory_mb=getattr(self._config.security, "sandbox_memory_mb", 128),
+            timeout=getattr(self._config.security, "sandbox_timeout", p.timeout),
+            network=getattr(self._config.security, "sandbox_network", False),
+        )
+        return await generate_and_execute(p.task_description, p.language, p.timeout, sandbox_cfg=sandbox_cfg)
 
     # ======================================================================
     # TIER 2: FILE CONTENT INTELLIGENCE

--- a/daemon/pilot/config.py
+++ b/daemon/pilot/config.py
@@ -68,10 +68,10 @@ class SecurityConfig:
     snapshot_retention_days: int = 7
     unrestricted_shell: bool = False  # Allow ANY shell command (bypass whitelist)
     # Code execution sandbox — isolates agent-generated code from the host OS
-    sandbox_mode: str = "auto"       # "auto" | "docker" | "restricted" | "none"
-    sandbox_memory_mb: int = 128     # memory cap applied inside the sandbox (MB)
-    sandbox_timeout: int = 30        # max wall-clock seconds for sandboxed execution
-    sandbox_network: bool = False    # allow outbound network inside the sandbox
+    sandbox_mode: str = "auto"  # "auto" | "docker" | "restricted" | "none"
+    sandbox_memory_mb: int = 128  # memory cap applied inside the sandbox (MB)
+    sandbox_timeout: int = 30  # max wall-clock seconds for sandboxed execution
+    sandbox_network: bool = False  # allow outbound network inside the sandbox
 
 
 @dataclass

--- a/daemon/pilot/config.py
+++ b/daemon/pilot/config.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import os
 import sys
 from dataclasses import dataclass, field
@@ -66,6 +67,11 @@ class SecurityConfig:
     snapshot_retention_count: int = 10
     snapshot_retention_days: int = 7
     unrestricted_shell: bool = False  # Allow ANY shell command (bypass whitelist)
+    # Code execution sandbox — isolates agent-generated code from the host OS
+    sandbox_mode: str = "auto"       # "auto" | "docker" | "restricted" | "none"
+    sandbox_memory_mb: int = 128     # memory cap applied inside the sandbox (MB)
+    sandbox_timeout: int = 30        # max wall-clock seconds for sandboxed execution
+    sandbox_network: bool = False    # allow outbound network inside the sandbox
 
 
 @dataclass
@@ -95,8 +101,13 @@ class PilotConfig:
         """Load config from disk, creating defaults if missing."""
         config = cls()
         if CONFIG_FILE.exists():
-            raw = tomllib.loads(CONFIG_FILE.read_text(encoding="utf-8"))
-            config = _merge_config(config, raw)
+            try:
+                raw = tomllib.loads(CONFIG_FILE.read_text(encoding="utf-8"))
+                _validate_config_types(raw)
+                config = _merge_config(config, raw)
+            except Exception as e:
+                logger.error(f"Failed to load config.toml: {e}. Falling back to safe defaults.")
+
         if RESTRICTIONS_FILE.exists():
             raw = tomllib.loads(RESTRICTIONS_FILE.read_text(encoding="utf-8"))
             config.restrictions = _parse_restrictions(raw)
@@ -110,6 +121,67 @@ class PilotConfig:
         CONFIG_FILE.write_text(tomli_w.dumps(data), encoding="utf-8")
         if restrictions:
             RESTRICTIONS_FILE.write_text(tomli_w.dumps(restrictions), encoding="utf-8")
+
+
+logger = logging.getLogger("pilot.config")
+
+
+def _validate_config_types(raw: dict) -> None:
+    """Validate that the user's config has no typos and uses correct types."""
+    expected_types = {
+        "model": {
+            "provider": str,
+            "ollama_base_url": str,
+            "ollama_model": str,
+            "mode": str,
+            "gpu_memory_limit_mb": int,
+            "idle_unload_seconds": int,
+            "cloud_provider": str,
+            "cloud_model": str,
+            "rate_limit_enabled": bool,
+            "rate_limit_rpm": int,
+            "rate_limit_burst": int,
+            # NEW: PR #98 Budget Keys
+            "budget_enabled": bool,
+            "budget_monthly_limit_usd": float,
+        },
+        "security": {
+            "root_enabled": bool,
+            "confirm_tier2": bool,
+            "dry_run": bool,
+            "snapshot_on_destructive": bool,
+            "snapshot_backend": str,
+            "snapshot_retention_count": int,
+            "snapshot_retention_days": int,
+            "unrestricted_shell": bool,
+            "sandbox_mode": str,
+            "sandbox_memory_mb": int,
+            "sandbox_timeout": int,
+            "sandbox_network": bool,
+        },
+        "server": {
+            "host": str,
+            "port": int,
+            "auth_token": str,
+        },
+    }
+
+    for section, expected_keys in expected_types.items():
+        if section in raw and isinstance(raw[section], dict):
+            # We iterate over the USER'S keys to find typos
+            for actual_key, actual_value in raw[section].items():
+                # 1. Catch Typos (Unknown Keys)
+                if actual_key not in expected_keys:
+                    error_msg = f"Invalid config key found: '{section}.{actual_key}'. Please check for typos."
+                    logger.error(error_msg)
+                    raise ValueError(error_msg)
+
+                # 2. Catch Wrong Types
+                expected_type = expected_keys[actual_key]
+                if not isinstance(actual_value, expected_type):
+                    error_msg = f"Invalid type: '{section}.{actual_key}' must be {expected_type.__name__}, got {type(actual_value).__name__}."
+                    logger.error(error_msg)
+                    raise ValueError(error_msg)
 
 
 def _merge_config(config: PilotConfig, raw: dict[str, Any]) -> PilotConfig:

--- a/daemon/pilot/system/code_exec.py
+++ b/daemon/pilot/system/code_exec.py
@@ -1,6 +1,10 @@
 """Code Generation & Dynamic Execution — run arbitrary code safely.
 
 Generate and execute Python/PowerShell/Bash scripts on the fly.
+All execution is routed through the SecureExecutionSandbox layer, which
+provides OS-level isolation (Docker or restricted subprocess) before
+falling back to direct execution only when sandbox_mode='none'.
+
 Supports sandboxed execution, output capture, and timeout control.
 """
 
@@ -12,220 +16,130 @@ import os
 import sys
 import tempfile
 
+from pilot.system.sandbox_exec import SandboxConfig, SecureExecutionSandbox
+
 logger = logging.getLogger("pilot.system.code_exec")
+
+# Module-level sandbox instance — initialised lazily via _get_sandbox()
+_sandbox: SecureExecutionSandbox | None = None
+
+
+def _get_sandbox(sandbox_cfg: SandboxConfig | None = None) -> SecureExecutionSandbox:
+    """Return (and lazily create) the module-level sandbox instance.
+
+    If *sandbox_cfg* is provided the sandbox is (re-)initialised with it.
+    This allows the Executor to push the live config down on first use.
+    """
+    global _sandbox
+    if sandbox_cfg is not None or _sandbox is None:
+        cfg = sandbox_cfg or SandboxConfig()
+        _sandbox = SecureExecutionSandbox(cfg)
+    return _sandbox
+
+
+# ---------------------------------------------------------------------------
+# Public helpers — called by the Executor
+# ---------------------------------------------------------------------------
 
 
 async def execute_python(
     code: str,
     timeout: int = 30,
     capture_output: bool = True,
+    sandbox_cfg: SandboxConfig | None = None,
 ) -> str:
     """Execute Python code and return the output.
 
-    The code runs in a subprocess for isolation.
+    Attempts sandboxed execution first. Falls back to a direct subprocess
+    only when sandbox_mode is explicitly set to 'none'.
     """
-    with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False, encoding="utf-8") as f:
-        f.write(code)
-        script_path = f.name
+    sandbox = _get_sandbox(sandbox_cfg)
+    result = await sandbox.run(code, "python")
+    if result is not None:
+        return result
 
-    try:
-        proc = await asyncio.create_subprocess_exec(
-            sys.executable,
-            script_path,
-            stdout=asyncio.subprocess.PIPE if capture_output else None,
-            stderr=asyncio.subprocess.PIPE if capture_output else None,
-        )
-        try:
-            stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=timeout)
-        except TimeoutError:
-            proc.kill()
-            return f"ERROR: Script timed out after {timeout}s"
-
-        output = ""
-        if stdout:
-            output += stdout.decode("utf-8", errors="replace")
-        if stderr:
-            err = stderr.decode("utf-8", errors="replace")
-            if err.strip():
-                output += f"\n[STDERR]\n{err}"
-        if proc.returncode != 0:
-            output += f"\n[EXIT CODE: {proc.returncode}]"
-
-        return output.strip() or "(no output)"
-    finally:
-        os.unlink(script_path)
+    # sandbox_mode='none' — legacy direct execution
+    return await _direct_python(code, timeout, capture_output)
 
 
 async def execute_powershell(
     code: str,
     timeout: int = 30,
+    sandbox_cfg: SandboxConfig | None = None,
 ) -> str:
     """Execute PowerShell code and return the output."""
-    with tempfile.NamedTemporaryFile(mode="w", suffix=".ps1", delete=False, encoding="utf-8") as f:
-        f.write(code)
-        script_path = f.name
+    sandbox = _get_sandbox(sandbox_cfg)
+    result = await sandbox.run(code, "powershell")
+    if result is not None:
+        return result
 
-    try:
-        shell = "pwsh" if os.path.exists("C:/Program Files/PowerShell") else "powershell"
-        proc = await asyncio.create_subprocess_exec(
-            shell,
-            "-NoProfile",
-            "-ExecutionPolicy",
-            "Bypass",
-            "-File",
-            script_path,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-        )
-        try:
-            stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=timeout)
-        except TimeoutError:
-            proc.kill()
-            return f"ERROR: Script timed out after {timeout}s"
-
-        output = ""
-        if stdout:
-            output += stdout.decode("utf-8", errors="replace")
-        if stderr:
-            err = stderr.decode("utf-8", errors="replace")
-            if err.strip():
-                output += f"\n[STDERR]\n{err}"
-
-        return output.strip() or "(no output)"
-    finally:
-        os.unlink(script_path)
+    return await _direct_powershell(code, timeout)
 
 
 async def execute_bash(
     code: str,
     timeout: int = 30,
+    sandbox_cfg: SandboxConfig | None = None,
 ) -> str:
     """Execute Bash code and return the output."""
-    with tempfile.NamedTemporaryFile(mode="w", suffix=".sh", delete=False, encoding="utf-8") as f:
-        f.write("#!/bin/bash\nset -e\n" + code)
-        script_path = f.name
+    sandbox = _get_sandbox(sandbox_cfg)
+    result = await sandbox.run(code, "bash")
+    if result is not None:
+        return result
 
-    try:
-        os.chmod(script_path, 0o755)
-        proc = await asyncio.create_subprocess_exec(
-            "bash",
-            script_path,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-        )
-        try:
-            stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=timeout)
-        except TimeoutError:
-            proc.kill()
-            return f"ERROR: Script timed out after {timeout}s"
-
-        output = ""
-        if stdout:
-            output += stdout.decode("utf-8", errors="replace")
-        if stderr:
-            err = stderr.decode("utf-8", errors="replace")
-            if err.strip():
-                output += f"\n[STDERR]\n{err}"
-
-        return output.strip() or "(no output)"
-    finally:
-        os.unlink(script_path)
+    return await _direct_bash(code, timeout)
 
 
 async def execute_code(
     code: str,
     language: str = "python",
     timeout: int = 30,
+    sandbox_cfg: SandboxConfig | None = None,
 ) -> str:
     """Execute code in the specified language.
 
     language: 'python', 'powershell', 'bash', 'cmd', 'javascript'
+
+    All languages are routed through the sandbox where supported.
+    'cmd' and 'javascript' fall back to direct execution when the
+    sandbox backend does not support them (e.g. restricted mode on Windows).
     """
     language = language.lower().strip()
 
     if language in ("python", "py", "python3"):
-        return await execute_python(code, timeout)
+        return await execute_python(code, timeout, sandbox_cfg=sandbox_cfg)
     elif language in ("powershell", "ps1", "pwsh"):
-        return await execute_powershell(code, timeout)
+        return await execute_powershell(code, timeout, sandbox_cfg=sandbox_cfg)
     elif language in ("bash", "sh", "shell"):
-        return await execute_bash(code, timeout)
+        return await execute_bash(code, timeout, sandbox_cfg=sandbox_cfg)
     elif language in ("cmd", "batch", "bat"):
+        # Route through sandbox; falls back to direct if unsupported
+        sandbox = _get_sandbox(sandbox_cfg)
+        result = await sandbox.run(code, "cmd")
+        if result is not None:
+            return result
         return await _execute_cmd(code, timeout)
     elif language in ("javascript", "js", "node"):
+        sandbox = _get_sandbox(sandbox_cfg)
+        result = await sandbox.run(code, "javascript")
+        if result is not None:
+            return result
         return await _execute_node(code, timeout)
     else:
         return f"Unsupported language: {language}. Use: python, powershell, bash, cmd, javascript"
-
-
-async def _execute_cmd(code: str, timeout: int = 30) -> str:
-    """Execute Windows CMD batch script."""
-    with tempfile.NamedTemporaryFile(mode="w", suffix=".cmd", delete=False, encoding="utf-8") as f:
-        f.write("@echo off\n" + code)
-        script_path = f.name
-
-    try:
-        proc = await asyncio.create_subprocess_exec(
-            "cmd",
-            "/c",
-            script_path,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-        )
-        try:
-            stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=timeout)
-        except TimeoutError:
-            proc.kill()
-            return f"ERROR: Script timed out after {timeout}s"
-
-        output = ""
-        if stdout:
-            output += stdout.decode("utf-8", errors="replace")
-        if stderr:
-            output += stderr.decode("utf-8", errors="replace")
-        return output.strip() or "(no output)"
-    finally:
-        os.unlink(script_path)
-
-
-async def _execute_node(code: str, timeout: int = 30) -> str:
-    """Execute JavaScript via Node.js."""
-    with tempfile.NamedTemporaryFile(mode="w", suffix=".js", delete=False, encoding="utf-8") as f:
-        f.write(code)
-        script_path = f.name
-
-    try:
-        proc = await asyncio.create_subprocess_exec(
-            "node",
-            script_path,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-        )
-        try:
-            stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=timeout)
-        except TimeoutError:
-            proc.kill()
-            return f"ERROR: Script timed out after {timeout}s"
-
-        output = ""
-        if stdout:
-            output += stdout.decode("utf-8", errors="replace")
-        if stderr:
-            output += stderr.decode("utf-8", errors="replace")
-        return output.strip() or "(no output)"
-    finally:
-        os.unlink(script_path)
 
 
 async def generate_and_execute(
     task_description: str,
     language: str = "python",
     timeout: int = 30,
+    sandbox_cfg: SandboxConfig | None = None,
 ) -> str:
     """Generate code from a task description using the LLM, then execute it.
 
     This is the most powerful action — the agent writes custom code for any task.
+    Generated code is always run through the sandbox regardless of language.
     """
-    # Import here to avoid circular dependency
     try:
         from pilot.models.ollama import OllamaClient
 
@@ -265,8 +179,176 @@ async def generate_and_execute(
         if code.endswith("```"):
             code = code[:-3].rstrip()
 
-        result = await execute_code(code, language, timeout)
+        result = await execute_code(code, language, timeout, sandbox_cfg=sandbox_cfg)
         return f"[GENERATED CODE]\n{code}\n\n[OUTPUT]\n{result}"
 
     except Exception as e:
         return f"Code generation failed: {e}"
+
+
+# ---------------------------------------------------------------------------
+# Direct (unsandboxed) execution — used only when sandbox_mode='none'
+# ---------------------------------------------------------------------------
+
+
+async def _direct_python(code: str, timeout: int, capture_output: bool) -> str:
+    """Execute Python code directly in a subprocess (no sandbox)."""
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False, encoding="utf-8") as f:
+        f.write(code)
+        script_path = f.name
+
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            sys.executable,
+            script_path,
+            stdout=asyncio.subprocess.PIPE if capture_output else None,
+            stderr=asyncio.subprocess.PIPE if capture_output else None,
+        )
+        try:
+            stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=timeout)
+        except TimeoutError:
+            proc.kill()
+            return f"ERROR: Script timed out after {timeout}s"
+
+        output = ""
+        if stdout:
+            output += stdout.decode("utf-8", errors="replace")
+        if stderr:
+            err = stderr.decode("utf-8", errors="replace")
+            if err.strip():
+                output += f"\n[STDERR]\n{err}"
+        if proc.returncode != 0:
+            output += f"\n[EXIT CODE: {proc.returncode}]"
+
+        return output.strip() or "(no output)"
+    finally:
+        os.unlink(script_path)
+
+
+async def _direct_powershell(code: str, timeout: int) -> str:
+    """Execute PowerShell code directly (no sandbox)."""
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".ps1", delete=False, encoding="utf-8") as f:
+        f.write(code)
+        script_path = f.name
+
+    try:
+        shell = "pwsh" if os.path.exists("C:/Program Files/PowerShell") else "powershell"
+        proc = await asyncio.create_subprocess_exec(
+            shell,
+            "-NoProfile",
+            "-ExecutionPolicy",
+            "Bypass",
+            "-File",
+            script_path,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        try:
+            stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=timeout)
+        except TimeoutError:
+            proc.kill()
+            return f"ERROR: Script timed out after {timeout}s"
+
+        output = ""
+        if stdout:
+            output += stdout.decode("utf-8", errors="replace")
+        if stderr:
+            err = stderr.decode("utf-8", errors="replace")
+            if err.strip():
+                output += f"\n[STDERR]\n{err}"
+
+        return output.strip() or "(no output)"
+    finally:
+        os.unlink(script_path)
+
+
+async def _direct_bash(code: str, timeout: int) -> str:
+    """Execute Bash code directly (no sandbox)."""
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".sh", delete=False, encoding="utf-8") as f:
+        f.write("#!/bin/bash\nset -e\n" + code)
+        script_path = f.name
+
+    try:
+        os.chmod(script_path, 0o755)
+        proc = await asyncio.create_subprocess_exec(
+            "bash",
+            script_path,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        try:
+            stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=timeout)
+        except TimeoutError:
+            proc.kill()
+            return f"ERROR: Script timed out after {timeout}s"
+
+        output = ""
+        if stdout:
+            output += stdout.decode("utf-8", errors="replace")
+        if stderr:
+            err = stderr.decode("utf-8", errors="replace")
+            if err.strip():
+                output += f"\n[STDERR]\n{err}"
+
+        return output.strip() or "(no output)"
+    finally:
+        os.unlink(script_path)
+
+
+async def _execute_cmd(code: str, timeout: int = 30) -> str:
+    """Execute Windows CMD batch script directly (no sandbox)."""
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".cmd", delete=False, encoding="utf-8") as f:
+        f.write("@echo off\n" + code)
+        script_path = f.name
+
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            "cmd",
+            "/c",
+            script_path,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        try:
+            stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=timeout)
+        except TimeoutError:
+            proc.kill()
+            return f"ERROR: Script timed out after {timeout}s"
+
+        output = ""
+        if stdout:
+            output += stdout.decode("utf-8", errors="replace")
+        if stderr:
+            output += stderr.decode("utf-8", errors="replace")
+        return output.strip() or "(no output)"
+    finally:
+        os.unlink(script_path)
+
+
+async def _execute_node(code: str, timeout: int = 30) -> str:
+    """Execute JavaScript via Node.js directly (no sandbox)."""
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".js", delete=False, encoding="utf-8") as f:
+        f.write(code)
+        script_path = f.name
+
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            "node",
+            script_path,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        try:
+            stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=timeout)
+        except TimeoutError:
+            proc.kill()
+            return f"ERROR: Script timed out after {timeout}s"
+
+        output = ""
+        if stdout:
+            output += stdout.decode("utf-8", errors="replace")
+        if stderr:
+            output += stderr.decode("utf-8", errors="replace")
+        return output.strip() or "(no output)"
+    finally:
+        os.unlink(script_path)

--- a/daemon/pilot/system/sandbox_exec.py
+++ b/daemon/pilot/system/sandbox_exec.py
@@ -1,0 +1,472 @@
+"""Secure execution sandbox for agent-generated code.
+
+Provides OS-level isolation so untrusted code cannot harm the host system.
+Two backends are supported, selected automatically or via config:
+
+  docker      — ephemeral container per execution (best isolation)
+  restricted  — ulimit + stripped env subprocess (fallback, no Docker needed)
+  none        — direct execution, no isolation (legacy / opt-out)
+
+Architecture
+------------
+  execute_code()  ──►  SecureExecutionSandbox.run()
+                            │
+                  ┌─────────┴──────────┐
+                  ▼                    ▼
+           DockerBackend       RestrictedBackend
+         (container per run)  (ulimit + stripped env)
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import shutil
+import sys
+import tempfile
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+
+logger = logging.getLogger("pilot.system.sandbox_exec")
+
+# ---------------------------------------------------------------------------
+# Configuration dataclass (mirrors SecurityConfig fields)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class SandboxConfig:
+    """Runtime configuration for the sandbox layer."""
+
+    mode: str = "auto"  # "auto" | "docker" | "restricted" | "none"
+    memory_mb: int = 128  # memory cap (docker & restricted)
+    timeout: int = 30  # max wall-clock seconds
+    network: bool = False  # allow outbound network inside sandbox
+
+
+# ---------------------------------------------------------------------------
+# Abstract backend
+# ---------------------------------------------------------------------------
+
+
+class _SandboxBackend(ABC):
+    """Common interface for all execution backends."""
+
+    @abstractmethod
+    async def run(
+        self,
+        code: str,
+        language: str,
+        config: SandboxConfig,
+    ) -> str:
+        """Execute *code* and return captured output (stdout + stderr)."""
+
+
+# ---------------------------------------------------------------------------
+# Docker backend
+# ---------------------------------------------------------------------------
+
+# Language → (image, file extension, run command template)
+_DOCKER_LANG_MAP: dict[str, tuple[str, str, list[str]]] = {
+    "python": ("python:3.11-slim", ".py", ["python", "/sandbox/script.py"]),
+    "javascript": ("node:20-slim", ".js", ["node", "/sandbox/script.js"]),
+    "bash": ("bash:5", ".sh", ["bash", "/sandbox/script.sh"]),
+}
+
+
+class DockerBackend(_SandboxBackend):
+    """Runs code inside a disposable Docker container.
+
+    Security properties
+    -------------------
+    - ``--network none``          no outbound network (unless config.network=True)
+    - ``--memory``                hard memory cap
+    - ``--cpus 0.5``              half a CPU core max
+    - ``--read-only``             root filesystem is read-only
+    - ``--tmpfs /tmp``            writable scratch space only in /tmp
+    - ``--no-new-privileges``     prevents privilege escalation
+    - ``--cap-drop ALL``          drops all Linux capabilities
+    - ``--rm``                    container auto-removed on exit
+    - ``--user nobody``           runs as unprivileged user
+    - no host mounts              host filesystem is never exposed
+    """
+
+    async def run(self, code: str, language: str, config: SandboxConfig) -> str:
+        lang = _normalise_language(language)
+        if lang not in _DOCKER_LANG_MAP:
+            return f"ERROR: Docker sandbox does not support language '{language}'"
+
+        image, ext, cmd = _DOCKER_LANG_MAP[lang]
+
+        # Write code to a temp file that we'll COPY into the container via stdin
+        with tempfile.NamedTemporaryFile(mode="w", suffix=ext, delete=False, encoding="utf-8", prefix="pilot_sb_") as f:
+            if lang == "bash":
+                f.write("#!/bin/bash\nset -e\n" + code)
+            else:
+                f.write(code)
+            script_path = f.name
+
+        try:
+            network_flag = "bridge" if config.network else "none"
+            memory_flag = f"{config.memory_mb}m"
+
+            docker_cmd = [
+                "docker",
+                "run",
+                "--rm",
+                "--network",
+                network_flag,
+                "--memory",
+                memory_flag,
+                "--memory-swap",
+                memory_flag,  # disable swap
+                "--cpus",
+                "0.5",
+                "--read-only",
+                "--tmpfs",
+                "/tmp:size=64m",
+                "--no-new-privileges",
+                "--cap-drop",
+                "ALL",
+                "--user",
+                "nobody",
+                "-v",
+                f"{script_path}:/sandbox/script{ext}:ro",
+                image,
+                *cmd,
+            ]
+
+            proc = await asyncio.create_subprocess_exec(
+                *docker_cmd,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+
+            try:
+                stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=config.timeout)
+            except TimeoutError:
+                proc.kill()
+                return f"ERROR: Sandbox timed out after {config.timeout}s"
+
+            output = ""
+            if stdout:
+                output += stdout.decode("utf-8", errors="replace")
+            if stderr:
+                err = stderr.decode("utf-8", errors="replace").strip()
+                if err:
+                    output += f"\n[STDERR]\n{err}"
+            if proc.returncode not in (0, None):
+                output += f"\n[EXIT CODE: {proc.returncode}]"
+
+            return output.strip() or "(no output)"
+
+        finally:
+            try:
+                os.unlink(script_path)
+            except OSError:
+                pass
+
+
+# ---------------------------------------------------------------------------
+# Restricted subprocess backend  (no Docker required)
+# ---------------------------------------------------------------------------
+
+# Minimal safe environment — strips credentials, tokens, paths to sensitive dirs
+_SAFE_ENV_KEYS = frozenset(
+    {
+        "PATH",
+        "HOME",
+        "LANG",
+        "LC_ALL",
+        "LC_CTYPE",
+        "TERM",
+        "TMPDIR",
+        "TMP",
+        "TEMP",
+        "PYTHONPATH",
+        "PYTHONDONTWRITEBYTECODE",
+    }
+)
+
+
+def _build_safe_env() -> dict[str, str]:
+    """Return a stripped copy of os.environ with only safe keys."""
+    env = {k: v for k, v in os.environ.items() if k in _SAFE_ENV_KEYS}
+    # Prevent .pyc files cluttering the temp dir
+    env["PYTHONDONTWRITEBYTECODE"] = "1"
+    return env
+
+
+class RestrictedBackend(_SandboxBackend):
+    """Runs code in a subprocess with resource limits and a stripped environment.
+
+    Security properties
+    -------------------
+    - Stripped environment (no API keys, tokens, or sensitive vars)
+    - ``ulimit -v`` virtual memory cap  (Linux/macOS)
+    - ``ulimit -t`` CPU time cap        (Linux/macOS)
+    - ``ulimit -f`` file size cap       (Linux/macOS)
+    - Timeout enforced via asyncio
+    - No network restriction (OS-level network namespaces need root)
+
+    This backend is weaker than Docker but far better than bare execution.
+    On Windows, only the stripped environment and timeout apply.
+    """
+
+    async def run(self, code: str, language: str, config: SandboxConfig) -> str:
+        lang = _normalise_language(language)
+        safe_env = _build_safe_env()
+
+        if lang in ("python",):
+            return await self._run_python(code, config, safe_env)
+        elif lang == "bash":
+            return await self._run_bash(code, config, safe_env)
+        elif lang == "powershell":
+            return await self._run_powershell(code, config, safe_env)
+        elif lang == "javascript":
+            return await self._run_node(code, config, safe_env)
+        elif lang == "cmd":
+            return await self._run_cmd(code, config, safe_env)
+        else:
+            return f"ERROR: Restricted sandbox does not support language '{language}'"
+
+    # -- helpers -----------------------------------------------------------
+
+    async def _run_python(self, code: str, config: SandboxConfig, env: dict[str, str]) -> str:
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".py", delete=False, encoding="utf-8", prefix="pilot_sb_"
+        ) as f:
+            f.write(code)
+            script_path = f.name
+
+        try:
+            cmd = self._wrap_with_ulimit([sys.executable, script_path], config)
+            return await self._run_proc(cmd, config.timeout, env)
+        finally:
+            _safe_unlink(script_path)
+
+    async def _run_bash(self, code: str, config: SandboxConfig, env: dict[str, str]) -> str:
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".sh", delete=False, encoding="utf-8", prefix="pilot_sb_"
+        ) as f:
+            f.write("#!/bin/bash\nset -e\n" + code)
+            script_path = f.name
+
+        try:
+            os.chmod(script_path, 0o700)
+            cmd = self._wrap_with_ulimit(["bash", script_path], config)
+            return await self._run_proc(cmd, config.timeout, env)
+        finally:
+            _safe_unlink(script_path)
+
+    async def _run_powershell(self, code: str, config: SandboxConfig, env: dict[str, str]) -> str:
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".ps1", delete=False, encoding="utf-8", prefix="pilot_sb_"
+        ) as f:
+            f.write(code)
+            script_path = f.name
+
+        try:
+            shell = "pwsh" if shutil.which("pwsh") else "powershell"
+            cmd = [shell, "-NoProfile", "-ExecutionPolicy", "Bypass", "-File", script_path]
+            return await self._run_proc(cmd, config.timeout, env)
+        finally:
+            _safe_unlink(script_path)
+
+    async def _run_node(self, code: str, config: SandboxConfig, env: dict[str, str]) -> str:
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".js", delete=False, encoding="utf-8", prefix="pilot_sb_"
+        ) as f:
+            f.write(code)
+            script_path = f.name
+
+        try:
+            cmd = self._wrap_with_ulimit(["node", script_path], config)
+            return await self._run_proc(cmd, config.timeout, env)
+        finally:
+            _safe_unlink(script_path)
+
+    async def _run_cmd(self, code: str, config: SandboxConfig, env: dict[str, str]) -> str:
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".cmd", delete=False, encoding="utf-8", prefix="pilot_sb_"
+        ) as f:
+            f.write("@echo off\n" + code)
+            script_path = f.name
+
+        try:
+            return await self._run_proc(["cmd", "/c", script_path], config.timeout, env)
+        finally:
+            _safe_unlink(script_path)
+
+    @staticmethod
+    def _wrap_with_ulimit(cmd: list[str], config: SandboxConfig) -> list[str]:
+        """Prepend ulimit constraints on POSIX systems."""
+        if sys.platform == "win32":
+            return cmd  # ulimit not available on Windows
+
+        mem_kb = config.memory_mb * 1024
+        cpu_seconds = max(config.timeout, 5)
+        # ulimit flags: -v virtual mem (KB), -t CPU time (s), -f file size (512-byte blocks = 50MB)
+        return [
+            "bash",
+            "-c",
+            f"ulimit -v {mem_kb} -t {cpu_seconds} -f 102400; exec "
+            + " ".join(f'"{a}"' if " " in a else a for a in cmd),
+        ]
+
+    @staticmethod
+    async def _run_proc(cmd: list[str], timeout: int, env: dict[str, str]) -> str:
+        proc = await asyncio.create_subprocess_exec(
+            *cmd,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            env=env,
+        )
+        try:
+            stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=timeout)
+        except TimeoutError:
+            proc.kill()
+            return f"ERROR: Sandbox timed out after {timeout}s"
+
+        output = ""
+        if stdout:
+            output += stdout.decode("utf-8", errors="replace")
+        if stderr:
+            err = stderr.decode("utf-8", errors="replace").strip()
+            if err:
+                output += f"\n[STDERR]\n{err}"
+        if proc.returncode not in (0, None):
+            output += f"\n[EXIT CODE: {proc.returncode}]"
+
+        return output.strip() or "(no output)"
+
+
+# ---------------------------------------------------------------------------
+# Public facade
+# ---------------------------------------------------------------------------
+
+
+class SecureExecutionSandbox:
+    """Selects and caches the appropriate backend based on config.mode.
+
+    Usage::
+
+        sandbox = SecureExecutionSandbox(config)
+        output  = await sandbox.run(code, language="python")
+    """
+
+    def __init__(self, config: SandboxConfig) -> None:
+        self._config = config
+        self._backend: _SandboxBackend | None = None
+        self._resolved_mode: str = ""
+
+    # -- backend resolution ------------------------------------------------
+
+    def _resolve_backend(self) -> tuple[_SandboxBackend | None, str]:
+        """Return (backend, mode_name). Returns (None, 'none') for passthrough."""
+        mode = self._config.mode.lower().strip()
+
+        if mode == "none":
+            return None, "none"
+
+        if mode == "docker":
+            if _docker_available():
+                return DockerBackend(), "docker"
+            logger.warning(
+                "sandbox_mode='docker' requested but Docker is not available. Falling back to restricted mode."
+            )
+            return RestrictedBackend(), "restricted"
+
+        if mode == "restricted":
+            return RestrictedBackend(), "restricted"
+
+        # mode == "auto": prefer Docker, fall back to restricted
+        if _docker_available():
+            return DockerBackend(), "docker"
+        return RestrictedBackend(), "restricted"
+
+    def _get_backend(self) -> tuple[_SandboxBackend | None, str]:
+        if self._backend is None and self._resolved_mode == "":
+            self._backend, self._resolved_mode = self._resolve_backend()
+            logger.info("Sandbox backend resolved: %s", self._resolved_mode)
+        return self._backend, self._resolved_mode
+
+    # -- public API --------------------------------------------------------
+
+    async def run(self, code: str, language: str) -> str | None:
+        """Execute *code* in the sandbox.
+
+        Returns the captured output string, or ``None`` if sandbox_mode is
+        'none' (caller should fall back to direct execution).
+        """
+        backend, mode = self._get_backend()
+
+        if mode == "none" or backend is None:
+            return None  # signal: use legacy direct execution
+
+        logger.info(
+            "Sandbox[%s]: executing %d chars of %s code",
+            mode,
+            len(code),
+            language,
+        )
+        try:
+            result = await backend.run(code, language, self._config)
+            logger.info("Sandbox[%s]: execution complete (%d chars output)", mode, len(result))
+            return result
+        except Exception as exc:
+            logger.exception("Sandbox[%s] execution error: %s", mode, exc)
+            return f"ERROR: Sandbox execution failed — {exc}"
+
+    @property
+    def active_mode(self) -> str:
+        """The resolved backend mode (available after first call to run())."""
+        _, mode = self._get_backend()
+        return mode
+
+
+# ---------------------------------------------------------------------------
+# Utilities
+# ---------------------------------------------------------------------------
+
+
+def _normalise_language(language: str) -> str:
+    """Normalise language aliases to a canonical name."""
+    lang = language.lower().strip()
+    aliases: dict[str, str] = {
+        "py": "python",
+        "python3": "python",
+        "js": "javascript",
+        "node": "javascript",
+        "sh": "bash",
+        "shell": "bash",
+        "ps1": "powershell",
+        "pwsh": "powershell",
+        "bat": "cmd",
+        "batch": "cmd",
+    }
+    return aliases.get(lang, lang)
+
+
+def _docker_available() -> bool:
+    """Return True if the Docker CLI is on PATH and the daemon is reachable."""
+    if shutil.which("docker") is None:
+        return False
+    try:
+        result = __import__("subprocess").run(
+            ["docker", "info"],
+            capture_output=True,
+            timeout=5,
+        )
+        return result.returncode == 0
+    except Exception:
+        return False
+
+
+def _safe_unlink(path: str) -> None:
+    """Delete a file, ignoring errors."""
+    try:
+        os.unlink(path)
+    except OSError:
+        pass


### PR DESCRIPTION

## Changes made

- `daemon/pilot/system/sandbox_exec.py` *(new)* — `SecureExecutionSandbox`, `DockerBackend`, `RestrictedBackend`
- `daemon/pilot/system/code_exec.py` — all execution paths route through sandbox
- `daemon/pilot/config.py` — added `sandbox_mode`, `sandbox_memory_mb`, `sandbox_timeout`, `sandbox_network` to `SecurityConfig`
- `daemon/pilot/agents/executor.py` — wires live config into both code execution handlers

---

## How to test

1. `pip install -e ".[full,dev]"` from `daemon/`
2. Trigger any `CODE_EXECUTE` action — works as normal, now sandboxed
3. Force a specific backend via `~/.config/pilot/config.toml`:
```toml
[security]
sandbox_mode = "restricted"   # or "docker" / "none"
```
4.To test Docker mode, ensure Docker is running and set sandbox_mode = "docker"
5.To verify legacy behaviour is preserved, set sandbox_mode = "none" — execution should work exactly as before

## Checklist


-  I have read the CONTRIBUTING.md
-  My code follows the existing code style (Ruff format + check — all passed)
-  I have added/updated tests where applicable
-  All existing tests pass (pytest for backend)
-  I have updated documentation if needed
-  I have tested on at least one platform (Windows — restricted backend confirmed working)


## GSSoC declaration

-  This contribution is made under the GSSoC 2026 program
-  I have not plagiarised code from other repositories