### PR TITLE
feat(ui): implement highly optimized virtualized chat list (fix #26)

### DIFF
--- a/tauri-app/ui/src/App.svelte
+++ b/tauri-app/ui/src/App.svelte
@@ -222,21 +222,23 @@
               {#snippet item(msg)}
                 {@render messageBlock(msg)}
               {/snippet}
-            </VirtualList>
-
-            {#if $session.loading}
-              <ExecutionGraph />
               
-              <div class="message system">
-                <div class="msg-header">
-                  <span class="msg-label">HELIOX</span>
-                  <span class="phase-badge">{$session.phase || "thinking"}</span>
-                </div>
-                <span class="msg-text loading-dots">
-                  {$session.phase ? `${$session.phase}` : "Thinking"}
-                </span>
-              </div>
-            {/if}
+              {#snippet footer()}
+                {#if $session.loading}
+                  <ExecutionGraph />
+                  
+                  <div class="message system">
+                    <div class="msg-header">
+                      <span class="msg-label">HELIOX</span>
+                      <span class="phase-badge">{$session.phase || "thinking"}</span>
+                    </div>
+                    <span class="msg-text loading-dots">
+                      {$session.phase ? `${$session.phase}` : "Thinking"}
+                    </span>
+                  </div>
+                {/if}
+              {/snippet}
+            </VirtualList>
           {/if}
         </div>
 

--- a/tauri-app/ui/src/App.svelte
+++ b/tauri-app/ui/src/App.svelte
@@ -12,6 +12,7 @@
   import ParticleBurst from "./lib/components/ParticleBurst.svelte";
   import ExecutionGraph from "./lib/components/ExecutionGraph.svelte";
   import ReActPipeline from "./lib/components/ReActPipeline.svelte";
+  import VirtualList from "./lib/components/VirtualList.svelte";
   import PluginsTab from "./lib/components/PluginsTab.svelte";
   import { session } from "./lib/stores/session";
   import type { Message } from "./lib/stores/session";
@@ -25,7 +26,7 @@
   let showWizard = $derived(
     !$settings.first_run_complete && localStorage.getItem("heliox_first_run_complete") !== "true"
   );
-  let resultsEl: HTMLDivElement | undefined = $state();
+  let virtualListEl: VirtualList<Message> | undefined = $state();
   let particleBurst: ParticleBurst | undefined = $state();
 
   async function onSetupComplete() {
@@ -59,9 +60,7 @@
   }
 
   function scrollToBottom() {
-    tick().then(() => {
-      if (resultsEl) resultsEl.scrollTop = resultsEl.scrollHeight;
-    });
+    tick().then(() => virtualListEl?.scrollToBottom());
   }
 
   $effect(() => {
@@ -206,7 +205,7 @@
           />
         {/if}
 
-        <div class="results" bind:this={resultsEl}>
+        <div class="results">
           {#if $session.messages.length === 0 && !$session.loading}
             <div class="empty-state">
               <div class="empty-logo">C</div>
@@ -219,9 +218,11 @@
               </div>
             </div>
           {:else}
-            {#each $session.messages as msg (msg.timestamp)}
-              {@render messageBlock(msg)}
-            {/each}
+            <VirtualList bind:this={virtualListEl} items={$session.messages}>
+              {#snippet item(msg)}
+                {@render messageBlock(msg)}
+              {/snippet}
+            </VirtualList>
 
             {#if $session.loading}
               <ExecutionGraph />
@@ -513,11 +514,9 @@
 
   .results {
     flex: 1;
-    overflow-y: auto;
-    padding: 12px 16px;
+    overflow: hidden;
     display: flex;
     flex-direction: column;
-    gap: 8px;
   }
 
   /* Empty state */

--- a/tauri-app/ui/src/lib/components/VirtualList.svelte
+++ b/tauri-app/ui/src/lib/components/VirtualList.svelte
@@ -1,0 +1,270 @@
+<!-- VirtualList.svelte — Svelte 5 virtualised scroller for chat messages -->
+<script lang="ts" generics="T">
+  /**
+   * VirtualList — Svelte 5 virtualised scroller.
+   *
+   * Only the messages visible in the viewport (± overscan) are mounted in the
+   * DOM.  Top and bottom padding spacers keep the scroll-bar thumb at the right
+   * position without rendering off-screen nodes.
+   *
+   * Usage:
+   *   <VirtualList bind:this={ref} items={messages}>
+   *     {#snippet item(msg, index)}
+   *       <MessageRow {msg} />
+   *     {/snippet}
+   *   </VirtualList>
+   */
+
+  import { tick, onDestroy } from "svelte";
+  import type { Snippet } from "svelte";
+
+  // ── Props ──────────────────────────────────────────────────────────────────
+
+  interface Props<T> {
+    /** Full list of items to virtualise. */
+    items: T[];
+    /** Fallback height (px) used before a row's real height is measured. */
+    estimatedItemHeight?: number;
+    /** Extra items rendered above and below the visible window. */
+    overscan?: number;
+    /** Slot — receives (item, index). */
+    item: Snippet<[T, number]>;
+  }
+
+  let {
+    items,
+    estimatedItemHeight = 80,
+    overscan = 5,
+    item: itemSnippet,
+  }: Props<T> = $props();
+
+  // ── Internal state ─────────────────────────────────────────────────────────
+
+  /** Measured heights for every item (may be estimated until observed). */
+  let heights = $state<number[]>([]);
+
+  /** Index of the first rendered item. */
+  let visStart = $state(0);
+
+  /** Index of the last rendered item (inclusive). */
+  let visEnd = $state(Math.min(overscan * 2, 0));
+
+  /** The scrollable container element. */
+  let scrollerEl: HTMLDivElement | undefined = $state();
+
+  /** Whether the user was at the bottom before the last items update. */
+  let wasAtBottom = true;
+
+  /** ResizeObserver watching rendered row heights. */
+  let ro: ResizeObserver | null = null;
+
+  // ── Derived geometry ───────────────────────────────────────────────────────
+
+  /** Total virtual height of all items (px). */
+  let totalHeight = $derived(
+    heights.reduce((sum, h) => sum + h, 0)
+  );
+
+  /** Pixels of invisible content above the rendered window. */
+  let paddingTop = $derived(
+    heights.slice(0, visStart).reduce((sum, h) => sum + h, 0)
+  );
+
+  /** Pixels of invisible content below the rendered window. */
+  let paddingBottom = $derived(
+    heights.slice(visEnd + 1).reduce((sum, h) => sum + h, 0)
+  );
+
+  /** Slice of items currently in the DOM. */
+  let visibleItems = $derived(
+    items.slice(visStart, visEnd + 1).map((value, i) => ({
+      value,
+      index: visStart + i,
+    }))
+  );
+
+  // ── Height initialisation ──────────────────────────────────────────────────
+
+  /**
+   * Keep `heights` in sync with `items`.
+   * Newly appended items get the estimated height until observed.
+   */
+  $effect(() => {
+    const len = items.length;
+    if (heights.length === len) return;
+
+    if (len > heights.length) {
+      // Items added — extend with estimates
+      const extra = Array(len - heights.length).fill(estimatedItemHeight);
+      heights = [...heights, ...extra];
+    } else {
+      // Items removed — truncate
+      heights = heights.slice(0, len);
+    }
+  });
+
+  // ── Scroll-to-bottom on new messages ──────────────────────────────────────
+
+  let prevItemCount = 0;
+
+  $effect(() => {
+    const newCount = items.length;
+    if (newCount !== prevItemCount) {
+      if (wasAtBottom) {
+        tick().then(() => scrollToBottom());
+      }
+      prevItemCount = newCount;
+    }
+  });
+
+  // ── Window calculation ─────────────────────────────────────────────────────
+
+  function recalcWindow() {
+    if (!scrollerEl) return;
+
+    const scrollTop = scrollerEl.scrollTop;
+    const clientH = scrollerEl.clientHeight;
+
+    // Check if we are at (or very near) the bottom before recalculating
+    wasAtBottom =
+      scrollerEl.scrollTop + scrollerEl.clientHeight >=
+      scrollerEl.scrollHeight - 8;
+
+    // Walk the heights array to find the first and last visible item
+    let cumulative = 0;
+    let newStart = 0;
+    let newEnd = heights.length - 1;
+    let foundStart = false;
+
+    for (let i = 0; i < heights.length; i++) {
+      const bottom = cumulative + heights[i];
+
+      if (!foundStart && bottom > scrollTop) {
+        newStart = Math.max(0, i - overscan);
+        foundStart = true;
+      }
+
+      if (foundStart && cumulative > scrollTop + clientH) {
+        newEnd = Math.min(heights.length - 1, i + overscan);
+        break;
+      }
+
+      cumulative = bottom;
+    }
+
+    // Guard: if list is shorter than viewport just render everything
+    if (!foundStart) {
+      newStart = 0;
+      newEnd = heights.length - 1;
+    } else {
+      newEnd = Math.min(heights.length - 1, newEnd + overscan);
+    }
+
+    visStart = newStart;
+    visEnd = newEnd;
+  }
+
+  // ── ResizeObserver — measure real heights ─────────────────────────────────
+
+  function attachResizeObserver() {
+    if (!scrollerEl) return;
+
+    ro?.disconnect();
+    ro = new ResizeObserver((entries) => {
+      let changed = false;
+      for (const entry of entries) {
+        const el = entry.target as HTMLElement;
+        const idx = Number(el.dataset.vlIndex);
+        if (isNaN(idx)) continue;
+        const h = entry.contentRect.height;
+        if (heights[idx] !== h) {
+          heights[idx] = h;
+          changed = true;
+        }
+      }
+      if (changed) recalcWindow();
+    });
+
+    // Observe all currently rendered rows
+    observeRenderedRows();
+  }
+
+  function observeRenderedRows() {
+    if (!scrollerEl || !ro) return;
+    const rows = scrollerEl.querySelectorAll<HTMLElement>("[data-vl-index]");
+    rows.forEach((el) => ro!.observe(el));
+  }
+
+  // ── Lifecycle ──────────────────────────────────────────────────────────────
+
+  $effect(() => {
+    if (!scrollerEl) return;
+
+    scrollerEl.addEventListener("scroll", recalcWindow, { passive: true });
+    attachResizeObserver();
+    recalcWindow();
+
+    return () => {
+      scrollerEl?.removeEventListener("scroll", recalcWindow);
+    };
+  });
+
+  // Re-observe whenever the visible slice changes (new rows mounted)
+  $effect(() => {
+    // Depend on visStart + visEnd so this re-runs when the window shifts
+    void visStart;
+    void visEnd;
+    tick().then(observeRenderedRows);
+  });
+
+  onDestroy(() => {
+    ro?.disconnect();
+  });
+
+  // ── Public API ─────────────────────────────────────────────────────────────
+
+  /** Scroll the list to the very bottom. */
+  export function scrollToBottom() {
+    if (scrollerEl) {
+      scrollerEl.scrollTop = scrollerEl.scrollHeight;
+      wasAtBottom = true;
+    }
+  }
+</script>
+
+<!-- Scrollable container -->
+<div class="vl-scroller" bind:this={scrollerEl}>
+  <!-- Top spacer: pushes rendered rows to the correct vertical position -->
+  <div class="vl-spacer" style="height: {paddingTop}px;" aria-hidden="true"></div>
+
+  <!-- Rendered rows (only the visible window + overscan) -->
+  {#each visibleItems as { value, index } (index)}
+    <div class="vl-row" data-vl-index={index}>
+      {@render itemSnippet(value, index)}
+    </div>
+  {/each}
+
+  <!-- Bottom spacer: keeps scrollbar thumb proportional -->
+  <div class="vl-spacer" style="height: {paddingBottom}px;" aria-hidden="true"></div>
+</div>
+
+<style>
+  .vl-scroller {
+    height: 100%;
+    overflow-y: auto;
+    /* Inherit padding from the parent .results rule in App.svelte */
+    padding: 12px 16px;
+    display: flex;
+    flex-direction: column;
+    box-sizing: border-box;
+  }
+
+  .vl-spacer {
+    flex-shrink: 0;
+    width: 100%;
+  }
+
+  .vl-row {
+    flex-shrink: 0;
+  }
+</style>

--- a/tauri-app/ui/src/lib/components/VirtualList.svelte
+++ b/tauri-app/ui/src/lib/components/VirtualList.svelte
@@ -50,7 +50,7 @@
   let visStart = $state(0);
 
   /** Index of the last rendered item (inclusive). */
-  let visEnd = $state(Math.min(overscan * 2, 0));
+  let visEnd = $state(-1);
 
   /** The scrollable container element. */
   let scrollerEl: HTMLDivElement | undefined = $state();
@@ -63,27 +63,38 @@
 
   // ── Derived geometry ───────────────────────────────────────────────────────
 
+  /** Pre-calculated cumulative heights for O(1) lookups. */
+  let cumulativeHeights = $derived.by(() => {
+    let sum = 0;
+    return heights.map(h => {
+      sum += h;
+      return sum;
+    });
+  });
+
   /** Total virtual height of all items (px). */
   let totalHeight = $derived(
-    heights.reduce((sum, h) => sum + h, 0)
+    cumulativeHeights.length > 0 ? cumulativeHeights[cumulativeHeights.length - 1] : 0
   );
 
   /** Pixels of invisible content above the rendered window. */
   let paddingTop = $derived(
-    heights.slice(0, visStart).reduce((sum, h) => sum + h, 0)
+    visStart > 0 && cumulativeHeights.length > 0 ? cumulativeHeights[visStart - 1] : 0
   );
 
   /** Pixels of invisible content below the rendered window. */
   let paddingBottom = $derived(
-    heights.slice(visEnd + 1).reduce((sum, h) => sum + h, 0)
+    visEnd >= 0 && visEnd < cumulativeHeights.length - 1
+      ? totalHeight - cumulativeHeights[visEnd]
+      : 0
   );
 
   /** Slice of items currently in the DOM. */
   let visibleItems = $derived(
-    items.slice(visStart, visEnd + 1).map((value, i) => ({
+    visEnd >= visStart ? items.slice(visStart, visEnd + 1).map((value, i) => ({
       value,
       index: visStart + i,
-    }))
+    })) : []
   );
 
   // ── Height initialisation ──────────────────────────────────────────────────
@@ -143,27 +154,23 @@
     let foundStart = false;
 
     for (let i = 0; i < heights.length; i++) {
-      const bottom = cumulative + heights[i];
+      const bottom = cumulativeHeights[i];
 
       if (!foundStart && bottom > scrollTop) {
         newStart = Math.max(0, i - overscan);
         foundStart = true;
       }
 
-      if (foundStart && cumulative > scrollTop + clientH) {
+      if (foundStart && bottom > scrollTop + clientH) {
         newEnd = Math.min(heights.length - 1, i + overscan);
         break;
       }
-
-      cumulative = bottom;
     }
 
     // Guard: if list is shorter than viewport just render everything
     if (!foundStart) {
       newStart = 0;
       newEnd = heights.length - 1;
-    } else {
-      newEnd = Math.min(heights.length - 1, newEnd + overscan);
     }
 
     visStart = newStart;
@@ -277,5 +284,6 @@
 
   .vl-row {
     flex-shrink: 0;
+    margin-bottom: 8px;
   }
 </style>

--- a/tauri-app/ui/src/lib/components/VirtualList.svelte
+++ b/tauri-app/ui/src/lib/components/VirtualList.svelte
@@ -29,6 +29,8 @@
     overscan?: number;
     /** Slot — receives (item, index). */
     item: Snippet<[T, number]>;
+    /** Optional footer rendered below all items. */
+    footer?: Snippet;
   }
 
   let {
@@ -36,6 +38,7 @@
     estimatedItemHeight = 80,
     overscan = 5,
     item: itemSnippet,
+    footer: footerSnippet,
   }: Props<T> = $props();
 
   // ── Internal state ─────────────────────────────────────────────────────────
@@ -101,6 +104,9 @@
       // Items removed — truncate
       heights = heights.slice(0, len);
     }
+    
+    // Recalculate window so new items can be rendered
+    tick().then(recalcWindow);
   });
 
   // ── Scroll-to-bottom on new messages ──────────────────────────────────────
@@ -246,11 +252,16 @@
 
   <!-- Bottom spacer: keeps scrollbar thumb proportional -->
   <div class="vl-spacer" style="height: {paddingBottom}px;" aria-hidden="true"></div>
+
+  {#if footerSnippet}
+    {@render footerSnippet()}
+  {/if}
 </div>
 
 <style>
   .vl-scroller {
-    height: 100%;
+    flex: 1;
+    min-height: 0;
     overflow-y: auto;
     /* Inherit padding from the parent .results rule in App.svelte */
     padding: 12px 16px;


### PR DESCRIPTION
## Summary

As chat history grows, the DOM was mounting every message unconditionally, causing heavy rendering and scroll jank, particularly because of the structurally complex message blocks. This PR implements a custom, zero-dependency Svelte 5 Virtualized List to only render visible messages with $O(1)$ calculations.

Closes #26

---

## Type of change

- [ ] Bug fix
- [x] New feature / enhancement
- [ ] Documentation update
- [ ] Tests / CI
- [x] Performance improvement
- [ ] Refactor (no functional change)

---

## Changes made

- **`tauri-app/ui/src/lib/components/VirtualList.svelte`**: 
  - Created a zero-dependency, Svelte 5-native virtualized scroller using runes (`$state`, `$derived`, `$effect`).
  - Implements `ResizeObserver` for measuring real item heights dynamically.
  - Optimized scroll tracking using a `cumulativeHeights` array for $O(1)$ padding calculations, preventing scroll jank.
  - Includes a `footer` snippet for rendering non-message elements (like the loading indicator) safely inside the scroll bounds.
- **`tauri-app/ui/src/App.svelte`**: 
  - Replaced the unoptimized `{#each}` loop inside the `.results` container with `<VirtualList>`.
  - Wired up the new `scrollToBottom()` API correctly to maintain auto-scrolling when anchored.
  - Adjusted flexbox styles (`min-height: 0` and spacing layout) to prevent the container from collapsing under the ReAct pipeline.

---

## How to test

1. Start the UI using `npm run dev` in the `tauri-app/ui` directory.
2. Send a series of commands or prompts until there are more than 20-30 messages in the chat history.
3. Scroll rapidly up and down the history — notice there is no blank flickering, no scroll jank, and scrolling remains buttery smooth.
4. Verify that when anchored at the bottom, a newly arriving message automatically scrolls the view down, and the "Thinking..." indicator sits correctly beneath the messages.

---

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My code follows the existing code style
- [ ] I have added/updated tests where applicable
- [x] All existing tests pass (`pytest` for backend, `npm run check` / `npm run test` for frontend)
- [ ] I have updated documentation if needed
- [x] I have tested on at least one platform (Windows / macOS / Linux)

---

## GSSoC declaration

- [x] This contribution is made under the GSSoC 2026 program
- [x] I have not plagiarised code from other repositories
