### PR TITLE
Add configurable screen vision capture interval

### DIFF
--- a/daemon/pilot/agents/screen_vision.py
+++ b/daemon/pilot/agents/screen_vision.py
@@ -38,6 +38,9 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger("pilot.agents.screen_vision")
 
+MIN_CAPTURE_INTERVAL_SECONDS = 0.5
+MAX_CAPTURE_INTERVAL_SECONDS = 60.0
+
 
 @dataclass
 class ScreenState:
@@ -130,19 +133,28 @@ class ScreenVisionAgent:
         self._context = ScreenContext()
         self._task: asyncio.Task[None] | None = None
         self._running = False
-        self._interval_seconds: float = 2.0
+        self._interval_seconds: float = 3.0
         self._last_hash: str = ""
         self._screenshot_dir = Path.home() / ".heliox" / "screenshots"
         self._enable_llm_describe = False  # Disabled by default (expensive)
 
-    async def start(self, interval_seconds: float = 2.0, enable_describe: bool = False) -> None:
+    def set_interval(self, interval_seconds: float) -> None:
+        """Update the capture cadence while keeping it inside safe bounds."""
+        self._interval_seconds = max(
+            MIN_CAPTURE_INTERVAL_SECONDS,
+            min(float(interval_seconds), MAX_CAPTURE_INTERVAL_SECONDS),
+        )
+
+    async def start(self, interval_seconds: float = 3.0, enable_describe: bool = False) -> None:
         """Start the screen monitoring loop."""
-        self._interval_seconds = interval_seconds
+        self.set_interval(interval_seconds)
         self._enable_llm_describe = enable_describe
+        if self._task and not self._task.done():
+            await self.stop()
         self._running = True
         self._screenshot_dir.mkdir(parents=True, exist_ok=True)
         self._task = asyncio.create_task(self._capture_loop())
-        logger.info("Screen vision started (every %.1fs, describe=%s)", interval_seconds, enable_describe)
+        logger.info("Screen vision started (every %.1fs, describe=%s)", self._interval_seconds, enable_describe)
 
     async def stop(self) -> None:
         """Stop the monitoring loop."""

--- a/daemon/pilot/config.py
+++ b/daemon/pilot/config.py
@@ -88,6 +88,11 @@ class VoiceConfig:
 
 
 @dataclass
+class ScreenVisionConfig:
+    capture_interval_seconds: float = 3.0
+
+
+@dataclass
 class Restrictions:
     protected_folders: list[str] = field(default_factory=list)
     protected_packages: list[str] = field(default_factory=list)
@@ -103,6 +108,7 @@ class PilotConfig:
     security: SecurityConfig = field(default_factory=SecurityConfig)
     server: ServerConfig = field(default_factory=ServerConfig)
     voice: VoiceConfig = field(default_factory=VoiceConfig)
+    screen_vision: ScreenVisionConfig = field(default_factory=ScreenVisionConfig)
     restrictions: Restrictions = field(default_factory=Restrictions)
     first_run_complete: bool = False
 
@@ -188,6 +194,9 @@ def _validate_config_types(raw: dict) -> None:
             "language": str,
             "whisper_model": str,
         },
+        "screen_vision": {
+            "capture_interval_seconds": (int, float),
+        },
     }
 
     for section, expected_keys in expected_types.items():
@@ -204,11 +213,17 @@ def _validate_config_types(raw: dict) -> None:
                 if not isinstance(actual_value, expected_type):
                     error_msg = (
                         f"Invalid type: '{section}.{actual_key}' must be "
-                        f"{expected_type.__name__}, got "
+                        f"{_format_type_name(expected_type)}, got "
                         f"{type(actual_value).__name__}."
                     )
                     logger.error(error_msg)
                     raise ValueError(error_msg)
+
+
+def _format_type_name(expected_type: type | tuple[type, ...]) -> str:
+    if isinstance(expected_type, tuple):
+        return " or ".join(t.__name__ for t in expected_type)
+    return expected_type.__name__
 
 
 def _merge_config(config: PilotConfig, raw: dict[str, Any]) -> PilotConfig:
@@ -231,6 +246,11 @@ def _merge_config(config: PilotConfig, raw: dict[str, Any]) -> PilotConfig:
         for k, v in raw["voice"].items():
             if hasattr(config.voice, k):
                 setattr(config.voice, k, v)
+
+    if "screen_vision" in raw:
+        for k, v in raw["screen_vision"].items():
+            if hasattr(config.screen_vision, k):
+                setattr(config.screen_vision, k, float(v))
 
     config.first_run_complete = raw.get(
         "first_run_complete",

--- a/daemon/pilot/server.py
+++ b/daemon/pilot/server.py
@@ -258,8 +258,9 @@ class PilotServer:
             from pilot.agents.screen_vision import ScreenVisionAgent
 
             self._screen_vision = ScreenVisionAgent(model_router)
-            asyncio.create_task(self._screen_vision.start(interval_seconds=3.0, enable_describe=False))
-            logger.info("ScreenVisionAgent auto-started (every 3s, JARVIS mode)")
+            interval_seconds = self.config.screen_vision.capture_interval_seconds
+            asyncio.create_task(self._screen_vision.start(interval_seconds=interval_seconds, enable_describe=False))
+            logger.info("ScreenVisionAgent auto-started (every %.1fs, JARVIS mode)", interval_seconds)
         except Exception:
             logger.warning("ScreenVisionAgent init failed (non-critical)", exc_info=True)
 
@@ -1099,8 +1100,13 @@ class PilotServer:
             return {"status": "error", "message": f"Unknown config section: {section}"}
         for k, v in values.items():
             if hasattr(target, k):
+                if section == "screen_vision" and k == "capture_interval_seconds":
+                    v = float(v)
                 setattr(target, k, v)
         self.config.save()
+
+        if section == "screen_vision" and "capture_interval_seconds" in values and self._screen_vision:
+            self._screen_vision.set_interval(self.config.screen_vision.capture_interval_seconds)
 
         if section == "model" and ("cloud_provider" in values or "provider" in values):
             if self.config.model.cloud_provider:
@@ -1840,7 +1846,7 @@ class PilotServer:
         enabled = params.get("enabled", True)
         if self._screen_vision:
             if enabled:
-                interval = params.get("interval_seconds", 2.0)
+                interval = params.get("interval_seconds", self.config.screen_vision.capture_interval_seconds)
                 describe = params.get("enable_describe", False)
                 await self._screen_vision.start(interval, describe)
             else:

--- a/daemon/tests/test_ipc_integration.py
+++ b/daemon/tests/test_ipc_integration.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 import websockets
 
-from pilot.config import PilotConfig
+from pilot.config import PilotConfig, _merge_config
 from pilot.server import PilotServer
 
 
@@ -30,6 +30,8 @@ async def daemon_server(server_port, tmp_path, monkeypatch):
     state_dir.mkdir()
 
     monkeypatch.setattr("pilot.config.CONFIG_DIR", config_dir)
+    monkeypatch.setattr("pilot.config.CONFIG_FILE", config_dir / "config.toml")
+    monkeypatch.setattr("pilot.config.RESTRICTIONS_FILE", config_dir / "restrictions.toml")
     monkeypatch.setattr("pilot.config.DATA_DIR", data_dir)
     monkeypatch.setattr("pilot.config.STATE_DIR", state_dir)
     monkeypatch.setattr("pilot.config.DB_FILE", data_dir / "pilot.db")
@@ -114,7 +116,56 @@ async def test_ipc_get_config(daemon_server):
         result = response["result"]
         assert "model" in result
         assert "security" in result
+        assert result["screen_vision"]["capture_interval_seconds"] == 3.0
         assert "first_run_complete" in result
+
+
+@pytest.mark.asyncio
+async def test_ipc_update_screen_vision_interval(daemon_server):
+    """Verify screen vision interval updates round-trip through config IPC."""
+    async with websockets.connect(daemon_server) as ws:
+        request = {
+            "jsonrpc": "2.0",
+            "method": "update_config",
+            "params": {
+                "section": "screen_vision",
+                "values": {"capture_interval_seconds": 7.5},
+            },
+            "id": "screen-cfg-1",
+        }
+        await ws.send(json.dumps(request))
+
+        response = json.loads(await ws.recv())
+        assert response["result"]["status"] == "ok"
+
+        await ws.send(json.dumps({"jsonrpc": "2.0", "method": "get_config", "id": "screen-cfg-2"}))
+        response = json.loads(await ws.recv())
+        assert response["result"]["screen_vision"]["capture_interval_seconds"] == 7.5
+
+
+@pytest.mark.asyncio
+async def test_screen_vision_toggle_uses_configured_interval_by_default():
+    """Verify toggling screen vision without params uses the persisted interval."""
+    config = PilotConfig()
+    config.screen_vision.capture_interval_seconds = 8.5
+    server = PilotServer(config)
+    screen_vision = MagicMock()
+    screen_vision.start = AsyncMock()
+    server._screen_vision = screen_vision
+
+    result = await server._handle_screen_vision_toggle({"enabled": True}, MagicMock())
+
+    assert result == {"status": "ok", "enabled": True}
+    screen_vision.start.assert_awaited_once_with(8.5, False)
+
+
+def test_screen_vision_config_merges_numeric_interval():
+    config = PilotConfig()
+    raw = {"screen_vision": {"capture_interval_seconds": 12}}
+
+    merged = _merge_config(config, raw)
+
+    assert merged.screen_vision.capture_interval_seconds == 12.0
 
 
 @pytest.mark.asyncio

--- a/tauri-app/ui/src/lib/components/SettingsPanel.svelte
+++ b/tauri-app/ui/src/lib/components/SettingsPanel.svelte
@@ -43,6 +43,13 @@
     settings.updateSection("security", { snapshot_retention_count: val });
   }
 
+  function updateScreenVisionInterval(e: Event) {
+    const rawValue = Number((e.target as HTMLInputElement).value);
+    if (!Number.isFinite(rawValue)) return;
+    const capture_interval_seconds = Math.min(60, Math.max(0.5, rawValue));
+    settings.updateSection("screen_vision", { capture_interval_seconds });
+  }
+
   function updateOllamaModel(e: Event) {
     const val = (e.target as HTMLInputElement).value;
     settings.updateSection("model", { ollama_model: val });
@@ -177,6 +184,26 @@
 
     <div class="setting-row">
       <button class="btn-save" onclick={() => session.resetUsage()}> Reset Session Usage </button>
+    </div>
+  </section>
+
+  <section class="settings-group">
+    <h3>Screen Vision</h3>
+
+    <div class="setting-row">
+      <div class="setting-info">
+        <span class="setting-label">Capture Interval</span>
+        <span class="setting-desc">Seconds between screen awareness captures</span>
+      </div>
+      <input
+        type="number"
+        class="input-sm"
+        value={$settings.screen_vision?.capture_interval_seconds ?? 3}
+        onchange={updateScreenVisionInterval}
+        min="0.5"
+        max="60"
+        step="0.5"
+      />
     </div>
   </section>
 

--- a/tauri-app/ui/src/lib/stores/settings.ts
+++ b/tauri-app/ui/src/lib/stores/settings.ts
@@ -20,6 +20,9 @@ export interface PilotSettings {
     snapshot_retention_count: number;
     snapshot_retention_days: number;
   };
+  screen_vision: {
+    capture_interval_seconds: number;
+  };
   restrictions: {
     protected_folders: string[];
     protected_packages: string[];
@@ -46,6 +49,9 @@ const defaultSettings: PilotSettings = {
     snapshot_backend: "auto",
     snapshot_retention_count: 10,
     snapshot_retention_days: 7,
+  },
+  screen_vision: {
+    capture_interval_seconds: 3,
   },
   restrictions: {
     protected_folders: [],


### PR DESCRIPTION
## Summary
- add a persisted `screen_vision.capture_interval_seconds` setting in `config.toml`
- start and toggle the ScreenVisionAgent using the configured interval instead of a hardcoded value
- add a Settings panel number input so users can tune screen capture cadence for battery/privacy
- add IPC regression coverage for config round-trip and default screen vision toggle behavior

Fixes #55

## Testing
- `/Users/saurabhkumarbajpaiai/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 -m pytest daemon/tests/test_ipc_integration.py -q` ✅ 8 passed
- `/Users/saurabhkumarbajpaiai/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 -m ruff check daemon/pilot/config.py daemon/pilot/agents/screen_vision.py daemon/pilot/server.py daemon/tests/test_ipc_integration.py` ✅
- `git diff --check` ✅

## Note
I also attempted the UI verification commands with the bundled Node runtime, but this checkout is missing `node_modules/@tauri-apps/plugin-notification` even though it is listed in `package.json` and `package-lock.json`. That pre-existing missing install causes both `svelte-check` and `vite build` to fail before this change is evaluated.

## GSSoC labels requested
Please add `gssoc:approved`, `level:intermediate`, `quality:clean`, and `type:feature` if this PR meets the project criteria.
