### PR TITLE
perf: implement memory mapping (mmap) for zero-copy model loading

### DIFF
--- a/daemon/pilot/cognitive/tribe_engine.py
+++ b/daemon/pilot/cognitive/tribe_engine.py
@@ -192,6 +192,8 @@ class TribeEngine:
                     local_dir,
                     cache_folder=cache_str,
                     device="auto",
+                    mmap=True,               # The zero-copy Memory Mapping flag
+                    low_cpu_mem_usage=True,  # Prevents double RAM allocation during load
                 )
 
                 _UNGATED_LLAMA = "unsloth/Llama-3.2-3B"

--- a/daemon/pilot/cognitive/tribe_engine.py
+++ b/daemon/pilot/cognitive/tribe_engine.py
@@ -192,7 +192,7 @@ class TribeEngine:
                     local_dir,
                     cache_folder=cache_str,
                     device="auto",
-                    mmap=True,               # The zero-copy Memory Mapping flag
+                    mmap=True,  # The zero-copy Memory Mapping flag
                     low_cpu_mem_usage=True,  # Prevents double RAM allocation during load
                 )
 


### PR DESCRIPTION
Resolves #31

### Problem
The daemon was previously loading the complete `.ckpt` file directly into system RAM before moving it to the target device. For large multi-gigabyte models, this standard I/O operation causes a massive spike in memory usage and drastically increases daemon startup latency.

### Solution
Modified the `_TribeModel.from_pretrained` initialization in `tribe_engine.py` to utilize memory mapping.
* Added `mmap=True`: Tells the underlying PyTorch engine to memory-map the checkpoint file directly from the disk, bypassing the standard RAM buffer.
* Added `low_cpu_mem_usage=True`: Leverages the `accelerate` library to instantiate an empty model shell and load weights directly into it, preventing double RAM allocation during the initialization phase.

This zero-copy approach should drastically reduce the startup time and initial memory overhead.