### PR TITLE
feat: add DestructiveCriticAgent for Tier 4 plan safety review(fixes #36)

### DIFF
--- a/daemon/pilot/agents/destructive_critic.py
+++ b/daemon/pilot/agents/destructive_critic.py
@@ -1,0 +1,283 @@
+"""Destructive Critic Agent — safety reviewer for Tier 4 (ROOT_CRITICAL) plans.
+
+For any plan that contains Tier 4 destructive actions, the orchestration
+pipeline runs a two-agent handshake:
+
+  1. Planner              → produces the ActionPlan as normal.
+  2. DestructiveCriticAgent → independently reviews the plan and returns a
+     structured safety verdict BEFORE the user confirmation gate fires.
+
+If the critic blocks the plan, execution is aborted immediately and the
+reason is surfaced to the user. The critic never executes anything — it
+only reads the plan and reasons about it.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from pilot.actions import ActionPlan
+    from pilot.models.router import ModelRouter
+
+logger = logging.getLogger("pilot.agents.destructive_critic")
+
+# ---------------------------------------------------------------------------
+# Prompts
+# ---------------------------------------------------------------------------
+
+_CRITIC_SYSTEM_PROMPT = """\
+You are the Destructive Action Safety Critic for Heliox OS.
+Your ONLY job is to review action plans that contain Tier 4 (ROOT_CRITICAL) or
+Tier 3 (DESTRUCTIVE) operations and decide whether they are safe to proceed.
+
+You are a second, independent agent. You did NOT create this plan. Approach it
+with healthy skepticism.
+
+Evaluate the plan against these five criteria:
+
+1. INTENT ALIGNMENT  — Does every action directly serve the stated user request?
+   Flag any action that seems unrelated or excessive.
+2. BLAST RADIUS      — What is the worst-case irreversible damage if something
+   goes wrong? (e.g. deleting /home vs deleting a temp file)
+3. REVERSIBILITY     — Can the damage be undone without a snapshot?
+4. PRIVILEGE CREEP   — Does the plan request root/elevated access beyond what is
+   strictly necessary for the task?
+5. INJECTION RISK    — Could any parameter (path, command, script) be exploited
+   via path traversal, shell injection, or wildcard expansion?
+
+Respond with ONLY a JSON object — no markdown, no prose outside the JSON:
+{
+  "verdict": "APPROVE" | "WARN" | "BLOCK",
+  "risk_score": 0.0-1.0,
+  "issues": ["list of specific concerns, empty if none"],
+  "safe_actions": ["action_types that are fine"],
+  "flagged_actions": ["action_types that are risky"],
+  "recommendation": "One sentence summary for the user"
+}
+
+Verdict rules:
+- APPROVE : Plan is safe to proceed (risk_score < 0.4, no critical issues).
+- WARN    : Plan has concerns but can proceed with user awareness (0.4 <= risk_score < 0.75).
+- BLOCK   : Plan must NOT execute — too dangerous or misaligned (risk_score >= 0.75).
+"""
+
+_CRITIC_USER_TEMPLATE = """\
+User request: {user_input}
+
+Planned actions ({action_count} total, max permission tier: {max_tier}):
+{action_list}
+
+Plan explanation: {explanation}
+"""
+
+# ---------------------------------------------------------------------------
+# Data model
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class CriticVerdict:
+    """Structured output from the DestructiveCriticAgent."""
+
+    verdict: str  # "APPROVE" | "WARN" | "BLOCK"
+    risk_score: float
+    issues: list[str] = field(default_factory=list)
+    safe_actions: list[str] = field(default_factory=list)
+    flagged_actions: list[str] = field(default_factory=list)
+    recommendation: str = ""
+    raw_response: str = ""
+
+    @property
+    def is_blocked(self) -> bool:
+        """Return True when the critic has hard-blocked the plan."""
+        return self.verdict == "BLOCK"
+
+    @property
+    def has_warnings(self) -> bool:
+        """Return True when the critic approved with caveats."""
+        return self.verdict == "WARN"
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialise to a plain dict suitable for JSON broadcast."""
+        return {
+            "verdict": self.verdict,
+            "risk_score": self.risk_score,
+            "issues": self.issues,
+            "safe_actions": self.safe_actions,
+            "flagged_actions": self.flagged_actions,
+            "recommendation": self.recommendation,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Agent
+# ---------------------------------------------------------------------------
+
+
+class DestructiveCriticAgent:
+    """Secondary critic agent that reviews Tier 4 plans before execution.
+
+    This agent is intentionally stateless and has no side effects — it only
+    reads the plan and calls the LLM to produce a safety verdict.
+
+    The critic is invoked by the server's execution pipeline whenever a plan
+    contains at least one ROOT_CRITICAL (Tier 4) action.  It runs *before*
+    the user confirmation gate so that a BLOCK verdict can abort the pipeline
+    without ever prompting the user to approve something dangerous.
+
+    Usage::
+
+        critic = DestructiveCriticAgent(model_router)
+        verdict = await critic.review(user_input, plan)
+        if verdict.is_blocked:
+            # abort — surface verdict.recommendation to the user
+        elif verdict.has_warnings:
+            # surface warnings alongside the normal confirmation prompt
+    """
+
+    def __init__(self, model_router: ModelRouter) -> None:
+        self._model = model_router
+
+    async def review(self, user_input: str, plan: ActionPlan) -> CriticVerdict:
+        """Review a Tier 4 plan and return a structured safety verdict.
+
+        Args:
+            user_input: The original natural-language request from the user.
+            plan: The ActionPlan produced by the Planner.
+
+        Returns:
+            A CriticVerdict with verdict, risk_score, issues, and recommendation.
+        """
+        action_list = self._format_action_list(plan)
+        max_tier = plan.max_tier.name if plan.actions else "UNKNOWN"
+
+        user_message = _CRITIC_USER_TEMPLATE.format(
+            user_input=user_input,
+            action_count=len(plan.actions),
+            max_tier=max_tier,
+            action_list=action_list,
+            explanation=plan.explanation or "(no explanation provided)",
+        )
+
+        logger.info(
+            "[DestructiveCritic] Reviewing plan — %d action(s), max_tier=%s",
+            len(plan.actions),
+            max_tier,
+        )
+
+        raw = ""
+        try:
+            raw = await self._model.generate(
+                user_message,
+                system_prompt=_CRITIC_SYSTEM_PROMPT,
+            )
+            verdict = self._parse_verdict(raw)
+            logger.info(
+                "[DestructiveCritic] verdict=%s risk=%.2f flagged=%s",
+                verdict.verdict,
+                verdict.risk_score,
+                verdict.flagged_actions,
+            )
+            return verdict
+
+        except Exception as exc:
+            # Fail-safe: if the critic itself errors, emit WARN rather than
+            # silently approving or hard-blocking — let the user decide.
+            logger.warning("[DestructiveCritic] Review failed (%s), defaulting to WARN", exc)
+            return CriticVerdict(
+                verdict="WARN",
+                risk_score=0.5,
+                issues=[f"Critic agent encountered an error: {exc}"],
+                recommendation="Critic review failed — proceed with extra caution.",
+                raw_response=raw,
+            )
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    def _format_action_list(self, plan: ActionPlan) -> str:
+        """Render the plan's actions as a numbered list for the critic prompt.
+
+        Only the fields most relevant to safety analysis are included to keep
+        the prompt concise and focused.
+        """
+        lines: list[str] = []
+        for i, action in enumerate(plan.actions, start=1):
+            tier = action.permission_tier.name
+            target = action.target or "(no target)"
+            flags = ""
+            if action.requires_root:
+                flags += " [REQUIRES ROOT]"
+            if action.destructive:
+                flags += " [DESTRUCTIVE]"
+            lines.append(f"  {i}. {action.action_type.value} | tier={tier} | target={target}{flags}")
+
+            # Surface key parameters so the critic can reason about concrete values
+            if action.parameters:
+                try:
+                    param_dict = action.parameters.model_dump(exclude_none=True)
+                    # Only include fields that carry safety-relevant information
+                    relevant = {
+                        k: v
+                        for k, v in param_dict.items()
+                        if k
+                        in (
+                            "path",
+                            "command",
+                            "script",
+                            "name",
+                            "destination",
+                            "recursive",
+                            "elevated",
+                            "force",
+                        )
+                        and v not in (None, "", [], {}, False)
+                    }
+                    if relevant:
+                        lines.append(f"     params: {json.dumps(relevant)}")
+                except Exception:
+                    pass  # Parameter serialisation is best-effort
+
+        return "\n".join(lines) if lines else "  (empty plan)"
+
+    def _parse_verdict(self, raw: str) -> CriticVerdict:
+        """Parse the LLM JSON response into a CriticVerdict.
+
+        Handles markdown code fences that some models wrap around JSON output.
+        """
+        text = raw.strip()
+
+        # Strip markdown code fences if present (e.g. ```json ... ```)
+        if text.startswith("```"):
+            text = text.split("```", 2)[1]
+            if text.startswith("json"):
+                text = text[4:]
+            text = text.strip()
+        if text.endswith("```"):
+            text = text[:-3].strip()
+
+        data: dict[str, Any] = json.loads(text)
+
+        # Normalise verdict — default to WARN for any unexpected value
+        verdict_str = str(data.get("verdict", "WARN")).upper()
+        if verdict_str not in ("APPROVE", "WARN", "BLOCK"):
+            verdict_str = "WARN"
+
+        # Clamp risk_score to [0.0, 1.0]
+        risk_score = float(data.get("risk_score", 0.5))
+        risk_score = max(0.0, min(1.0, risk_score))
+
+        return CriticVerdict(
+            verdict=verdict_str,
+            risk_score=risk_score,
+            issues=list(data.get("issues", [])),
+            safe_actions=list(data.get("safe_actions", [])),
+            flagged_actions=list(data.get("flagged_actions", [])),
+            recommendation=str(data.get("recommendation", "")),
+            raw_response=raw,
+        )

--- a/daemon/pilot/agents/destructive_critic.py
+++ b/daemon/pilot/agents/destructive_critic.py
@@ -1,14 +1,14 @@
-"""Destructive Critic Agent — safety reviewer for Tier 4 (ROOT_CRITICAL) plans.
+"""Destructive Critic Agent â€” safety reviewer for Tier 4 (ROOT_CRITICAL) plans.
 
 For any plan that contains Tier 4 destructive actions, the orchestration
 pipeline runs a two-agent handshake:
 
-  1. Planner              → produces the ActionPlan as normal.
-  2. DestructiveCriticAgent → independently reviews the plan and returns a
+  1. Planner              â†’ produces the ActionPlan as normal.
+  2. DestructiveCriticAgent â†’ independently reviews the plan and returns a
      structured safety verdict BEFORE the user confirmation gate fires.
 
 If the critic blocks the plan, execution is aborted immediately and the
-reason is surfaced to the user. The critic never executes anything — it
+reason is surfaced to the user. The critic never executes anything â€” it
 only reads the plan and reasons about it.
 """
 
@@ -39,17 +39,17 @@ with healthy skepticism.
 
 Evaluate the plan against these five criteria:
 
-1. INTENT ALIGNMENT  — Does every action directly serve the stated user request?
+1. INTENT ALIGNMENT  â€” Does every action directly serve the stated user request?
    Flag any action that seems unrelated or excessive.
-2. BLAST RADIUS      — What is the worst-case irreversible damage if something
+2. BLAST RADIUS      â€” What is the worst-case irreversible damage if something
    goes wrong? (e.g. deleting /home vs deleting a temp file)
-3. REVERSIBILITY     — Can the damage be undone without a snapshot?
-4. PRIVILEGE CREEP   — Does the plan request root/elevated access beyond what is
+3. REVERSIBILITY     â€” Can the damage be undone without a snapshot?
+4. PRIVILEGE CREEP   â€” Does the plan request root/elevated access beyond what is
    strictly necessary for the task?
-5. INJECTION RISK    — Could any parameter (path, command, script) be exploited
+5. INJECTION RISK    â€” Could any parameter (path, command, script) be exploited
    via path traversal, shell injection, or wildcard expansion?
 
-Respond with ONLY a JSON object — no markdown, no prose outside the JSON:
+Respond with ONLY a JSON object â€” no markdown, no prose outside the JSON:
 {
   "verdict": "APPROVE" | "WARN" | "BLOCK",
   "risk_score": 0.0-1.0,
@@ -62,7 +62,7 @@ Respond with ONLY a JSON object — no markdown, no prose outside the JSON:
 Verdict rules:
 - APPROVE : Plan is safe to proceed (risk_score < 0.4, no critical issues).
 - WARN    : Plan has concerns but can proceed with user awareness (0.4 <= risk_score < 0.75).
-- BLOCK   : Plan must NOT execute — too dangerous or misaligned (risk_score >= 0.75).
+- BLOCK   : Plan must NOT execute â€” too dangerous or misaligned (risk_score >= 0.75).
 """
 
 _CRITIC_USER_TEMPLATE = """\
@@ -121,7 +121,7 @@ class CriticVerdict:
 class DestructiveCriticAgent:
     """Secondary critic agent that reviews Tier 4 plans before execution.
 
-    This agent is intentionally stateless and has no side effects — it only
+    This agent is intentionally stateless and has no side effects â€” it only
     reads the plan and calls the LLM to produce a safety verdict.
 
     The critic is invoked by the server's execution pipeline whenever a plan
@@ -134,7 +134,7 @@ class DestructiveCriticAgent:
         critic = DestructiveCriticAgent(model_router)
         verdict = await critic.review(user_input, plan)
         if verdict.is_blocked:
-            # abort — surface verdict.recommendation to the user
+            # abort â€” surface verdict.recommendation to the user
         elif verdict.has_warnings:
             # surface warnings alongside the normal confirmation prompt
     """
@@ -164,7 +164,7 @@ class DestructiveCriticAgent:
         )
 
         logger.info(
-            "[DestructiveCritic] Reviewing plan — %d action(s), max_tier=%s",
+            "[DestructiveCritic] Reviewing plan â€” %d action(s), max_tier=%s",
             len(plan.actions),
             max_tier,
         )
@@ -186,13 +186,13 @@ class DestructiveCriticAgent:
 
         except Exception as exc:
             # Fail-safe: if the critic itself errors, emit WARN rather than
-            # silently approving or hard-blocking — let the user decide.
+            # silently approving or hard-blocking â€” let the user decide.
             logger.warning("[DestructiveCritic] Review failed (%s), defaulting to WARN", exc)
             return CriticVerdict(
                 verdict="WARN",
                 risk_score=0.5,
                 issues=[f"Critic agent encountered an error: {exc}"],
-                recommendation="Critic review failed — proceed with extra caution.",
+                recommendation="Critic review failed â€” proceed with extra caution.",
                 raw_response=raw,
             )
 
@@ -263,7 +263,7 @@ class DestructiveCriticAgent:
 
         data: dict[str, Any] = json.loads(text)
 
-        # Normalise verdict — default to WARN for any unexpected value
+        # Normalise verdict â€” default to WARN for any unexpected value
         verdict_str = str(data.get("verdict", "WARN")).upper()
         if verdict_str not in ("APPROVE", "WARN", "BLOCK"):
             verdict_str = "WARN"

--- a/daemon/pilot/reasoning/events.py
+++ b/daemon/pilot/reasoning/events.py
@@ -48,6 +48,7 @@ class ReasoningStage(StrEnum):
     VERIFICATION = "verification"
     REFLECTION = "reflection"
     MEMORY_UPDATE = "memory_update"
+    CRITIC_REVIEW = "critic_review"
 
 
 class EventType(StrEnum):
@@ -141,6 +142,12 @@ VERIFICATION_FAILED = "verification_failed"
 REFLECTION_STARTED = "reflection_started"
 REFLECTION_INSIGHT = "reflection_insight"
 REFLECTION_COMPLETE = "reflection_complete"
+
+# Destructive critic stage — Tier 4 safety review
+CRITIC_REVIEW_STARTED = "critic_review_started"
+CRITIC_REVIEW_APPROVED = "critic_review_approved"
+CRITIC_REVIEW_WARNED = "critic_review_warned"
+CRITIC_REVIEW_BLOCKED = "critic_review_blocked"
 
 
 class ReasoningEmitter:

--- a/daemon/pilot/reasoning/events.py
+++ b/daemon/pilot/reasoning/events.py
@@ -1,10 +1,10 @@
-"""Thought Visualization Event System — granular reasoning telemetry.
+"""Thought Visualization Event System â€” granular reasoning telemetry.
 
 Defines the event schema, emitter, and stream manager for broadcasting
 real-time AI reasoning events to the frontend.
 
 Event Flow:
-  Agent Runtime → ReasoningEmitter → WebSocket → ThoughtGraph UI
+  Agent Runtime â†’ ReasoningEmitter â†’ WebSocket â†’ ThoughtGraph UI
 
 Each reasoning event carries:
   - event_type: Categorized phase (memory, planning, routing, etc.)
@@ -32,7 +32,7 @@ from typing import Any, Callable, Coroutine
 logger = logging.getLogger("pilot.reasoning.events")
 
 
-# ── Event Schema ──
+# â”€â”€ Event Schema â”€â”€
 
 
 class ReasoningStage(StrEnum):
@@ -92,7 +92,7 @@ class ReasoningEvent:
         }
 
 
-# ── Predefined event names ──
+# â”€â”€ Predefined event names â”€â”€
 
 # Memory stage
 MEMORY_SEARCH_STARTED = "memory_search_started"
@@ -143,7 +143,7 @@ REFLECTION_STARTED = "reflection_started"
 REFLECTION_INSIGHT = "reflection_insight"
 REFLECTION_COMPLETE = "reflection_complete"
 
-# Destructive critic stage — Tier 4 safety review
+# Destructive critic stage â€” Tier 4 safety review
 CRITIC_REVIEW_STARTED = "critic_review_started"
 CRITIC_REVIEW_APPROVED = "critic_review_approved"
 CRITIC_REVIEW_WARNED = "critic_review_warned"
@@ -184,7 +184,7 @@ class ReasoningEmitter:
         self._session_id = uuid.uuid4().hex[:8]
         self._event_log.clear()
 
-    # ── High-level emitters ──
+    # â”€â”€ High-level emitters â”€â”€
 
     async def phase_start(
         self,
@@ -349,7 +349,7 @@ class ReasoningEmitter:
         )
         await self._emit(event)
 
-    # ── Internal ──
+    # â”€â”€ Internal â”€â”€
 
     async def _emit(self, event: ReasoningEvent) -> None:
         """Broadcast the event to all connected frontends."""
@@ -369,7 +369,7 @@ class ReasoningEmitter:
         if self._broadcast_fn:
             await self._broadcast_fn("reasoning_event", event.to_dict())
 
-    # ── Stats ──
+    # â”€â”€ Stats â”€â”€
 
     def get_session_log(self) -> list[dict[str, Any]]:
         """Return the full event log for the current session."""

--- a/daemon/pilot/server.py
+++ b/daemon/pilot/server.py
@@ -92,6 +92,7 @@ class PilotServer:
         self._planner: Any = None
         self._executor: Any = None
         self._verifier: Any = None
+        self._destructive_critic: Any = None
         self._reflector: Any = None
         self._multi_agent: Any = None
         self._background: Any = None
@@ -163,6 +164,13 @@ class PilotServer:
         self._planner = Planner(model_router, self._memory)
         self._executor = Executor(self.config, validator, permissions, audit)
         self._verifier = Verifier(model_router)
+
+        # Destructive Critic Agent — secondary safety reviewer for Tier 4 plans.
+        # Sits between the Planner and the confirmation gate so a BLOCK verdict
+        # aborts execution before the user is ever asked to approve.
+        from pilot.agents.destructive_critic import DestructiveCriticAgent
+
+        self._destructive_critic = DestructiveCriticAgent(model_router)
 
         # Advanced agent components
         self._reflector = Reflector(model_router)
@@ -521,6 +529,10 @@ class PilotServer:
             CONFIRMATION_APPROVED,
             CONFIRMATION_DENIED,
             CONFIRMATION_REQUIRED,
+            CRITIC_REVIEW_APPROVED,
+            CRITIC_REVIEW_BLOCKED,
+            CRITIC_REVIEW_STARTED,
+            CRITIC_REVIEW_WARNED,
             EXECUTOR_ACTION_COMPLETE,
             EXECUTOR_ACTION_STARTED,
             EXECUTOR_ALL_COMPLETE,
@@ -669,6 +681,61 @@ class PilotServer:
                     },
                 )
             )
+
+            # ── Stage: Destructive Critic Review (Tier 4 plans only) ──
+            # For any plan that contains ROOT_CRITICAL (Tier 4) actions, a
+            # second independent agent reviews the plan for safety before the
+            # user confirmation gate fires.  A BLOCK verdict aborts execution
+            # immediately; a WARN verdict surfaces issues alongside the normal
+            # confirmation prompt.
+            from pilot.actions import PermissionTier
+
+            plan_has_tier4 = any(a.permission_tier == PermissionTier.ROOT_CRITICAL for a in plan.actions)
+            if plan_has_tier4 and self._destructive_critic and not dry_run:
+                critic_phase = ""
+                await ws.send(_notification("status", {"phase": "critic review"}))
+                if emit:
+                    critic_phase = await emit.phase_start(
+                        "critic_review",
+                        CRITIC_REVIEW_STARTED,
+                        {"plan_id": plan_id, "action_count": len(plan.actions)},
+                    )
+                    await emit.thought(
+                        "critic_review",
+                        "Tier 4 actions detected — running independent safety review...",
+                        parent_id=critic_phase,
+                    )
+
+                verdict = await self._destructive_critic.review(user_input, plan)
+
+                # Broadcast the full verdict to the UI so the user can see it
+                await ws.send(_notification("critic_verdict", verdict.to_dict()))
+
+                if verdict.is_blocked:
+                    # Hard block — do not proceed to confirmation or execution
+                    if emit:
+                        await emit.phase_error(
+                            "critic_review",
+                            CRITIC_REVIEW_BLOCKED,
+                            verdict.recommendation,
+                            parent_id=critic_phase,
+                        )
+                    return {
+                        "status": "blocked_by_critic",
+                        "verdict": verdict.to_dict(),
+                        "message": (f"Plan blocked by safety critic: {verdict.recommendation}"),
+                        "explanation": plan.explanation,
+                    }
+
+                # WARN or APPROVE — continue, but surface issues if any
+                if emit:
+                    event_name = CRITIC_REVIEW_WARNED if verdict.has_warnings else CRITIC_REVIEW_APPROVED
+                    await emit.phase_complete(
+                        "critic_review",
+                        event_name,
+                        verdict.to_dict(),
+                        parent_id=critic_phase,
+                    )
 
             # ── Stage: Confirmation Gate ──
             needs_confirm = any(a.requires_confirmation for a in plan.actions) and not dry_run

--- a/daemon/pilot/server.py
+++ b/daemon/pilot/server.py
@@ -165,7 +165,7 @@ class PilotServer:
         self._executor = Executor(self.config, validator, permissions, audit)
         self._verifier = Verifier(model_router)
 
-        # Destructive Critic Agent — secondary safety reviewer for Tier 4 plans.
+        # Destructive Critic Agent Ã¢â‚¬â€ secondary safety reviewer for Tier 4 plans.
         # Sits between the Planner and the confirmation gate so a BLOCK verdict
         # aborts execution before the user is ever asked to approve.
         from pilot.agents.destructive_critic import DestructiveCriticAgent
@@ -180,7 +180,7 @@ class PilotServer:
         self._background.set_broadcast(self._broadcast_notification)
         self._background.register_builtin_monitors()
 
-        # Multi-Agent Orchestrator — register all specialist agents
+        # Multi-Agent Orchestrator Ã¢â‚¬â€ register all specialist agents
         self._orchestrator = AgentOrchestrator(model_router)
         self._orchestrator.set_broadcast(self._broadcast_notification)
         self._orchestrator.register_agent(SystemAgent(model_router, self._executor))
@@ -190,13 +190,13 @@ class PilotServer:
         self._orchestrator.register_agent(CommunicationAgent(model_router, self._executor))
         await self._orchestrator.start_all()
 
-        # Multimodal Fusion Engine — voice + gesture intent fusion
+        # Multimodal Fusion Engine Ã¢â‚¬â€ voice + gesture intent fusion
         from pilot.multimodal.fusion import MultimodalFusionEngine
 
         self._fusion = MultimodalFusionEngine()
         self._fusion.set_broadcast(self._broadcast_notification)
 
-        # Reasoning Event Emitter — thought visualization telemetry
+        # Reasoning Event Emitter Ã¢â‚¬â€ thought visualization telemetry
         from pilot.reasoning.events import ReasoningEmitter
 
         self._reasoning = ReasoningEmitter()
@@ -207,7 +207,7 @@ class PilotServer:
 
         self._decomposer = TaskDecomposer(model_router)
 
-        # Simulation Sandbox — pre-execution risk analysis
+        # Simulation Sandbox Ã¢â‚¬â€ pre-execution risk analysis
         from pilot.agents.sandbox import SimulationSandbox
 
         self._sandbox = SimulationSandbox()
@@ -225,19 +225,19 @@ class PilotServer:
         plugin_count = self._plugin_registry.discover()
         logger.info("Plugins loaded: %d", plugin_count)
 
-        # Subconscious Agent — long-term memory consolidation (lazy start)
+        # Subconscious Agent Ã¢â‚¬â€ long-term memory consolidation (lazy start)
         try:
             from pilot.agents.subconscious import SubconsciousAgent
 
             self._subconscious = SubconsciousAgent(model_router)
             await self._subconscious.initialize(str(DB_FILE))
-            # NOTE: Don't auto-start the consolidation loop — it can block
+            # NOTE: Don't auto-start the consolidation loop Ã¢â‚¬â€ it can block
             # the event loop with LLM calls. Users start it via API.
             logger.info("SubconsciousAgent initialized (idle, use persona_consolidate to trigger)")
         except Exception:
             logger.warning("SubconsciousAgent init failed (non-critical)", exc_info=True)
 
-        # Cognitive Hub — unified TRIBE v2 cognitive features
+        # Cognitive Hub Ã¢â‚¬â€ unified TRIBE v2 cognitive features
         try:
             from pilot.changelog import announce_new_features, mark_version_seen
             from pilot.cognitive.hub import CognitiveHub
@@ -256,7 +256,7 @@ class PilotServer:
             logger.warning("CognitiveHub init failed (non-critical)", exc_info=True)
             self._new_features_announcement = None
 
-        # Screen Vision Agent — continuous screen awareness (AUTO-START for JARVIS mode)
+        # Screen Vision Agent Ã¢â‚¬â€ continuous screen awareness (AUTO-START for JARVIS mode)
         try:
             from pilot.agents.screen_vision import ScreenVisionAgent
 
@@ -268,7 +268,7 @@ class PilotServer:
         except Exception:
             logger.warning("ScreenVisionAgent init failed (non-critical)", exc_info=True)
 
-        # ── Cognitive Intelligence (TRIBE v2) ──
+        # Ã¢â€â‚¬Ã¢â€â‚¬ Cognitive Intelligence (TRIBE v2) Ã¢â€â‚¬Ã¢â€â‚¬
         try:
             from pilot.cognitive.attention_scorer import AttentionAwareUI
             from pilot.cognitive.intent_predictor import IntentPredictor
@@ -300,7 +300,7 @@ class PilotServer:
 
         self._notification_buffer: list[tuple[str, dict[str, Any]]] = []
 
-        # ── Autonomous Executor (JARVIS fire-and-forget) ──
+        # Ã¢â€â‚¬Ã¢â€â‚¬ Autonomous Executor (JARVIS fire-and-forget) Ã¢â€â‚¬Ã¢â€â‚¬
         try:
             from pilot.agents.autonomous import AutonomousExecutor
 
@@ -316,7 +316,7 @@ class PilotServer:
         except Exception:
             logger.warning("AutonomousExecutor init failed (non-critical)", exc_info=True)
 
-        # ── Proactive Suggestion Engine (JARVIS anticipation) ──
+        # Ã¢â€â‚¬Ã¢â€â‚¬ Proactive Suggestion Engine (JARVIS anticipation) Ã¢â€â‚¬Ã¢â€â‚¬
         try:
             from pilot.agents.proactive import ProactiveSuggestionEngine
 
@@ -416,7 +416,7 @@ class PilotServer:
             method: The notification method name.
             params: The notification parameters.
         """
-        # ── Feature 5: Attention-Optimized Notification Timing ──
+        # Ã¢â€â‚¬Ã¢â€â‚¬ Feature 5: Attention-Optimized Notification Timing Ã¢â€â‚¬Ã¢â€â‚¬
         if getattr(self, "_attention_ui", None) and self._attention_ui.enabled:
             try:
                 content = params if isinstance(params, dict) else {"data": params}
@@ -563,7 +563,7 @@ class PilotServer:
         if emit:
             emit.reset()
 
-        # ── Stage: User Input ──
+        # Ã¢â€â‚¬Ã¢â€â‚¬ Stage: User Input Ã¢â€â‚¬Ã¢â€â‚¬
         input_phase = ""
         await ws.send(_notification("status", {"phase": "receiving input"}))
         if emit:
@@ -572,7 +572,7 @@ class PilotServer:
                 "user_input", "user_input_received", {"length": len(user_input)}, parent_id=input_phase
             )
 
-        # ── Stage: Memory Recall ──
+        # Ã¢â€â‚¬Ã¢â€â‚¬ Stage: Memory Recall Ã¢â€â‚¬Ã¢â€â‚¬
         mem_phase = ""
         await ws.send(_notification("status", {"phase": "recalling memory"}))
         if emit:
@@ -588,7 +588,7 @@ class PilotServer:
                 "memory_recall", MEMORY_CONTEXT_LOADED, {"has_context": bool(improvement_ctx)}, parent_id=mem_phase
             )
 
-        # ── Stage: Agent Routing ──
+        # Ã¢â€â‚¬Ã¢â€â‚¬ Stage: Agent Routing Ã¢â€â‚¬Ã¢â€â‚¬
         route_phase = ""
         await ws.send(_notification("status", {"phase": "routing agents"}))
         if emit:
@@ -613,7 +613,7 @@ class PilotServer:
         last_explanation = ""
 
         for attempt in range(1 + self.MAX_RETRIES):
-            # ── Stage: Planning ──
+            # Ã¢â€â‚¬Ã¢â€â‚¬ Stage: Planning Ã¢â€â‚¬Ã¢â€â‚¬
             plan_phase = ""
             if emit:
                 event_name = PLANNER_STARTED if attempt == 0 else PLANNER_REPLANNING
@@ -682,7 +682,7 @@ class PilotServer:
                 )
             )
 
-            # ── Stage: Destructive Critic Review (Tier 4 plans only) ──
+            # Ã¢â€â‚¬Ã¢â€â‚¬ Stage: Destructive Critic Review (Tier 4 plans only) Ã¢â€â‚¬Ã¢â€â‚¬
             # For any plan that contains ROOT_CRITICAL (Tier 4) actions, a
             # second independent agent reviews the plan for safety before the
             # user confirmation gate fires.  A BLOCK verdict aborts execution
@@ -702,7 +702,7 @@ class PilotServer:
                     )
                     await emit.thought(
                         "critic_review",
-                        "Tier 4 actions detected — running independent safety review...",
+                        "Tier 4 actions detected Ã¢â‚¬â€ running independent safety review...",
                         parent_id=critic_phase,
                     )
 
@@ -712,7 +712,7 @@ class PilotServer:
                 await ws.send(_notification("critic_verdict", verdict.to_dict()))
 
                 if verdict.is_blocked:
-                    # Hard block — do not proceed to confirmation or execution
+                    # Hard block Ã¢â‚¬â€ do not proceed to confirmation or execution
                     if emit:
                         await emit.phase_error(
                             "critic_review",
@@ -727,7 +727,7 @@ class PilotServer:
                         "explanation": plan.explanation,
                     }
 
-                # WARN or APPROVE — continue, but surface issues if any
+                # WARN or APPROVE Ã¢â‚¬â€ continue, but surface issues if any
                 if emit:
                     event_name = CRITIC_REVIEW_WARNED if verdict.has_warnings else CRITIC_REVIEW_APPROVED
                     await emit.phase_complete(
@@ -737,14 +737,16 @@ class PilotServer:
                         parent_id=critic_phase,
                     )
 
-            # ── Stage: Confirmation Gate ──
+            # Ã¢â€â‚¬Ã¢â€â‚¬ Stage: Confirmation Gate Ã¢â€â‚¬Ã¢â€â‚¬
             needs_confirm = any(a.requires_confirmation for a in plan.actions) and not dry_run
             if needs_confirm:
                 confirm_phase = ""
                 if emit:
                     confirm_phase = await emit.phase_start("confirmation", CONFIRMATION_REQUIRED, {"plan_id": plan_id})
                     await emit.thought(
-                        "confirmation", "Dangerous action detected — awaiting user approval...", parent_id=confirm_phase
+                        "confirmation",
+                        "Dangerous action detected Ã¢â‚¬â€ awaiting user approval...",
+                        parent_id=confirm_phase,
                     )
 
                 confirmed = await self._wait_for_confirmation(plan_id, plan, ws)
@@ -772,7 +774,7 @@ class PilotServer:
                         "confirmation", "confirmation_skipped", {"reason": "No dangerous actions"}, parent_id=skip_phase
                     )
 
-            # ── Stage: Execution ──
+            # Ã¢â€â‚¬Ã¢â€â‚¬ Stage: Execution Ã¢â€â‚¬Ã¢â€â‚¬
             exec_phase = ""
             if emit:
                 exec_phase = await emit.phase_start("execution", EXECUTOR_STARTED, {"action_count": len(plan.actions)})
@@ -848,7 +850,7 @@ class PilotServer:
                     parent_id=exec_phase,
                 )
 
-            # ── Stage: Verification ──
+            # Ã¢â€â‚¬Ã¢â€â‚¬ Stage: Verification Ã¢â€â‚¬Ã¢â€â‚¬
             verify_phase = ""
             if emit:
                 verify_phase = await emit.phase_start("verification", VERIFICATION_STARTED)
@@ -879,7 +881,7 @@ class PilotServer:
                         parent_id=verify_phase,
                     )
 
-                # ── Stage: Reflection ──
+                # Ã¢â€â‚¬Ã¢â€â‚¬ Stage: Reflection Ã¢â€â‚¬Ã¢â€â‚¬
                 if emit:
                     refl_phase = await emit.phase_start("reflection", REFLECTION_STARTED)
                     await emit.thought(
@@ -891,7 +893,7 @@ class PilotServer:
                         "reflection", REFLECTION_COMPLETE, {"retry_count": attempt}, parent_id=refl_phase
                     )
 
-                # ── Stage: Memory Update ──
+                # Ã¢â€â‚¬Ã¢â€â‚¬ Stage: Memory Update Ã¢â€â‚¬Ã¢â€â‚¬
                 if emit:
                     mem_store_phase = await emit.phase_start("memory_update", MEMORY_STORE_STARTED)
                     await emit.thought(
@@ -930,7 +932,7 @@ class PilotServer:
                     "agent_routing": self._multi_agent.get_routing_summary(user_input),
                 }
 
-            # Execution failed — build error context for retry
+            # Execution failed Ã¢â‚¬â€ build error context for retry
             if emit:
                 await emit.phase_error(
                     "verification", VERIFICATION_FAILED, "; ".join(verification.details[:3]), parent_id=verify_phase
@@ -945,7 +947,7 @@ class PilotServer:
                     _notification(
                         "status",
                         {
-                            "phase": "retrying — previous attempt failed",
+                            "phase": "retrying Ã¢â‚¬â€ previous attempt failed",
                         },
                     )
                 )
@@ -956,7 +958,7 @@ class PilotServer:
             else:
                 break
 
-        # ── Final memory save on partial failure ──
+        # Ã¢â€â‚¬Ã¢â€â‚¬ Final memory save on partial failure Ã¢â€â‚¬Ã¢â€â‚¬
         if emit:
             mem_final = await emit.phase_start("memory_update", MEMORY_STORE_STARTED)
             await emit.phase_complete("memory_update", MEMORY_STORE_COMPLETE, {"partial": True}, parent_id=mem_final)
@@ -1678,7 +1680,7 @@ class PilotServer:
             logger.error("Failed to uninstall plugin %s: %s", plugin_name, e)
             return {"error": str(e)}
 
-    # ── Subconscious Agent Handlers ──
+    # Ã¢â€â‚¬Ã¢â€â‚¬ Subconscious Agent Handlers Ã¢â€â‚¬Ã¢â€â‚¬
 
     async def _handle_persona_rules(self, params: dict, ws: ServerConnection) -> dict:
         """Return all persona rules.
@@ -1744,7 +1746,7 @@ class PilotServer:
             return await self._subconscious.get_stats()
         return {"error": "Subconscious agent not initialized"}
 
-    # ── Screen Vision Handlers ──
+    # Ã¢â€â‚¬Ã¢â€â‚¬ Screen Vision Handlers Ã¢â€â‚¬Ã¢â€â‚¬
 
     async def _handle_screen_context(self, params: dict, ws: ServerConnection) -> dict:
         """Return the current screen context summary.
@@ -1886,7 +1888,7 @@ class PilotServer:
             self._tribe_engine.unload_model()
         logger.info("Pilot daemon stopped")
 
-    # ── Budget Tracking Handlers ──
+    # Ã¢â€â‚¬Ã¢â€â‚¬ Budget Tracking Handlers Ã¢â€â‚¬Ã¢â€â‚¬
 
     async def _handle_budget_stats(self, params: dict, ws: ServerConnection) -> dict:
         """Return current-month token usage and cost summary."""
@@ -1901,7 +1903,7 @@ class PilotServer:
         await self._budget_tracker.reset_current_month()
         return {"status": "ok"}
 
-    # ── Cognitive Intelligence (TRIBE v2) Handlers ──
+    # Ã¢â€â‚¬Ã¢â€â‚¬ Cognitive Intelligence (TRIBE v2) Handlers Ã¢â€â‚¬Ã¢â€â‚¬
 
     async def _handle_cognitive_stats(self, params: dict, ws: ServerConnection) -> dict:
         """Get stats for all cognitive subsystems."""
@@ -1959,7 +1961,7 @@ class PilotServer:
             "available": self._tribe_engine.is_available,
         }
 
-    # ── Voice Listener (JARVIS Mode) Handlers ──
+    # Ã¢â€â‚¬Ã¢â€â‚¬ Voice Listener (JARVIS Mode) Handlers Ã¢â€â‚¬Ã¢â€â‚¬
 
     async def _voice_command_dispatch(self, command_text: str) -> None:
         """Called by ContinuousVoiceListener when a voice command is recognized.
@@ -2099,7 +2101,7 @@ class PilotServer:
             return {"running": False, "message": "Voice listener not initialized"}
         return self._voice_listener.get_stats()
 
-    # ── Autonomous Executor Handlers ──
+    # Ã¢â€â‚¬Ã¢â€â‚¬ Autonomous Executor Handlers Ã¢â€â‚¬Ã¢â€â‚¬
 
     async def _handle_autonomous_submit(self, params: dict, ws: ServerConnection) -> dict:
         """Submit a task for autonomous background execution.
@@ -2172,7 +2174,7 @@ class PilotServer:
             return {"error": f"Job not found: {job_id}"}
         return job.to_dict()
 
-    # ── Proactive Suggestions Handlers ──
+    # Ã¢â€â‚¬Ã¢â€â‚¬ Proactive Suggestions Handlers Ã¢â€â‚¬Ã¢â€â‚¬
 
     async def _handle_proactive_start(self, params: dict, ws: ServerConnection) -> dict:
         """Start the proactive suggestion engine.
@@ -2219,7 +2221,7 @@ class PilotServer:
         return self._proactive.get_stats()
 
     async def _handle_proactive_accept(self, params: dict, ws: ServerConnection) -> dict:
-        """Accept a proactive suggestion — execute the suggested action.
+        """Accept a proactive suggestion Ã¢â‚¬â€ execute the suggested action.
 
         Args:
             params: JSON-RPC parameters with suggestion_id.


### PR DESCRIPTION
## Summary

Implements the two-agent safety handshake for Tier 4 (ROOT_CRITICAL) destructive tasks.

For any plan containing ROOT_CRITICAL (Tier 4) actions, a second independent
DestructiveCriticAgent now reviews the plan *before* the user confirmation gate fires.
A BLOCK verdict aborts the pipeline immediately; a WARN verdict surfaces issues
alongside the normal confirmation prompt.

## Changes

### daemon/pilot/agents/destructive_critic.py (new)
- CriticVerdict dataclass — verdict (APPROVE/WARN/BLOCK), risk_score, issues,
  flagged_actions, recommendation
- DestructiveCriticAgent.review() — stateless LLM-backed agent with a focused
  safety prompt covering: intent alignment, blast radius, reversibility,
  privilege creep, and injection risk
- Fail-safe: LLM errors fall back to WARN instead of crashing or silently approving

### daemon/pilot/reasoning/events.py
- Added CRITIC_REVIEW to ReasoningStage enum
- Added CRITIC_REVIEW_STARTED / APPROVED / WARNED / BLOCKED event constants

### daemon/pilot/server.py
- _destructive_critic instantiated alongside planner/executor/verifier
- New critic review stage in _handle_execute() between plan_preview and
  confirmation gate — only fires for Tier 4 plans, skipped in dry-run mode
- BLOCK → returns {"status": "blocked_by_critic"} immediately
- WARN/APPROVE → continues to confirmation gate, verdict broadcast via
  critic_verdict WebSocket notification

## PR Checklist
- [x] Code follows the style guidelines (ruff check + ruff format — all clean)
- [x] Self-reviewed the code
- [x] Added comments for complex logic
- [x] No API keys or secrets committed
- [x] Tested on Windows