### PR TITLE
Add Ed25519 plugin signature verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -464,7 +464,11 @@ Heliox OS ships with **3 flagship plugins** and supports community-built extensi
 | **media-control** | System | Spotify (play/pause/skip), system volume, YouTube, media keys |
 | **home-assistant** | IoT | Smart lights, switches, thermostats, scenes, device discovery |
 
-Drop custom plugins into `~/.heliox/plugins/` — they're auto-discovered at startup.
+Drop custom plugins into `~/.heliox/plugins/` — they're auto-discovered at startup
+after Ed25519 signature verification. Production registries can verify against
+bundled trusted public keys; local plugin packages can include
+`plugin.ed25519.pub` with `plugin.ed25519.sig`. Unsigned, untrusted, or tampered
+plugins are rejected before their manifest or code is loaded.
 
 ```json
 {

--- a/daemon/pilot/plugins/__init__.py
+++ b/daemon/pilot/plugins/__init__.py
@@ -28,21 +28,141 @@ Plugin directory structure:
   ~/.heliox/plugins/
     docker-agent/
       manifest.json
+      plugin.ed25519.pub
+      plugin.ed25519.sig
       docker_plugin.py
     spotify-agent/
       manifest.json
+      plugin.ed25519.pub
+      plugin.ed25519.sig
       spotify_plugin.py
+
+Plugin signatures:
+  Each plugin directory must include an Ed25519 signature file. Production
+  registries should provide bundled trusted public keys to PluginRegistry; local
+  development may also include plugin.ed25519.pub beside the signature. The
+  signature is verified before manifest parsing and covers a deterministic
+  digest of every plugin file except signature metadata, so changes to either
+  manifest.json or plugin code are rejected before loading.
 """
 
 from __future__ import annotations
 
+import base64
+import hashlib
 import json
 import logging
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+
 logger = logging.getLogger("pilot.plugins")
+
+PLUGIN_PUBLIC_KEY_FILE = "plugin.ed25519.pub"
+PLUGIN_SIGNATURE_FILE = "plugin.ed25519.sig"
+PLUGIN_SIGNATURE_EXCLUDES = frozenset(
+    {
+        PLUGIN_PUBLIC_KEY_FILE,
+        PLUGIN_SIGNATURE_FILE,
+    }
+)
+
+
+class PluginSignatureError(ValueError):
+    """Raised when a plugin signature is missing, malformed, or invalid."""
+
+
+def _load_public_key(raw: bytes, *, source: str) -> Ed25519PublicKey:
+    """Load an Ed25519 public key from PEM or base64-encoded raw bytes."""
+
+    stripped = raw.strip()
+    if stripped.startswith(b"-----BEGIN"):
+        key = serialization.load_pem_public_key(stripped)
+        if not isinstance(key, Ed25519PublicKey):
+            raise PluginSignatureError(f"Public key is not Ed25519: {source}")
+        return key
+
+    try:
+        key_bytes = base64.b64decode(stripped, validate=True)
+    except ValueError as exc:
+        raise PluginSignatureError(f"Public key is not valid base64: {source}") from exc
+
+    try:
+        return Ed25519PublicKey.from_public_bytes(key_bytes)
+    except ValueError as exc:
+        raise PluginSignatureError(f"Public key is not valid Ed25519: {source}") from exc
+
+
+def _read_public_key(path: Path) -> Ed25519PublicKey:
+    """Load an Ed25519 public key from a file."""
+
+    return _load_public_key(path.read_bytes(), source=str(path))
+
+
+def _coerce_public_key(source: Ed25519PublicKey | bytes | str | Path) -> Ed25519PublicKey:
+    """Normalize supported trusted-key inputs into Ed25519 public keys."""
+
+    if isinstance(source, Ed25519PublicKey):
+        return source
+    if isinstance(source, bytes):
+        return _load_public_key(source, source="trusted public key bytes")
+    return _read_public_key(Path(source))
+
+
+def _read_signature(path: Path) -> bytes:
+    """Load a base64-encoded Ed25519 signature."""
+
+    try:
+        return base64.b64decode(path.read_bytes().strip(), validate=True)
+    except ValueError as exc:
+        raise PluginSignatureError(f"Signature is not valid base64: {path}") from exc
+
+
+def _plugin_digest(plugin_dir: Path) -> bytes:
+    """Build a deterministic digest over plugin package contents."""
+
+    digest = hashlib.sha256()
+    for file_path in sorted(path for path in plugin_dir.rglob("*") if path.is_file()):
+        relative_path = file_path.relative_to(plugin_dir).as_posix()
+        if relative_path in PLUGIN_SIGNATURE_EXCLUDES:
+            continue
+        digest.update(relative_path.encode("utf-8"))
+        digest.update(b"\0")
+        digest.update(file_path.read_bytes())
+        digest.update(b"\0")
+    return digest.digest()
+
+
+def verify_plugin_signature(plugin_dir: Path, trusted_public_keys: tuple[Ed25519PublicKey, ...] = ()) -> None:
+    """Verify a plugin directory's Ed25519 signature before loading code."""
+
+    public_key_path = plugin_dir / PLUGIN_PUBLIC_KEY_FILE
+    signature_path = plugin_dir / PLUGIN_SIGNATURE_FILE
+    if not signature_path.exists():
+        raise PluginSignatureError(f"Plugin is missing Ed25519 signature: {signature_path}")
+
+    if trusted_public_keys:
+        public_keys = trusted_public_keys
+    elif public_key_path.exists():
+        public_keys = (_read_public_key(public_key_path),)
+    else:
+        raise PluginSignatureError(
+            f"Plugin is missing Ed25519 public key and no trusted key was configured: {public_key_path}"
+        )
+
+    signature = _read_signature(signature_path)
+    payload = _plugin_digest(plugin_dir)
+    for public_key in public_keys:
+        try:
+            public_key.verify(signature, payload)
+            return
+        except InvalidSignature:
+            continue
+    raise PluginSignatureError(f"Plugin signature verification failed: {plugin_dir}")
 
 
 @dataclass
@@ -105,10 +225,18 @@ class PluginRegistry:
       2. <data_dir>/plugins/    (system plugins)
     """
 
-    def __init__(self, plugin_dirs: list[Path] | None = None) -> None:
+    def __init__(
+        self,
+        plugin_dirs: list[Path] | None = None,
+        *,
+        require_signatures: bool = True,
+        trusted_public_keys: list[Ed25519PublicKey | bytes | str | Path] | None = None,
+    ) -> None:
         self._plugin_dirs: list[Path] = plugin_dirs or []
         self._plugins: dict[str, PluginManifest] = {}
         self._tool_index: dict[str, PluginManifest] = {}
+        self._require_signatures = require_signatures
+        self._trusted_public_keys = tuple(_coerce_public_key(key) for key in (trusted_public_keys or []))
 
         # Add default plugin directories
         home_plugins = Path.home() / ".heliox" / "plugins"
@@ -127,6 +255,8 @@ class PluginRegistry:
                 if child.is_dir():
                     manifest_path = child / "manifest.json"
                     if manifest_path.exists():
+                        if self._require_signatures and not self._verify_plugin(child):
+                            continue
                         manifest = self._load_manifest(manifest_path)
                         if manifest:
                             self._plugins[manifest.name] = manifest
@@ -143,6 +273,16 @@ class PluginRegistry:
 
         logger.info("Plugin discovery complete: %d plugins loaded", loaded)
         return loaded
+
+    def _verify_plugin(self, plugin_dir: Path) -> bool:
+        """Return True when a plugin directory passes signature verification."""
+
+        try:
+            verify_plugin_signature(plugin_dir, self._trusted_public_keys)
+            return True
+        except PluginSignatureError as exc:
+            logger.error("Rejected unsigned or tampered plugin %s: %s", plugin_dir, exc)
+            return False
 
     def _load_manifest(self, path: Path) -> PluginManifest | None:
         """Parse a plugin manifest.json file."""

--- a/daemon/tests/test_plugin_signatures.py
+++ b/daemon/tests/test_plugin_signatures.py
@@ -1,0 +1,167 @@
+"""Tests for Ed25519 plugin package verification."""
+
+from __future__ import annotations
+
+import base64
+import json
+from pathlib import Path
+
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+from pilot.plugins import (
+    PLUGIN_PUBLIC_KEY_FILE,
+    PLUGIN_SIGNATURE_FILE,
+    PluginRegistry,
+    _plugin_digest,
+)
+
+
+def _write_plugin(plugin_dir: Path, *, name: str = "signed-plugin") -> None:
+    plugin_dir.mkdir(parents=True)
+    (plugin_dir / "manifest.json").write_text(
+        json.dumps(
+            {
+                "name": name,
+                "version": "1.0.0",
+                "description": "Signed test plugin",
+                "entry_point": "plugin.py",
+                "tools": [
+                    {
+                        "name": "signed_tool",
+                        "description": "A signed plugin tool",
+                        "inputs": ["value"],
+                        "outputs": ["result"],
+                        "permission_tier": 2,
+                        "action_type": "shell_command",
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    (plugin_dir / "plugin.py").write_text(
+        "def run(value: str) -> str:\n    return value\n",
+        encoding="utf-8",
+    )
+
+
+def _sign_plugin(plugin_dir: Path, private_key: Ed25519PrivateKey | None = None) -> Ed25519PrivateKey:
+    private_key = private_key or Ed25519PrivateKey.generate()
+    public_key = private_key.public_key().public_bytes(
+        encoding=serialization.Encoding.Raw,
+        format=serialization.PublicFormat.Raw,
+    )
+    signature = private_key.sign(_plugin_digest(plugin_dir))
+    (plugin_dir / PLUGIN_PUBLIC_KEY_FILE).write_text(
+        base64.b64encode(public_key).decode("ascii"),
+        encoding="utf-8",
+    )
+    (plugin_dir / PLUGIN_SIGNATURE_FILE).write_text(
+        base64.b64encode(signature).decode("ascii"),
+        encoding="utf-8",
+    )
+    return private_key
+
+
+def test_discover_loads_valid_signed_plugin(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    plugin_root = tmp_path / "plugins"
+    plugin_dir = plugin_root / "signed-plugin"
+    _write_plugin(plugin_dir)
+    _sign_plugin(plugin_dir)
+
+    registry = PluginRegistry(plugin_dirs=[plugin_root])
+
+    assert registry.discover() == 1
+    assert registry.get_plugin("signed-plugin") is not None
+    assert registry.find_tool("signed_tool") is not None
+
+
+def test_discover_accepts_plugin_signed_by_trusted_bundled_key(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    plugin_root = tmp_path / "plugins"
+    plugin_dir = plugin_root / "trusted-plugin"
+    private_key = Ed25519PrivateKey.generate()
+    _write_plugin(plugin_dir, name="trusted-plugin")
+    _sign_plugin(plugin_dir, private_key)
+    trusted_key = private_key.public_key()
+
+    registry = PluginRegistry(plugin_dirs=[plugin_root], trusted_public_keys=[trusted_key])
+
+    assert registry.discover() == 1
+    assert registry.get_plugin("trusted-plugin") is not None
+
+
+def test_discover_rejects_plugin_signed_by_untrusted_replacement_key(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    plugin_root = tmp_path / "plugins"
+    plugin_dir = plugin_root / "forged-plugin"
+    trusted_private_key = Ed25519PrivateKey.generate()
+    attacker_private_key = Ed25519PrivateKey.generate()
+    _write_plugin(plugin_dir, name="forged-plugin")
+    _sign_plugin(plugin_dir, attacker_private_key)
+
+    registry = PluginRegistry(
+        plugin_dirs=[plugin_root],
+        trusted_public_keys=[trusted_private_key.public_key()],
+    )
+
+    assert registry.discover() == 0
+    assert registry.get_plugin("forged-plugin") is None
+
+
+def test_discover_rejects_missing_signature(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    plugin_root = tmp_path / "plugins"
+    _write_plugin(plugin_root / "unsigned-plugin", name="unsigned-plugin")
+
+    registry = PluginRegistry(plugin_dirs=[plugin_root])
+
+    assert registry.discover() == 0
+    assert registry.get_plugin("unsigned-plugin") is None
+
+
+def test_discover_rejects_tampered_plugin_file(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    plugin_root = tmp_path / "plugins"
+    plugin_dir = plugin_root / "tampered-plugin"
+    _write_plugin(plugin_dir, name="tampered-plugin")
+    _sign_plugin(plugin_dir)
+    (plugin_dir / "plugin.py").write_text(
+        "def run(value: str) -> str:\n    return 'tampered'\n",
+        encoding="utf-8",
+    )
+
+    registry = PluginRegistry(plugin_dirs=[plugin_root])
+
+    assert registry.discover() == 0
+    assert registry.get_plugin("tampered-plugin") is None
+
+
+def test_discover_rejects_invalid_public_key(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    plugin_root = tmp_path / "plugins"
+    plugin_dir = plugin_root / "bad-key-plugin"
+    _write_plugin(plugin_dir, name="bad-key-plugin")
+    _sign_plugin(plugin_dir)
+    (plugin_dir / PLUGIN_PUBLIC_KEY_FILE).write_text(
+        base64.b64encode(b"not-an-ed25519-key").decode("ascii"),
+        encoding="utf-8",
+    )
+
+    registry = PluginRegistry(plugin_dirs=[plugin_root])
+
+    assert registry.discover() == 0
+    assert registry.get_plugin("bad-key-plugin") is None
+
+
+def test_discover_can_disable_signature_requirement_for_tests(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    plugin_root = tmp_path / "plugins"
+    _write_plugin(plugin_root / "local-plugin", name="local-plugin")
+
+    registry = PluginRegistry(plugin_dirs=[plugin_root], require_signatures=False)
+
+    assert registry.discover() == 1
+    assert registry.get_plugin("local-plugin") is not None


### PR DESCRIPTION
## Summary
- add Ed25519 signature verification before plugin manifest parsing or code loading
- support registry-provided trusted public keys while preserving local plugin-bundled public key verification
- reject unsigned, tampered, malformed, or untrusted plugin packages with clear logging
- document the plugin signing requirement and add regression tests for valid, missing, tampered, invalid-key, trusted-key, and untrusted replacement-key flows

Fixes #142

## Testing
- `python3 -m pytest tests/test_plugin_signatures.py -q` ✅ 7 passed
- `python3 -m ruff check pilot/plugins/__init__.py tests/test_plugin_signatures.py` ✅
- `python3 -m ruff format --check pilot/plugins/__init__.py tests/test_plugin_signatures.py` ✅
- `python3 -m py_compile pilot/plugins/__init__.py tests/test_plugin_signatures.py` ✅
- `git diff --check` ✅

## GSSoC / NSoC Labels Requested
Please add `gssoc:approved`, `level:advanced`, `quality:exceptional`, `type:security`, `nsoc26`, and `level3` if this is accepted. This closes the assigned GSSoC/NSoC security issue #142.
