### PR TITLE
feat: vacuum SQLite database on daemon shutdown

### DIFF
--- a/daemon/pilot/server.py
+++ b/daemon/pilot/server.py
@@ -15,6 +15,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
+import aiosqlite
 import websockets
 from websockets.asyncio.server import Server, ServerConnection
 
@@ -1814,6 +1815,24 @@ class PilotServer:
             await self._memory.close()
         if self._budget_tracker:
             await self._budget_tracker.close()
+
+        if self._prompt_improver:
+            await self._prompt_improver.close()
+
+        if self._subconscious:
+            await self._subconscious.close()
+
+        try:
+            async with aiosqlite.connect(str(DB_FILE)) as db:
+                await db.execute("PRAGMA wal_checkpoint(FULL)")
+                await db.execute("VACUUM")
+                await db.commit()
+
+            logger.info("SQLite database vacuum completed successfully")
+
+        except Exception:
+            logger.exception("Failed to vacuum SQLite database during shutdown")
+
         # Unload TRIBE v2 model
         if self._tribe_engine and self._tribe_engine.is_loaded:
             self._tribe_engine.unload_model()


### PR DESCRIPTION
## Summary

This PR adds SQLite database cleanup during daemon shutdown by running a WAL checkpoint and VACUUM operation after active database connections are closed.

While exploring the issue, I traced the daemon shutdown flow and checked how SQLite is currently used across the memory store, caching system, and agent-related modules. Based on that flow, the cleanup logic was added centrally inside `PilotServer.stop()` so it runs safely during shutdown without affecting active database operations.

## Changes Made

* Added centralized SQLite cleanup during daemon shutdown
* Added `PRAGMA wal_checkpoint(FULL)` before running `VACUUM`
* Added async-safe `VACUUM` execution after SQLite-backed components are closed
* Ensured `PromptImprover` and `SubconsciousAgent` connections are closed before database maintenance
* Added exception-safe logging to avoid interrupting the shutdown process if cleanup fails

## Why

Since the project now relies on SQLite for memory storage and caching, the database can gradually grow and become fragmented over time. Running a vacuum operation during shutdown helps keep the database cleaner and more efficient by reclaiming unused space and checkpointing WAL data properly.

## Validation

* Reviewed the daemon shutdown lifecycle and SQLite usage across related modules
* Verified cleanup flow for SQLite-backed components
* Successfully passed:

  ```bash
  python -m compileall daemon
  ```
* Performed runtime startup and dependency validation using a Python 3.11 virtual environment

## Files Changed

* `daemon/pilot/server.py`
