### PR TITLE
Security: Strict Allowlist for Sandbox CLI Commands #127

### DIFF
--- a/daemon/pilot/agents/executor.py
+++ b/daemon/pilot/agents/executor.py
@@ -78,7 +78,9 @@ class Executor:
         self._permissions = permissions
         self._audit = audit
         self._snapshot_mgr = SnapshotManager(config)
-        self._simulation_sandbox = SimulationSandbox()
+        self._simulation_sandbox = SimulationSandbox(
+            allowed_commands=config.restrictions.sandbox_allowed_commands
+        )
         self._last_output: str = ""  # For output chaining between steps
         self._largest_output: str = ""  # Largest output from any step in the pipeline
 

--- a/daemon/pilot/agents/executor.py
+++ b/daemon/pilot/agents/executor.py
@@ -78,9 +78,7 @@ class Executor:
         self._permissions = permissions
         self._audit = audit
         self._snapshot_mgr = SnapshotManager(config)
-        self._simulation_sandbox = SimulationSandbox(
-            allowed_commands=config.restrictions.sandbox_allowed_commands
-        )
+        self._simulation_sandbox = SimulationSandbox(allowed_commands=config.restrictions.sandbox_allowed_commands)
         self._last_output: str = ""  # For output chaining between steps
         self._largest_output: str = ""  # Largest output from any step in the pipeline
 

--- a/daemon/pilot/agents/sandbox.py
+++ b/daemon/pilot/agents/sandbox.py
@@ -156,6 +156,11 @@ DANGEROUS_SHELL_PATTERNS = [
 class SimulationSandbox:
     """Pre-execution impact analysis and risk assessment."""
 
+    def __init__(self, allowed_commands: list[str] | None = None):
+        self.allowed_commands = allowed_commands or [
+            "echo", "ls", "dir", "cat", "type", "ping", "whoami", "pwd", "grep", "find"
+        ]
+
     def simulate(self, plan: Any) -> SimulationReport:
         """Analyze a plan and produce an impact report without executing anything."""
         report = SimulationReport(plan_id=getattr(plan, "plan_id", "unknown"))
@@ -219,10 +224,16 @@ class SimulationSandbox:
         if action_type in HIGH_RISK_ACTIONS:
             # Check for especially dangerous shell patterns
             if action_type in ("shell_command", "shell_script"):
-                params = getattr(action, "params", None)
+                params = getattr(action, "parameters", getattr(action, "params", None))
                 command = ""
                 if params:
                     command = getattr(params, "command", "") or getattr(params, "script", "") or ""
+                
+                # Verify against the sandbox allowlist
+                base_cmd = command.strip().split()[0].lower() if command.strip() else ""
+                if base_cmd and base_cmd not in self.allowed_commands:
+                    return RiskLevel.CRITICAL
+                
                 if any(pattern in command.lower() for pattern in DANGEROUS_SHELL_PATTERNS):
                     return RiskLevel.CRITICAL
             return RiskLevel.HIGH

--- a/daemon/pilot/agents/sandbox.py
+++ b/daemon/pilot/agents/sandbox.py
@@ -158,7 +158,16 @@ class SimulationSandbox:
 
     def __init__(self, allowed_commands: list[str] | None = None):
         self.allowed_commands = allowed_commands or [
-            "echo", "ls", "dir", "cat", "type", "ping", "whoami", "pwd", "grep", "find"
+            "echo",
+            "ls",
+            "dir",
+            "cat",
+            "type",
+            "ping",
+            "whoami",
+            "pwd",
+            "grep",
+            "find",
         ]
 
     def simulate(self, plan: Any) -> SimulationReport:

--- a/daemon/pilot/agents/sandbox.py
+++ b/daemon/pilot/agents/sandbox.py
@@ -228,12 +228,12 @@ class SimulationSandbox:
                 command = ""
                 if params:
                     command = getattr(params, "command", "") or getattr(params, "script", "") or ""
-                
+
                 # Verify against the sandbox allowlist
                 base_cmd = command.strip().split()[0].lower() if command.strip() else ""
                 if base_cmd and base_cmd not in self.allowed_commands:
                     return RiskLevel.CRITICAL
-                
+
                 if any(pattern in command.lower() for pattern in DANGEROUS_SHELL_PATTERNS):
                     return RiskLevel.CRITICAL
             return RiskLevel.HIGH

--- a/daemon/pilot/config.py
+++ b/daemon/pilot/config.py
@@ -92,6 +92,9 @@ class Restrictions:
     protected_folders: list[str] = field(default_factory=list)
     protected_packages: list[str] = field(default_factory=list)
     blocked_commands: list[str] = field(default_factory=list)
+    sandbox_allowed_commands: list[str] = field(
+        default_factory=lambda: ["echo", "ls", "dir", "cat", "type", "ping", "whoami", "pwd", "grep", "find"]
+    )
 
 
 @dataclass
@@ -242,6 +245,9 @@ def _parse_restrictions(raw: dict[str, Any]) -> Restrictions:
         protected_folders=raw.get("protected_folders", []),
         protected_packages=raw.get("protected_packages", []),
         blocked_commands=raw.get("blocked_commands", []),
+        sandbox_allowed_commands=raw.get("sandbox_allowed_commands", [
+            "echo", "ls", "dir", "cat", "type", "ping", "whoami", "pwd", "grep", "find"
+        ]),
     )
 
 

--- a/daemon/pilot/config.py
+++ b/daemon/pilot/config.py
@@ -245,9 +245,9 @@ def _parse_restrictions(raw: dict[str, Any]) -> Restrictions:
         protected_folders=raw.get("protected_folders", []),
         protected_packages=raw.get("protected_packages", []),
         blocked_commands=raw.get("blocked_commands", []),
-        sandbox_allowed_commands=raw.get("sandbox_allowed_commands", [
-            "echo", "ls", "dir", "cat", "type", "ping", "whoami", "pwd", "grep", "find"
-        ]),
+        sandbox_allowed_commands=raw.get(
+            "sandbox_allowed_commands", ["echo", "ls", "dir", "cat", "type", "ping", "whoami", "pwd", "grep", "find"]
+        ),
     )
 
 

--- a/daemon/pilot/security/sandbox.py
+++ b/daemon/pilot/security/sandbox.py
@@ -43,6 +43,7 @@ class SandboxEnvironment:
 
         if allowed_commands is None:
             from pilot.config import PilotConfig
+
             config = PilotConfig.load()
             self.allowed_commands = config.restrictions.sandbox_allowed_commands
         else:

--- a/daemon/pilot/security/sandbox.py
+++ b/daemon/pilot/security/sandbox.py
@@ -37,9 +37,16 @@ class SandboxPreview:
 class SandboxEnvironment:
     """Manages dry-run simulations and temporary workspaces."""
 
-    def __init__(self, workspace_dir: str | None = None):
+    def __init__(self, workspace_dir: str | None = None, allowed_commands: list[str] | None = None):
         self._workspace = workspace_dir or os.path.join(tempfile.gettempdir(), "pilot_sandbox")
         os.makedirs(self._workspace, exist_ok=True)
+        
+        if allowed_commands is None:
+            from pilot.config import PilotConfig
+            config = PilotConfig.load()
+            self.allowed_commands = config.restrictions.sandbox_allowed_commands
+        else:
+            self.allowed_commands = allowed_commands
 
     async def preview_file_delete(self, target_path: str, recursive: bool = False) -> SandboxPreview:
         """Simulate deleting a file or directory."""
@@ -95,6 +102,12 @@ class SandboxEnvironment:
             risk_level="medium",
             warnings=[],
         )
+
+        base_cmd = command.strip().split()[0].lower() if command.strip() else ""
+        if base_cmd and base_cmd not in self.allowed_commands:
+            preview.risk_level = "critical"
+            preview.warnings.append(f"Command '{base_cmd}' is not in the sandbox allowlist.")
+            return preview
 
         # Basic dumb heuristics
         if any(w in command_lower for w in ["rm ", "del ", "format ", "diskpart"]):

--- a/daemon/pilot/security/sandbox.py
+++ b/daemon/pilot/security/sandbox.py
@@ -40,7 +40,7 @@ class SandboxEnvironment:
     def __init__(self, workspace_dir: str | None = None, allowed_commands: list[str] | None = None):
         self._workspace = workspace_dir or os.path.join(tempfile.gettempdir(), "pilot_sandbox")
         os.makedirs(self._workspace, exist_ok=True)
-        
+
         if allowed_commands is None:
             from pilot.config import PilotConfig
             config = PilotConfig.load()


### PR DESCRIPTION
Resolves #32

This PR introduces a configurable allowlist for the Simulation Sandbox to prevent arbitrary execution vulnerabilities.

- **Config**: Added `sandbox_allowed_commands` to `Restrictions` in `pilot/config.py` with a default safe list.
- **SimulationSandbox**: Updated `_assess_action_risk` to validate the base executable of shell commands/scripts against the allowlist, flagging unpermitted actions as `CRITICAL`.
- **SandboxEnvironment**: Updated `preview_shell_command` to also enforce the allowlist and immediately return a `CRITICAL` risk with a clear warning.
- **Executor**: Wired the `PilotConfig` restrictions into the `SimulationSandbox` instantiation.

**Testing**: Ran `pytest tests`, zero failures.
