### PR TITLE
Add SQLite read/write connection pooling

### DIFF
--- a/daemon/pilot/db/__init__.py
+++ b/daemon/pilot/db/__init__.py
@@ -1,0 +1,2 @@
+"""Database infrastructure helpers."""
+

--- a/daemon/pilot/db/sqlite_pool.py
+++ b/daemon/pilot/db/sqlite_pool.py
@@ -1,0 +1,92 @@
+"""Async SQLite connection pool with read/write separation."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+from collections.abc import AsyncIterator
+from pathlib import Path
+
+import aiosqlite
+
+
+class AsyncSqlitePool:
+    """Small aiosqlite pool tuned for daemon-style shared databases.
+
+    SQLite allows many readers but only one writer. The pool reflects that:
+    read connections are leased from a bounded queue while writes are routed
+    through one WAL-enabled connection protected by a lock.
+    """
+
+    def __init__(self, db_path: str | Path, *, read_pool_size: int = 4, timeout: float = 30.0) -> None:
+        if read_pool_size < 1:
+            raise ValueError("read_pool_size must be at least 1")
+        self._db_path = Path(db_path)
+        self._read_pool_size = read_pool_size
+        self._timeout = timeout
+        self._read_pool: asyncio.Queue[aiosqlite.Connection] = asyncio.Queue(maxsize=read_pool_size)
+        self._write_conn: aiosqlite.Connection | None = None
+        self._write_lock = asyncio.Lock()
+        self._started = False
+        self._closed = False
+
+    async def start(self) -> None:
+        if self._started:
+            return
+        self._db_path.parent.mkdir(parents=True, exist_ok=True)
+        self._write_conn = await self._open_connection()
+        await self._configure_connection(self._write_conn, writable=True)
+        for _ in range(self._read_pool_size):
+            conn = await self._open_connection()
+            await self._configure_connection(conn, writable=False)
+            await self._read_pool.put(conn)
+        self._started = True
+        self._closed = False
+
+    @contextlib.asynccontextmanager
+    async def read(self) -> AsyncIterator[aiosqlite.Connection]:
+        self._ensure_started()
+        conn = await asyncio.wait_for(self._read_pool.get(), timeout=self._timeout)
+        try:
+            yield conn
+        finally:
+            await self._read_pool.put(conn)
+
+    @contextlib.asynccontextmanager
+    async def write(self) -> AsyncIterator[aiosqlite.Connection]:
+        self._ensure_started()
+        if self._write_conn is None:
+            raise RuntimeError("SQLite pool writer is not initialized")
+        async with self._write_lock:
+            yield self._write_conn
+
+    async def close(self) -> None:
+        if not self._started or self._closed:
+            return
+        if self._write_conn is not None:
+            await self._write_conn.close()
+            self._write_conn = None
+        while not self._read_pool.empty():
+            conn = await self._read_pool.get()
+            await conn.close()
+        self._closed = True
+        self._started = False
+
+    @property
+    def read_pool_size(self) -> int:
+        return self._read_pool_size
+
+    async def _open_connection(self) -> aiosqlite.Connection:
+        return await aiosqlite.connect(str(self._db_path), timeout=self._timeout)
+
+    async def _configure_connection(self, conn: aiosqlite.Connection, *, writable: bool) -> None:
+        await conn.execute("PRAGMA journal_mode = WAL")
+        await conn.execute("PRAGMA synchronous = NORMAL")
+        await conn.execute("PRAGMA busy_timeout = 5000")
+        if not writable:
+            await conn.execute("PRAGMA query_only = ON")
+        await conn.commit()
+
+    def _ensure_started(self) -> None:
+        if not self._started or self._closed:
+            raise RuntimeError("SQLite pool is not started")

--- a/daemon/pilot/memory/store.py
+++ b/daemon/pilot/memory/store.py
@@ -12,9 +12,9 @@ from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
 import aiofiles.os
-import aiosqlite
 
 from pilot.config import DATA_DIR, DB_FILE
+from pilot.db.sqlite_pool import AsyncSqlitePool
 
 if TYPE_CHECKING:
     from pilot.actions import ActionPlan, ActionResult
@@ -49,15 +49,17 @@ class MemoryStore:
     """Persistent memory with action history and semantic preference learning."""
 
     def __init__(self) -> None:
-        self._db: aiosqlite.Connection | None = None
+        self._pool: AsyncSqlitePool | None = None
         self._chroma_collection: Any = None
         self._workspace_index = None
 
     async def initialize(self) -> None:
         await aiofiles.os.makedirs(DATA_DIR, exist_ok=True)
-        self._db = await aiosqlite.connect(str(DB_FILE))
-        await self._db.executescript(SCHEMA_SQL)
-        await self._db.commit()
+        self._pool = AsyncSqlitePool(DB_FILE)
+        await self._pool.start()
+        async with self._pool.write() as db:
+            await db.executescript(SCHEMA_SQL)
+            await db.commit()
         await asyncio.to_thread(self._init_chroma)
         self._init_workspace_index()
 
@@ -94,7 +96,7 @@ class MemoryStore:
         results: list[ActionResult],
     ) -> None:
         """Record an executed plan and its results."""
-        if not self._db:
+        if not self._pool:
             return
 
         now = datetime.now(UTC).isoformat()
@@ -102,13 +104,14 @@ class MemoryStore:
         results_json = json.dumps([r.model_dump() for r in results])
         success = all(r.success for r in results)
 
-        await self._db.execute(
-            """INSERT INTO action_history
-               (timestamp, user_input, plan_json, results_json, success, explanation)
-               VALUES (?, ?, ?, ?, ?, ?)""",
-            (now, user_input, plan_json, results_json, int(success), plan.explanation),
-        )
-        await self._db.commit()
+        async with self._pool.write() as db:
+            await db.execute(
+                """INSERT INTO action_history
+                   (timestamp, user_input, plan_json, results_json, success, explanation)
+                   VALUES (?, ?, ?, ?, ?, ?)""",
+                (now, user_input, plan_json, results_json, int(success), plan.explanation),
+            )
+            await db.commit()
 
         if self._chroma_collection is not None:
             try:
@@ -145,7 +148,7 @@ class MemoryStore:
             except Exception:
                 logger.debug("ChromaDB query failed", exc_info=True)
 
-        if self._db:
+        if self._pool:
             prefs = await self._get_preferences()
             if prefs:
                 parts.append("User preferences:")
@@ -155,15 +158,17 @@ class MemoryStore:
         return "\n".join(parts) if parts else ""
 
     async def get_history(self, *, limit: int = 50, offset: int = 0) -> list[dict[str, Any]]:
-        if not self._db:
+        if not self._pool:
             return []
 
-        cursor = await self._db.execute(
-            """SELECT id, timestamp, user_input, success, explanation
-               FROM action_history ORDER BY id DESC LIMIT ? OFFSET ?""",
-            (limit, offset),
-        )
-        rows = await cursor.fetchall()
+        async with self._pool.read() as db:
+            cursor = await db.execute(
+                """SELECT id, timestamp, user_input, success, explanation
+                   FROM action_history ORDER BY id DESC LIMIT ? OFFSET ?""",
+                (limit, offset),
+            )
+            rows = await cursor.fetchall()
+            await cursor.close()
         return [
             {
                 "id": r[0],
@@ -176,22 +181,25 @@ class MemoryStore:
         ]
 
     async def set_preference(self, key: str, value: str) -> None:
-        if not self._db:
+        if not self._pool:
             return
         now = datetime.now(UTC).isoformat()
-        await self._db.execute(
-            """INSERT INTO user_preferences (key, value, updated_at)
-               VALUES (?, ?, ?)
-               ON CONFLICT(key) DO UPDATE SET value=excluded.value, updated_at=excluded.updated_at""",
-            (key, value, now),
-        )
-        await self._db.commit()
+        async with self._pool.write() as db:
+            await db.execute(
+                """INSERT INTO user_preferences (key, value, updated_at)
+                   VALUES (?, ?, ?)
+                   ON CONFLICT(key) DO UPDATE SET value=excluded.value, updated_at=excluded.updated_at""",
+                (key, value, now),
+            )
+            await db.commit()
 
     async def _get_preferences(self) -> dict[str, str]:
-        if not self._db:
+        if not self._pool:
             return {}
-        cursor = await self._db.execute("SELECT key, value FROM user_preferences")
-        rows = await cursor.fetchall()
+        async with self._pool.read() as db:
+            cursor = await db.execute("SELECT key, value FROM user_preferences")
+            rows = await cursor.fetchall()
+            await cursor.close()
         return {r[0]: r[1] for r in rows}
 
     async def index_workspace(self, folder_path: str) -> dict:
@@ -211,6 +219,6 @@ class MemoryStore:
         return await asyncio.to_thread(self._workspace_index.search, query, n_results)
 
     async def close(self) -> None:
-        if self._db:
-            await self._db.close()
-            self._db = None
+        if self._pool:
+            await self._pool.close()
+            self._pool = None

--- a/daemon/pilot/models/budget_tracker.py
+++ b/daemon/pilot/models/budget_tracker.py
@@ -7,7 +7,7 @@ import logging
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
-import aiosqlite
+from pilot.db.sqlite_pool import AsyncSqlitePool
 
 if TYPE_CHECKING:
     from pilot.config import ModelConfig
@@ -58,14 +58,16 @@ class BudgetTracker:
         self._enabled: bool = config.budget_enabled
         self._monthly_limit: float = config.budget_monthly_limit_usd
         self._db_path = db_path
-        self._db: aiosqlite.Connection | None = None
+        self._pool: AsyncSqlitePool | None = None
         self._monthly_cost: float = 0.0
         self._lock = asyncio.Lock()
 
     async def initialize(self) -> None:
-        self._db = await aiosqlite.connect(self._db_path)
-        await self._db.executescript(SCHEMA_SQL)
-        await self._db.commit()
+        self._pool = AsyncSqlitePool(self._db_path, read_pool_size=2)
+        await self._pool.start()
+        async with self._pool.write() as db:
+            await db.executescript(SCHEMA_SQL)
+            await db.commit()
         self._monthly_cost = await self._load_monthly_cost()
         logger.info(
             "BudgetTracker ready — month=%s spent=%.4f limit=%.2f enabled=%s",
@@ -76,13 +78,15 @@ class BudgetTracker:
         )
 
     async def _load_monthly_cost(self) -> float:
-        if not self._db:
+        if not self._pool:
             return 0.0
-        cursor = await self._db.execute(
-            "SELECT COALESCE(SUM(cost_usd), 0.0) FROM token_usage WHERE month = ?",
-            (_current_month(),),
-        )
-        row = await cursor.fetchone()
+        async with self._pool.read() as db:
+            cursor = await db.execute(
+                "SELECT COALESCE(SUM(cost_usd), 0.0) FROM token_usage WHERE month = ?",
+                (_current_month(),),
+            )
+            row = await cursor.fetchone()
+            await cursor.close()
         return float(row[0]) if row else 0.0
 
     # ------------------------------------------------------------------
@@ -114,36 +118,39 @@ class BudgetTracker:
         output_tokens: int,
     ) -> None:
         """Persist one call's token usage and update the in-memory monthly total."""
-        if not self._db:
+        if not self._pool:
             return
         cost = _estimate_cost(provider, input_tokens, output_tokens)
         now = datetime.now(UTC).isoformat()
         month = _current_month()
         async with self._lock:
-            await self._db.execute(
-                """INSERT INTO token_usage
-                   (timestamp, month, provider, model, input_tokens, output_tokens, cost_usd)
-                   VALUES (?, ?, ?, ?, ?, ?, ?)""",
-                (now, month, provider, model, input_tokens, output_tokens, cost),
-            )
-            await self._db.commit()
+            async with self._pool.write() as db:
+                await db.execute(
+                    """INSERT INTO token_usage
+                       (timestamp, month, provider, model, input_tokens, output_tokens, cost_usd)
+                       VALUES (?, ?, ?, ?, ?, ?, ?)""",
+                    (now, month, provider, model, input_tokens, output_tokens, cost),
+                )
+                await db.commit()
             self._monthly_cost += cost
 
     async def get_stats(self) -> dict:
         """Return current-month usage summary."""
-        if not self._db:
+        if not self._pool:
             return {}
         month = _current_month()
-        cursor = await self._db.execute(
-            """SELECT
-                   COUNT(*) AS calls,
-                   COALESCE(SUM(input_tokens), 0) AS total_input,
-                   COALESCE(SUM(output_tokens), 0) AS total_output,
-                   COALESCE(SUM(cost_usd), 0.0) AS total_cost
-               FROM token_usage WHERE month = ?""",
-            (month,),
-        )
-        row = await cursor.fetchone()
+        async with self._pool.read() as db:
+            cursor = await db.execute(
+                """SELECT
+                       COUNT(*) AS calls,
+                       COALESCE(SUM(input_tokens), 0) AS total_input,
+                       COALESCE(SUM(output_tokens), 0) AS total_output,
+                       COALESCE(SUM(cost_usd), 0.0) AS total_cost
+                   FROM token_usage WHERE month = ?""",
+                (month,),
+            )
+            row = await cursor.fetchone()
+            await cursor.close()
         calls, total_input, total_output, total_cost = row if row else (0, 0, 0, 0.0)
         remaining = max(0.0, self._monthly_limit - float(total_cost)) if self._monthly_limit > 0 else None
         return {
@@ -159,15 +166,16 @@ class BudgetTracker:
 
     async def reset_current_month(self) -> None:
         """Delete all records for the current month and reset the in-memory cache."""
-        if not self._db:
+        if not self._pool:
             return
         async with self._lock:
-            await self._db.execute("DELETE FROM token_usage WHERE month = ?", (_current_month(),))
-            await self._db.commit()
+            async with self._pool.write() as db:
+                await db.execute("DELETE FROM token_usage WHERE month = ?", (_current_month(),))
+                await db.commit()
             self._monthly_cost = 0.0
         logger.info("BudgetTracker: current month reset")
 
     async def close(self) -> None:
-        if self._db:
-            await self._db.close()
-            self._db = None
+        if self._pool:
+            await self._pool.close()
+            self._pool = None

--- a/daemon/tests/test_budget_tracker_pool.py
+++ b/daemon/tests/test_budget_tracker_pool.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import pytest
+
+from pilot.config import ModelConfig
+from pilot.models.budget_tracker import BudgetExceededError, BudgetTracker
+
+
+@pytest.mark.asyncio
+async def test_budget_tracker_uses_pool_for_usage_stats_and_reset(tmp_path):
+    config = ModelConfig()
+    config.budget_enabled = True
+    config.budget_monthly_limit_usd = 1.0
+    tracker = BudgetTracker(config, str(tmp_path / "budget.db"))
+    await tracker.initialize()
+    try:
+        await tracker.record_usage("openai", "gpt-test", 100, 50)
+        stats = await tracker.get_stats()
+
+        assert stats["calls"] == 1
+        assert stats["input_tokens"] == 100
+        assert stats["output_tokens"] == 50
+        assert stats["cost_usd"] > 0
+
+        await tracker.reset_current_month()
+        reset_stats = await tracker.get_stats()
+        assert reset_stats["calls"] == 0
+        assert reset_stats["cost_usd"] == 0
+    finally:
+        await tracker.close()
+
+
+@pytest.mark.asyncio
+async def test_budget_tracker_budget_gate_uses_cached_monthly_total(tmp_path):
+    config = ModelConfig()
+    config.budget_enabled = True
+    config.budget_monthly_limit_usd = 0.0001
+    tracker = BudgetTracker(config, str(tmp_path / "budget.db"))
+    await tracker.initialize()
+    try:
+        await tracker.record_usage("openai", "gpt-test", 1000, 1000)
+        with pytest.raises(BudgetExceededError):
+            tracker.check_budget("openai")
+    finally:
+        await tracker.close()

--- a/daemon/tests/test_memory_store.py
+++ b/daemon/tests/test_memory_store.py
@@ -16,9 +16,11 @@ from __future__ import annotations
 import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
-import aiosqlite
 import pytest
 import pytest_asyncio
+
+from pilot.db.sqlite_pool import AsyncSqlitePool
+from pilot.memory.store import SCHEMA_SQL, MemoryStore
 
 # ---------------------------------------------------------------------------
 # Minimal stubs for ActionPlan and ActionResult
@@ -59,7 +61,7 @@ def fake_results_failed() -> list[_FakeResult]:
 
 
 @pytest_asyncio.fixture
-async def store():
+async def store(tmp_path):
     """
     Return an initialised MemoryStore backed by a real in-memory SQLite DB.
     ChromaDB and WorkspaceIndex are fully mocked — no external services needed.
@@ -67,27 +69,34 @@ async def store():
     Key fix: the real aiosqlite connection is created BEFORE any patching
     so the patch on aiosqlite.connect never intercepts our own :memory: call.
     """
-    from pilot.memory.store import MemoryStore, SCHEMA_SQL
-
-    # Create the real in-memory DB BEFORE entering any patch context
-    real_conn = await aiosqlite.connect(":memory:")
-    await real_conn.executescript(SCHEMA_SQL)
-    await real_conn.commit()
+    pool = AsyncSqlitePool(tmp_path / "memory.db")
+    await pool.start()
+    async with pool.write() as db:
+        await db.executescript(SCHEMA_SQL)
+        await db.commit()
 
     chroma_mock = MagicMock()
     chroma_mock.add = MagicMock()
     chroma_mock.query = MagicMock(return_value={"documents": [[]], "metadatas": [[]]})
 
     s = MemoryStore()
-    s._db = real_conn
+    s._pool = pool
     s._chroma_collection = chroma_mock
     s._workspace_index = None
 
     yield s
 
-    if s._db:
-        await s._db.close()
-        s._db = None
+    if s._pool:
+        await s._pool.close()
+        s._pool = None
+
+
+async def _fetch_one(store, query: str, params: tuple = ()):
+    async with store._pool.read() as db:
+        cursor = await db.execute(query, params)
+        row = await cursor.fetchone()
+        await cursor.close()
+        return row
 
 
 # ---------------------------------------------------------------------------
@@ -100,22 +109,23 @@ class TestMemoryStoreInit:
         """MemoryStore attributes start as None before initialize() is called."""
         from pilot.memory.store import MemoryStore
         s = MemoryStore()
-        assert s._db is None
+        assert s._pool is None
         assert s._chroma_collection is None
         assert s._workspace_index is None
 
     @pytest.mark.asyncio
-    async def test_initialize_sets_up_db(self):
-        """After manually wiring a DB, _db is not None."""
-        from pilot.memory.store import MemoryStore, SCHEMA_SQL
-        real_conn = await aiosqlite.connect(":memory:")
-        await real_conn.executescript(SCHEMA_SQL)
-        await real_conn.commit()
+    async def test_initialize_sets_up_pool(self, tmp_path):
+        """After manually wiring a pool, _pool is not None."""
+        pool = AsyncSqlitePool(tmp_path / "memory.db")
+        await pool.start()
+        async with pool.write() as db:
+            await db.executescript(SCHEMA_SQL)
+            await db.commit()
 
         s = MemoryStore()
-        s._db = real_conn
-        assert s._db is not None
-        await real_conn.close()
+        s._pool = pool
+        assert s._pool is not None
+        await pool.close()
 
 
 # ---------------------------------------------------------------------------
@@ -130,8 +140,7 @@ class TestRecord:
         with patch("pilot.memory.store.asyncio.to_thread", new_callable=AsyncMock):
             await store.record("open browser", fake_plan, fake_results)
 
-        cursor = await store._db.execute("SELECT COUNT(*) FROM action_history")
-        row = await cursor.fetchone()
+        row = await _fetch_one(store, "SELECT COUNT(*) FROM action_history")
         assert row[0] == 1
 
     @pytest.mark.asyncio
@@ -140,8 +149,7 @@ class TestRecord:
         with patch("pilot.memory.store.asyncio.to_thread", new_callable=AsyncMock):
             await store.record("close window", fake_plan, fake_results)
 
-        cursor = await store._db.execute("SELECT user_input FROM action_history")
-        row = await cursor.fetchone()
+        row = await _fetch_one(store, "SELECT user_input FROM action_history")
         assert row[0] == "close window"
 
     @pytest.mark.asyncio
@@ -150,8 +158,7 @@ class TestRecord:
         with patch("pilot.memory.store.asyncio.to_thread", new_callable=AsyncMock):
             await store.record("open terminal", fake_plan, fake_results)
 
-        cursor = await store._db.execute("SELECT success FROM action_history")
-        row = await cursor.fetchone()
+        row = await _fetch_one(store, "SELECT success FROM action_history")
         assert row[0] == 1
 
     @pytest.mark.asyncio
@@ -160,8 +167,7 @@ class TestRecord:
         with patch("pilot.memory.store.asyncio.to_thread", new_callable=AsyncMock):
             await store.record("delete file", fake_plan, fake_results_failed)
 
-        cursor = await store._db.execute("SELECT success FROM action_history")
-        row = await cursor.fetchone()
+        row = await _fetch_one(store, "SELECT success FROM action_history")
         assert row[0] == 0
 
     @pytest.mark.asyncio
@@ -172,16 +178,15 @@ class TestRecord:
             await store.record("task two", fake_plan, fake_results)
             await store.record("task three", fake_plan, fake_results)
 
-        cursor = await store._db.execute("SELECT COUNT(*) FROM action_history")
-        row = await cursor.fetchone()
+        row = await _fetch_one(store, "SELECT COUNT(*) FROM action_history")
         assert row[0] == 3
 
     @pytest.mark.asyncio
-    async def test_record_skips_when_db_none(self, fake_plan, fake_results):
-        """record() returns silently when _db is None (no crash)."""
+    async def test_record_skips_when_pool_none(self, fake_plan, fake_results):
+        """record() returns silently when _pool is None (no crash)."""
         from pilot.memory.store import MemoryStore
         s = MemoryStore()
-        s._db = None
+        s._pool = None
         await s.record("test input", fake_plan, fake_results)
 
     @pytest.mark.asyncio
@@ -267,11 +272,11 @@ class TestGetHistory:
             assert key in entry
 
     @pytest.mark.asyncio
-    async def test_get_history_returns_empty_when_db_none(self):
-        """get_history() returns [] when _db is None."""
+    async def test_get_history_returns_empty_when_pool_none(self):
+        """get_history() returns [] when _pool is None."""
         from pilot.memory.store import MemoryStore
         s = MemoryStore()
-        s._db = None
+        s._pool = None
         result = await s.get_history()
         assert result == []
 
@@ -313,19 +318,19 @@ class TestPreferences:
         assert prefs == {}
 
     @pytest.mark.asyncio
-    async def test_set_preference_skips_when_db_none(self):
-        """set_preference() returns silently when _db is None."""
+    async def test_set_preference_skips_when_pool_none(self):
+        """set_preference() returns silently when _pool is None."""
         from pilot.memory.store import MemoryStore
         s = MemoryStore()
-        s._db = None
+        s._pool = None
         await s.set_preference("key", "value")  # should not raise
 
     @pytest.mark.asyncio
-    async def test_get_preferences_returns_empty_when_db_none(self):
-        """_get_preferences() returns {} when _db is None."""
+    async def test_get_preferences_returns_empty_when_pool_none(self):
+        """_get_preferences() returns {} when _pool is None."""
         from pilot.memory.store import MemoryStore
         s = MemoryStore()
-        s._db = None
+        s._pool = None
         result = await s._get_preferences()
         assert result == {}
 
@@ -387,18 +392,19 @@ class TestGetContext:
 class TestClose:
 
     @pytest.mark.asyncio
-    async def test_close_sets_db_to_none(self):
-        """close() sets _db to None after closing the connection."""
+    async def test_close_sets_pool_to_none(self, tmp_path):
+        """close() sets _pool to None after closing the pool."""
         from pilot.memory.store import MemoryStore
         s = MemoryStore()
-        s._db = await aiosqlite.connect(":memory:")
+        s._pool = AsyncSqlitePool(tmp_path / "memory.db")
+        await s._pool.start()
         await s.close()
-        assert s._db is None
+        assert s._pool is None
 
     @pytest.mark.asyncio
     async def test_close_is_safe_when_already_none(self):
-        """close() does not raise when _db is already None."""
+        """close() does not raise when _pool is already None."""
         from pilot.memory.store import MemoryStore
         s = MemoryStore()
-        s._db = None
+        s._pool = None
         await s.close()  # should not raise

--- a/daemon/tests/test_sqlite_pool.py
+++ b/daemon/tests/test_sqlite_pool.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from pilot.db.sqlite_pool import AsyncSqlitePool
+
+
+@pytest.mark.asyncio
+async def test_sqlite_pool_reuses_read_connections_and_writes(tmp_path):
+    pool = AsyncSqlitePool(tmp_path / "pool.db", read_pool_size=2)
+    await pool.start()
+    try:
+        async with pool.write() as db:
+            await db.execute("CREATE TABLE demo (id INTEGER PRIMARY KEY, value TEXT NOT NULL)")
+            await db.execute("INSERT INTO demo (value) VALUES (?)", ("ready",))
+            await db.commit()
+
+        async with pool.read() as db:
+            cursor = await db.execute("SELECT value FROM demo")
+            row = await cursor.fetchone()
+            await cursor.close()
+
+        assert row[0] == "ready"
+    finally:
+        await pool.close()
+
+
+@pytest.mark.asyncio
+async def test_sqlite_pool_allows_concurrent_reads(tmp_path):
+    pool = AsyncSqlitePool(tmp_path / "pool.db", read_pool_size=3)
+    await pool.start()
+    try:
+        async with pool.write() as db:
+            await db.execute("CREATE TABLE demo (id INTEGER PRIMARY KEY, value INTEGER NOT NULL)")
+            await db.executemany("INSERT INTO demo (value) VALUES (?)", [(1,), (2,), (3,)])
+            await db.commit()
+
+        async def read_total() -> int:
+            async with pool.read() as db:
+                cursor = await db.execute("SELECT SUM(value) FROM demo")
+                row = await cursor.fetchone()
+                await cursor.close()
+                return int(row[0])
+
+        assert await asyncio.gather(read_total(), read_total(), read_total()) == [6, 6, 6]
+    finally:
+        await pool.close()
+
+
+@pytest.mark.asyncio
+async def test_sqlite_pool_serializes_writes(tmp_path):
+    pool = AsyncSqlitePool(tmp_path / "pool.db", read_pool_size=1)
+    await pool.start()
+    try:
+        async with pool.write() as db:
+            await db.execute("CREATE TABLE demo (value INTEGER NOT NULL)")
+            await db.commit()
+
+        async def insert_value(value: int) -> None:
+            async with pool.write() as db:
+                await db.execute("INSERT INTO demo (value) VALUES (?)", (value,))
+                await db.commit()
+
+        await asyncio.gather(*(insert_value(value) for value in range(10)))
+
+        async with pool.read() as db:
+            cursor = await db.execute("SELECT COUNT(*), SUM(value) FROM demo")
+            row = await cursor.fetchone()
+            await cursor.close()
+
+        assert row == (10, 45)
+    finally:
+        await pool.close()
+
+
+@pytest.mark.asyncio
+async def test_sqlite_pool_close_rejects_new_leases(tmp_path):
+    pool = AsyncSqlitePool(tmp_path / "pool.db")
+    await pool.start()
+    await pool.close()
+
+    with pytest.raises(RuntimeError, match="not started"):
+        async with pool.read():
+            pass


### PR DESCRIPTION
## Summary
- add a reusable `AsyncSqlitePool` with a bounded read pool, serialized writer, WAL mode, busy timeout, and explicit cleanup
- migrate `MemoryStore` history/preferences and `BudgetTracker` usage stats/reset paths onto the pooled read/write abstraction
- update memory-store tests for the pool-backed implementation
- add focused tests for connection reuse, concurrent reads, serialized writes, cleanup behavior, and budget tracking on the pooled path

Fixes #144

## Testing
- `python3 -m pytest tests/test_sqlite_pool.py tests/test_budget_tracker_pool.py tests/test_memory_store.py -q` ✅ 34 passed
- `python3 -m ruff check pilot/db/sqlite_pool.py pilot/memory/store.py pilot/models/budget_tracker.py tests/test_sqlite_pool.py tests/test_budget_tracker_pool.py tests/test_memory_store.py` ✅
- `python3 -m py_compile pilot/db/sqlite_pool.py pilot/memory/store.py pilot/models/budget_tracker.py tests/test_sqlite_pool.py tests/test_budget_tracker_pool.py` ✅
- `git diff --check` ✅

## GSSoC / NSoC labels requested
Could you please add `gssoc:approved`, `level:advanced`, `quality:exceptional`, `type:performance`, and the NSoC Level 3 labels when reviewing?