### PR TITLE
Add resumable workflow checkpoints

### DIFF
--- a/daemon/pilot/agents/executor.py
+++ b/daemon/pilot/agents/executor.py
@@ -323,12 +323,14 @@ class Executor:
         on_action_start: typing.Callable[[Action], typing.Awaitable[None]] | None = None,
         on_action_complete: typing.Callable[[ActionResult], typing.Awaitable[None]] | None = None,
         cancel_event: asyncio.Event | None = None,
+        plan_id: str | None = None,
+        initial_last_output: str = "",
     ) -> list[ActionResult]:
         """Execute all actions in a plan sequentially, with output chaining."""
-        plan_id = str(uuid.uuid4())[:8]
+        plan_id = plan_id or str(uuid.uuid4())[:8]
         results: list[ActionResult] = []
-        self._last_output = ""
-        self._largest_output = ""
+        self._last_output = initial_last_output
+        self._largest_output = initial_last_output
 
         allowed, reasons = self._permissions.plan_allowed(plan)
         if not allowed:

--- a/daemon/pilot/server.py
+++ b/daemon/pilot/server.py
@@ -111,6 +111,7 @@ class PilotServer:
         self._memory: Any = None
         self._vault: Any = None
         self._permission_audit: Any = None
+        self._checkpoint_store: Any = None
         # Cognitive intelligence (TRIBE v2)
         self._tribe_engine: Any = None
         self._attention_ui: Any = None
@@ -151,6 +152,7 @@ class PilotServer:
         from pilot.security.permissions import PermissionChecker
         from pilot.security.validator import ActionValidator
         from pilot.security.vault import KeyVault
+        from pilot.workflows.checkpoints import WorkflowCheckpointStore
 
         self._vault = KeyVault(self.config)
         model_router = ModelRouter(self.config, self._vault)
@@ -165,6 +167,8 @@ class PilotServer:
         audit = AuditLogger()
         self._permission_audit = PermissionEscalationAuditStore()
         await self._permission_audit.initialize()
+        self._checkpoint_store = WorkflowCheckpointStore()
+        await self._checkpoint_store.initialize()
         validator = ActionValidator(self.config)
         permissions = PermissionChecker(self.config)
         self._memory = MemoryStore()
@@ -333,6 +337,7 @@ class PilotServer:
 
         self._handlers = {
             "execute": self._handle_execute,
+            "resume_plan": self._handle_resume_plan,
             "export_session_chat": self._handle_export_session_chat,
             "confirm": self._handle_confirm,
             # ── Cancel Token (Issue #92) ──
@@ -678,6 +683,8 @@ class PilotServer:
             last_explanation = plan.explanation
             plan_id = str(uuid.uuid4())[:8]
             last_plan_id = plan_id
+            if self._checkpoint_store:
+                await self._checkpoint_store.start_plan(plan_id, user_input, plan)
 
             if emit:
                 await emit.phase_complete(
@@ -832,11 +839,13 @@ class PilotServer:
                         "execution", action_idx, _total, label=action.action_type.value, parent_id=_exec_phase
                     )
 
-            async def _on_action_complete(result: Any, _exec_phase: str = exec_phase) -> None:
+            async def _on_action_complete(result: Any, _exec_phase: str = exec_phase, _plan_id: str = plan_id) -> None:
                 result_payload = result.model_dump()
                 if dry_run:
                     result_payload["dry_run"] = True
                 await ws.send(_notification("action_complete", {"result": result_payload}))
+                if self._checkpoint_store and result.success:
+                    await self._checkpoint_store.record_result(_plan_id, result)
                 if emit:
                     event_name = EXECUTOR_ACTION_COMPLETE if result.success else EXECUTOR_ERROR
                     await emit.data_event(
@@ -861,6 +870,7 @@ class PilotServer:
                     on_action_start=_on_action_start,
                     on_action_complete=_on_action_complete,
                     cancel_event=cancel_event,  # ── Cancel Token (Issue #92) ──
+                    plan_id=plan_id,
                 )
             else:
                 results = await self._executor.execute(
@@ -868,6 +878,7 @@ class PilotServer:
                     on_action_start=_on_action_start,
                     on_action_complete=_on_action_complete,
                     cancel_event=cancel_event,  # ── Cancel Token (Issue #92) ──
+                    plan_id=plan_id,
                 )
             all_results = results
             if needs_confirm and not dry_run:
@@ -883,6 +894,8 @@ class PilotServer:
             if cancel_event.is_set():
                 logger.info("Execution was cancelled mid-plan after %d result(s)", len(results))
                 await ws.send(_notification("status", {"phase": "aborted"}))
+                if self._checkpoint_store:
+                    await self._checkpoint_store.mark_status(plan_id, "cancelled")
                 return {
                     "status": "cancelled",
                     "message": "Execution was aborted by user.",
@@ -946,6 +959,8 @@ class PilotServer:
                     )
 
                 asyncio.create_task(self._memory.record(user_input, plan, results))
+                if self._checkpoint_store:
+                    await self._checkpoint_store.mark_status(plan_id, "complete")
                 asyncio.create_task(
                     self._reflector.reflect(
                         user_input,
@@ -1006,6 +1021,8 @@ class PilotServer:
             await emit.phase_complete("memory_update", MEMORY_STORE_COMPLETE, {"partial": True}, parent_id=mem_final)
 
         asyncio.create_task(self._memory.record(user_input, plan, all_results))
+        if self._checkpoint_store and last_plan_id:
+            await self._checkpoint_store.mark_status(last_plan_id, "failed")
         await _emit_task_complete("partial_failure", last_explanation or "Task completed with errors.")
         return {
             "status": "partial_failure",
@@ -1019,6 +1036,110 @@ class PilotServer:
                 if dry_run
                 else last_explanation
             ),
+        }
+
+    async def _handle_resume_plan(self, params: dict[str, Any], ws: ServerConnection) -> dict:
+        """Resume a previously checkpointed plan from its last completed action."""
+        plan_id = str(params.get("plan_id", "")).strip()
+        if not plan_id:
+            return {"status": "error", "message": "resume_plan requires plan_id"}
+        if not self._checkpoint_store:
+            return {"status": "error", "message": "Workflow checkpoint store is not initialized"}
+
+        checkpoint = await self._checkpoint_store.get(plan_id)
+        if checkpoint is None:
+            return {"status": "error", "message": f"No checkpoint found for plan_id: {plan_id}"}
+
+        completed_count = max(0, min(checkpoint.completed_count, len(checkpoint.plan.actions)))
+        remaining_actions = checkpoint.plan.actions[completed_count:]
+        await ws.send(
+            _notification(
+                "status",
+                {
+                    "phase": "resuming",
+                    "plan_id": plan_id,
+                    "completed_actions": completed_count,
+                    "remaining_actions": len(remaining_actions),
+                },
+            )
+        )
+
+        if not remaining_actions:
+            await self._checkpoint_store.mark_status(plan_id, "complete")
+            return {
+                "status": "success",
+                "plan_id": plan_id,
+                "resumed": False,
+                "message": "Plan already completed.",
+                "results": [result.model_dump() for result in checkpoint.results],
+            }
+
+        self._cancel_event = asyncio.Event()
+        cancel_event = self._cancel_event
+
+        from pilot.actions import ActionPlan
+
+        remaining_plan = ActionPlan(
+            actions=remaining_actions,
+            explanation=checkpoint.plan.explanation,
+            raw_input=checkpoint.plan.raw_input,
+        )
+
+        async def _on_action_start(action: Any) -> None:
+            await ws.send(_notification("action_start", {"action": action.model_dump(), "resumed": True}))
+
+        async def _on_action_complete(result: Any) -> None:
+            await ws.send(_notification("action_complete", {"result": result.model_dump(), "resumed": True}))
+            if result.success:
+                await self._checkpoint_store.record_result(plan_id, result)
+
+        await self._checkpoint_store.mark_status(plan_id, "resuming")
+        results = await self._executor.execute(
+            remaining_plan,
+            on_action_start=_on_action_start,
+            on_action_complete=_on_action_complete,
+            cancel_event=cancel_event,
+            plan_id=plan_id,
+            initial_last_output=checkpoint.last_output,
+        )
+
+        updated = await self._checkpoint_store.get(plan_id)
+        combined_results = [
+            *(updated.results if updated else checkpoint.results),
+            *[r for r in results if not r.success],
+        ]
+
+        if cancel_event.is_set():
+            await self._checkpoint_store.mark_status(plan_id, "cancelled")
+            return {
+                "status": "cancelled",
+                "plan_id": plan_id,
+                "resumed": True,
+                "completed_actions": updated.completed_count if updated else completed_count,
+                "results": [result.model_dump() for result in combined_results],
+            }
+
+        failed = any(not result.success for result in results)
+        final_status = "failed" if failed else "complete"
+        await self._checkpoint_store.mark_status(plan_id, final_status)
+
+        verification_payload: dict[str, Any] = {}
+        if not failed and len(combined_results) >= len(checkpoint.plan.actions):
+            verification = await self._verifier.verify(checkpoint.plan, combined_results)
+            verification_payload = verification.model_dump()
+            if not verification.passed:
+                final_status = "partial_failure"
+                await self._checkpoint_store.mark_status(plan_id, "failed")
+
+        return {
+            "status": "partial_failure" if final_status in {"failed", "partial_failure"} else "success",
+            "plan_id": plan_id,
+            "resumed": True,
+            "skipped_actions": completed_count,
+            "executed_actions": len(results),
+            "results": [result.model_dump() for result in combined_results],
+            "verification": verification_payload,
+            "explanation": checkpoint.plan.explanation,
         }
 
     async def _record_permission_escalations(

--- a/daemon/pilot/workflows/checkpoints.py
+++ b/daemon/pilot/workflows/checkpoints.py
@@ -1,0 +1,219 @@
+"""SQLite-backed checkpoints for resumable multi-step plans."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import aiosqlite
+
+from pilot import config as pilot_config
+from pilot.actions import ActionPlan, ActionResult
+
+WORKFLOW_DB_FILENAME = "workflow_checkpoints.db"
+
+
+@dataclass(frozen=True)
+class PlanCheckpoint:
+    plan_id: str
+    user_input: str
+    plan: ActionPlan
+    results: list[ActionResult]
+    completed_count: int
+    last_output: str
+    snapshot_ids: list[str]
+    status: str
+    updated_at: str
+
+    @property
+    def is_complete(self) -> bool:
+        return self.completed_count >= len(self.plan.actions)
+
+
+class WorkflowCheckpointStore:
+    """Persists enough execution state to resume plans without replaying steps."""
+
+    def __init__(self, db_file: str | Path | None = None) -> None:
+        self._db_file = Path(db_file) if db_file is not None else pilot_config.DATA_DIR / WORKFLOW_DB_FILENAME
+
+    async def initialize(self) -> None:
+        self._db_file.parent.mkdir(parents=True, exist_ok=True)
+        async with aiosqlite.connect(self._db_file) as db:
+            await db.execute(
+                """
+                CREATE TABLE IF NOT EXISTS workflow_checkpoints (
+                    plan_id TEXT PRIMARY KEY,
+                    user_input TEXT NOT NULL,
+                    plan_json TEXT NOT NULL,
+                    results_json TEXT NOT NULL,
+                    completed_count INTEGER NOT NULL,
+                    last_output TEXT NOT NULL,
+                    snapshot_ids_json TEXT NOT NULL,
+                    status TEXT NOT NULL,
+                    updated_at TEXT NOT NULL
+                )
+                """
+            )
+            await db.execute(
+                """
+                CREATE INDEX IF NOT EXISTS idx_workflow_checkpoints_status
+                ON workflow_checkpoints(status)
+                """
+            )
+            await db.commit()
+
+    async def start_plan(self, plan_id: str, user_input: str, plan: ActionPlan) -> PlanCheckpoint:
+        checkpoint = PlanCheckpoint(
+            plan_id=plan_id,
+            user_input=user_input,
+            plan=plan,
+            results=[],
+            completed_count=0,
+            last_output="",
+            snapshot_ids=[],
+            status="running",
+            updated_at=self._now(),
+        )
+        await self._upsert(checkpoint)
+        return checkpoint
+
+    async def record_result(
+        self,
+        plan_id: str,
+        result: ActionResult,
+        *,
+        status: str | None = None,
+    ) -> PlanCheckpoint:
+        checkpoint = await self.get(plan_id)
+        if checkpoint is None:
+            raise KeyError(f"No checkpoint exists for plan_id: {plan_id}")
+
+        results = [*checkpoint.results, result]
+        completed_count = checkpoint.completed_count + (1 if result.success else 0)
+        snapshot_ids = list(checkpoint.snapshot_ids)
+        if result.snapshot_id and result.snapshot_id not in snapshot_ids:
+            snapshot_ids.append(result.snapshot_id)
+        updated = PlanCheckpoint(
+            plan_id=checkpoint.plan_id,
+            user_input=checkpoint.user_input,
+            plan=checkpoint.plan,
+            results=results,
+            completed_count=completed_count,
+            last_output=result.output or checkpoint.last_output,
+            snapshot_ids=snapshot_ids,
+            status=status or ("failed" if not result.success else "running"),
+            updated_at=self._now(),
+        )
+        await self._upsert(updated)
+        return updated
+
+    async def mark_status(self, plan_id: str, status: str) -> PlanCheckpoint | None:
+        checkpoint = await self.get(plan_id)
+        if checkpoint is None:
+            return None
+        updated = PlanCheckpoint(
+            plan_id=checkpoint.plan_id,
+            user_input=checkpoint.user_input,
+            plan=checkpoint.plan,
+            results=checkpoint.results,
+            completed_count=checkpoint.completed_count,
+            last_output=checkpoint.last_output,
+            snapshot_ids=checkpoint.snapshot_ids,
+            status=status,
+            updated_at=self._now(),
+        )
+        await self._upsert(updated)
+        return updated
+
+    async def get(self, plan_id: str) -> PlanCheckpoint | None:
+        await self.initialize()
+        async with aiosqlite.connect(self._db_file) as db:
+            cursor = await db.execute(
+                """
+                SELECT
+                    plan_id,
+                    user_input,
+                    plan_json,
+                    results_json,
+                    completed_count,
+                    last_output,
+                    snapshot_ids_json,
+                    status,
+                    updated_at
+                FROM workflow_checkpoints
+                WHERE plan_id = ?
+                """,
+                (plan_id,),
+            )
+            row = await cursor.fetchone()
+            await cursor.close()
+        if row is None:
+            return None
+        return self._from_row(row)
+
+    async def _upsert(self, checkpoint: PlanCheckpoint) -> None:
+        await self.initialize()
+        async with aiosqlite.connect(self._db_file) as db:
+            await db.execute(
+                """
+                INSERT INTO workflow_checkpoints (
+                    plan_id,
+                    user_input,
+                    plan_json,
+                    results_json,
+                    completed_count,
+                    last_output,
+                    snapshot_ids_json,
+                    status,
+                    updated_at
+                )
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(plan_id) DO UPDATE SET
+                    user_input = excluded.user_input,
+                    plan_json = excluded.plan_json,
+                    results_json = excluded.results_json,
+                    completed_count = excluded.completed_count,
+                    last_output = excluded.last_output,
+                    snapshot_ids_json = excluded.snapshot_ids_json,
+                    status = excluded.status,
+                    updated_at = excluded.updated_at
+                """,
+                self._to_row(checkpoint),
+            )
+            await db.commit()
+
+    @staticmethod
+    def _to_row(checkpoint: PlanCheckpoint) -> tuple[Any, ...]:
+        return (
+            checkpoint.plan_id,
+            checkpoint.user_input,
+            checkpoint.plan.model_dump_json(),
+            json.dumps([result.model_dump(mode="json") for result in checkpoint.results]),
+            checkpoint.completed_count,
+            checkpoint.last_output,
+            json.dumps(checkpoint.snapshot_ids),
+            checkpoint.status,
+            checkpoint.updated_at,
+        )
+
+    @staticmethod
+    def _from_row(row: tuple[Any, ...]) -> PlanCheckpoint:
+        results_raw = json.loads(row[3])
+        return PlanCheckpoint(
+            plan_id=row[0],
+            user_input=row[1],
+            plan=ActionPlan.model_validate_json(row[2]),
+            results=[ActionResult.model_validate(result) for result in results_raw],
+            completed_count=int(row[4]),
+            last_output=row[5],
+            snapshot_ids=list(json.loads(row[6])),
+            status=row[7],
+            updated_at=row[8],
+        )
+
+    @staticmethod
+    def _now() -> str:
+        return datetime.now(UTC).isoformat()

--- a/daemon/tests/test_workflow_checkpoints.py
+++ b/daemon/tests/test_workflow_checkpoints.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from pilot.actions import Action, ActionPlan, ActionResult, ActionType, NotifyParams, VerificationResult
+from pilot.config import PilotConfig
+from pilot.server import PilotServer
+from pilot.workflows.checkpoints import WorkflowCheckpointStore
+
+
+def _notify_action(message: str) -> Action:
+    return Action(
+        action_type=ActionType.NOTIFY,
+        target=message,
+        parameters=NotifyParams(summary="Test", body=message),
+    )
+
+
+@pytest.mark.asyncio
+async def test_checkpoint_store_round_trips_plan_results_and_resume_state(tmp_path):
+    store = WorkflowCheckpointStore(tmp_path / "checkpoints.db")
+    plan = ActionPlan(
+        actions=[_notify_action("one"), _notify_action("two")],
+        explanation="notify twice",
+        raw_input="send notifications",
+    )
+
+    await store.start_plan("plan-1", "send notifications", plan)
+    await store.record_result(
+        "plan-1",
+        ActionResult(action=plan.actions[0], success=True, output="first output", snapshot_id="snap-1"),
+    )
+
+    checkpoint = await store.get("plan-1")
+
+    assert checkpoint is not None
+    assert checkpoint.plan_id == "plan-1"
+    assert checkpoint.user_input == "send notifications"
+    assert checkpoint.completed_count == 1
+    assert checkpoint.last_output == "first output"
+    assert checkpoint.snapshot_ids == ["snap-1"]
+    assert checkpoint.plan.actions[1].target == "two"
+    assert checkpoint.results[0].output == "first output"
+    assert not checkpoint.is_complete
+
+
+@pytest.mark.asyncio
+async def test_resume_plan_skips_completed_actions_and_verifies_full_plan(tmp_path):
+    store = WorkflowCheckpointStore(tmp_path / "checkpoints.db")
+    plan = ActionPlan(
+        actions=[_notify_action("one"), _notify_action("two")],
+        explanation="notify twice",
+        raw_input="send notifications",
+    )
+    first_result = ActionResult(action=plan.actions[0], success=True, output="first output")
+    await store.start_plan("plan-1", "send notifications", plan)
+    await store.record_result("plan-1", first_result)
+
+    server = PilotServer(PilotConfig())
+    server._checkpoint_store = store
+    server._verifier = SimpleNamespace(
+        verify=AsyncMock(
+            return_value=VerificationResult(
+                passed=True,
+                details=["all actions completed"],
+                failed_actions=[],
+                rollback_triggered=False,
+            )
+        )
+    )
+
+    async def _execute(
+        remaining_plan,
+        *,
+        on_action_start,
+        on_action_complete,
+        cancel_event,
+        plan_id,
+        initial_last_output,
+    ):
+        assert plan_id == "plan-1"
+        assert initial_last_output == "first output"
+        assert [action.target for action in remaining_plan.actions] == ["two"]
+        result = ActionResult(action=remaining_plan.actions[0], success=True, output="second output")
+        await on_action_start(remaining_plan.actions[0])
+        await on_action_complete(result)
+        return [result]
+
+    server._executor = SimpleNamespace(execute=_execute)
+    ws = MagicMock()
+    ws.send = AsyncMock()
+
+    response = await server._handle_resume_plan({"plan_id": "plan-1"}, ws)
+    checkpoint = await store.get("plan-1")
+
+    assert response["status"] == "success"
+    assert response["resumed"] is True
+    assert response["skipped_actions"] == 1
+    assert response["executed_actions"] == 1
+    assert response["verification"]["passed"] is True
+    assert [result["output"] for result in response["results"]] == ["first output", "second output"]
+    assert checkpoint is not None
+    assert checkpoint.status == "complete"
+    assert checkpoint.completed_count == 2
+    server._verifier.verify.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_resume_plan_returns_success_when_checkpoint_already_complete(tmp_path):
+    store = WorkflowCheckpointStore(tmp_path / "checkpoints.db")
+    plan = ActionPlan(actions=[_notify_action("one")], explanation="done")
+    await store.start_plan("plan-1", "send notification", plan)
+    await store.record_result("plan-1", ActionResult(action=plan.actions[0], success=True, output="done"))
+    await store.mark_status("plan-1", "complete")
+
+    server = PilotServer(PilotConfig())
+    server._checkpoint_store = store
+    server._executor = SimpleNamespace(execute=AsyncMock())
+    ws = MagicMock()
+    ws.send = AsyncMock()
+
+    response = await server._handle_resume_plan({"plan_id": "plan-1"}, ws)
+
+    assert response["status"] == "success"
+    assert response["resumed"] is False
+    assert response["message"] == "Plan already completed."
+    server._executor.execute.assert_not_called()


### PR DESCRIPTION
## Summary
- add a SQLite-backed workflow checkpoint store that persists plan JSON, completed results, last output, snapshot IDs, status, and update time
- checkpoint successful actions during `execute` so long plans can recover after partial progress
- add a `resume_plan` JSON-RPC handler that skips completed actions, seeds prior output back into the executor, runs remaining steps, and verifies the full plan once resumed
- let `Executor.execute()` accept a stable plan ID and previous-output seed for safe resume execution
- add focused tests for checkpoint persistence, resume skipping behavior, verifier integration, and already-complete plans

Fixes #145

## Testing
- `python3 -m pytest tests/test_workflow_checkpoints.py -q` ✅ 3 passed
- `python3 -m pytest tests/test_workflow_checkpoints.py tests/test_ipc_integration.py::test_ipc_execute_flow_broadcast -q` ✅ 4 passed
- `python3 -m ruff check pilot/workflows/checkpoints.py pilot/agents/executor.py pilot/server.py tests/test_workflow_checkpoints.py` ✅
- `python3 -m ruff format --check pilot/workflows/checkpoints.py pilot/agents/executor.py pilot/server.py tests/test_workflow_checkpoints.py` ✅
- `python3 -m py_compile pilot/workflows/checkpoints.py pilot/agents/executor.py pilot/server.py tests/test_workflow_checkpoints.py` ✅
- `git diff --check` ✅

## GSSoC / NSoC Labels Requested
Please add `gssoc:approved`, `level:advanced`, `quality:exceptional`, `type:feature`, `type:architecture`, `nsoc26`, and `level3` if this is accepted.
