### PR TITLE
feat(ui): add scroll-to-bottom FAB for chat panel (closes #132)

### DIFF
--- a/tauri-app/ui/src/App.svelte
+++ b/tauri-app/ui/src/App.svelte
@@ -20,14 +20,24 @@
   import { onDestroy, tick } from "svelte";
   import { writeText } from "@tauri-apps/plugin-clipboard-manager";
   import { Copy } from "lucide-svelte";
+  import ScrollToBottom from "./lib/components/ScrollToBottom.svelte";
 
   let activeTab: "chat" | "log" | "settings" | "plugins" = $state("chat");
   let isDragging = $state(false);
   let showWizard = $derived(
     !$settings.first_run_complete && localStorage.getItem("heliox_first_run_complete") !== "true"
   );
+
+  let showScrollFAB = $state(false);
+  let isAtBottom = $state(true);
+
   let virtualListEl: VirtualList<Message> | undefined = $state();
   let particleBurst: ParticleBurst | undefined = $state();
+
+  // Show FAB whenever the user scrolls away from the bottom
+  $effect(() => {
+    showScrollFAB = !isAtBottom;
+  });
 
   async function onSetupComplete() {
     await settings.updateSection("", { first_run_complete: true });
@@ -60,7 +70,10 @@
   }
 
   function scrollToBottom() {
-    tick().then(() => virtualListEl?.scrollToBottom());
+    tick().then(() => {
+      virtualListEl?.scrollToBottom();
+      showScrollFAB = false;
+    });
   }
 
   $effect(() => {
@@ -218,7 +231,7 @@
               </div>
             </div>
           {:else}
-            <VirtualList bind:this={virtualListEl} items={$session.messages}>
+            <VirtualList bind:this={virtualListEl} items={$session.messages} bind:atBottom={isAtBottom}>
               {#snippet item(msg)}
                 {@render messageBlock(msg)}
               {/snippet}
@@ -250,6 +263,7 @@
               {/snippet}
             </VirtualList>
           {/if}
+          <ScrollToBottom show={showScrollFAB} onclick={scrollToBottom} />
         </div>
 
         <div class="input-row">
@@ -529,6 +543,7 @@
     overflow: hidden;
     display: flex;
     flex-direction: column;
+    position: relative;
   }
 
   /* Empty state */

--- a/tauri-app/ui/src/lib/components/ScrollToBottom.svelte
+++ b/tauri-app/ui/src/lib/components/ScrollToBottom.svelte
@@ -1,0 +1,52 @@
+<script lang="ts">
+  import { ArrowDown } from "lucide-svelte";
+
+  interface Props {
+    show: boolean;
+    onclick: () => void;
+  }
+
+  let { show, onclick }: Props = $props();
+</script>
+
+<button
+  class="scroll-fab"
+  class:visible={show}
+  aria-label="Scroll to bottom"
+  title="Scroll to bottom"
+  {onclick}
+>
+  <ArrowDown size={18} />
+</button>
+
+<style>
+  .scroll-fab {
+    position: absolute;
+    bottom: 16px;
+    right: 20px;
+    width: 36px;
+    height: 36px;
+    border-radius: 50%;
+    background: var(--accent);
+    color: white;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+    opacity: 0;
+    transform: translateY(8px);
+    transition: opacity 0.2s ease, transform 0.2s ease;
+    pointer-events: none;
+    z-index: 10;
+  }
+
+  .scroll-fab.visible {
+    opacity: 1;
+    transform: translateY(0);
+    pointer-events: auto;
+  }
+
+  .scroll-fab:hover {
+    background: var(--accent-hover);
+  }
+</style>

--- a/tauri-app/ui/src/lib/components/VirtualList.svelte
+++ b/tauri-app/ui/src/lib/components/VirtualList.svelte
@@ -31,6 +31,8 @@
     item: Snippet<[T, number]>;
     /** Optional footer rendered below all items. */
     footer?: Snippet;
+    /** Bindable — true when the list is scrolled to (or near) the bottom. */
+    atBottom?: boolean;
   }
 
   let {
@@ -39,6 +41,7 @@
     overscan = 5,
     item: itemSnippet,
     footer: footerSnippet,
+    atBottom = $bindable(true),
   }: Props<T> = $props();
 
   // ── Internal state ─────────────────────────────────────────────────────────
@@ -146,6 +149,7 @@
     wasAtBottom =
       scrollerEl.scrollTop + scrollerEl.clientHeight >=
       scrollerEl.scrollHeight - 8;
+    atBottom = wasAtBottom;
 
     // Walk the heights array to find the first and last visible item
     let cumulative = 0;

--- a/tauri-app/ui/src/lib/components/VirtualList.svelte
+++ b/tauri-app/ui/src/lib/components/VirtualList.svelte
@@ -61,6 +61,10 @@
   /** Whether the user was at the bottom before the last items update. */
   let wasAtBottom = true;
 
+  /** True while scrollToBottom() animation is in progress — prevents recalcWindow from flickering atBottom to false mid-scroll. */
+  let scrollingToBottom = false;
+  let scrollingTimer: ReturnType<typeof setTimeout> | null = null;
+
   /** ResizeObserver watching rendered row heights. */
   let ro: ResizeObserver | null = null;
 
@@ -149,7 +153,11 @@
     wasAtBottom =
       scrollerEl.scrollTop + scrollerEl.clientHeight >=
       scrollerEl.scrollHeight - 8;
-    atBottom = wasAtBottom;
+    // Only update bindable atBottom when the user is scrolling manually,
+    // not during a programmatic smooth-scroll animation
+    if (!scrollingToBottom) {
+      atBottom = wasAtBottom;
+    }
 
     // Walk the heights array to find the first and last visible item
     let cumulative = 0;
@@ -236,6 +244,7 @@
 
   onDestroy(() => {
     ro?.disconnect();
+    if (scrollingTimer) clearTimeout(scrollingTimer);
   });
 
   // ── Public API ─────────────────────────────────────────────────────────────
@@ -243,8 +252,17 @@
   /** Scroll the list to the very bottom. */
   export function scrollToBottom() {
     if (scrollerEl) {
-      scrollerEl.scrollTop = scrollerEl.scrollHeight;
+      // Immediately mark as at-bottom so the FAB hides at once
+      scrollingToBottom = true;
       wasAtBottom = true;
+      atBottom = true;
+      scrollerEl.scrollTo({ top: scrollerEl.scrollHeight, behavior: "smooth" });
+      // Re-enable manual scroll tracking after animation completes (~400ms)
+      if (scrollingTimer) clearTimeout(scrollingTimer);
+      scrollingTimer = setTimeout(() => {
+        scrollingToBottom = false;
+        scrollingTimer = null;
+      }, 450);
     }
   }
 </script>


### PR DESCRIPTION
## Summary

Added a scroll-to-bottom button in chat panel for when the user scrolls up and wants to go back to the latest message, integrating along with the existing component from PR #120

Closes #132 

---

## Type of change

- [x] New feature / enhancement

---

## Changes made

- **ScrollToBottom.svelte [NEW]:** Floating arrow-down button using 'lucide-svelte', with CSS transition for smooth show/hide.

- **VirtualList.svelte:** Added 'atBottom' as a '$bindable' prop so the parent can react to scroll position. Updated 'scrollToBottom()' to use smooth scroll ('scrollTo' with 'behavior: 'smooth''), with a 'scrollingToBottom' guard flag to prevent the FAB from flickering during animation.

- **App.svelte:** Bound 'atBottom' from VirtualList, wired up 'showScrollFAB' state, and placed the FAB inside '.results'.

---

## How to test

1. Run 'npm run dev' in 'tauri-app/ui/'
2. Send enough messages to make chat scrollable
3. Scroll up- FAB appears. Click it- scrolls to bottom, FAB hides.
4. Scroll to bottom manually- FAB auto-hides.

---

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My code follows the existing code style
- [x] I have added/updated tests where applicable
- [x] All existing tests pass (`pytest` for backend, `npm run test` for frontend)
- [x] I have updated documentation if needed
- [x] I have tested on at least one platform (Windows / macOS / Linux)

---

## Screenshots / recordings (if UI change)

https://github.com/user-attachments/assets/8b595391-3de4-49fe-ab94-88b153c14a9a

---

## GSSoC declaration

- [x] This contribution is made under the GSSoC 2026 program
- [x] I have not plagiarised code from other repositories
