### PR TITLE
feat(ui): add Markdown syntax highlighting to Log View (#59)

### DIFF
--- a/tauri-app/ui/package-lock.json
+++ b/tauri-app/ui/package-lock.json
@@ -11,11 +11,15 @@
         "@tauri-apps/api": "^2.0.0",
         "@tauri-apps/plugin-clipboard-manager": "^2.0.0",
         "@tauri-apps/plugin-notification": "^2.0.0",
-        "lucide-svelte": "^0.577.0"
+        "dompurify": "^3.4.3",
+        "highlight.js": "^11.11.1",
+        "lucide-svelte": "^0.577.0",
+        "marked": "^18.0.3"
       },
       "devDependencies": {
         "@sveltejs/vite-plugin-svelte": "^5.0.0",
         "@tsconfig/svelte": "^5.0.0",
+        "@types/dompurify": "^3.0.5",
         "svelte": "^5.0.0",
         "svelte-check": "^4.0.0",
         "tslib": "^2.7.0",
@@ -875,7 +879,6 @@
       "integrity": "sha512-Y1Cs7hhTc+a5E9Va/xwKlAJoariQyHY+5zBgCZg4PFWNYQ1nMN9sjK1zhw1gK69DuqVP++sht/1GZg1aRwmAXQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@sveltejs/vite-plugin-svelte-inspector": "^4.0.1",
         "debug": "^4.4.1",
@@ -945,6 +948,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/dompurify": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/dompurify/-/dompurify-3.0.5.tgz",
+      "integrity": "sha512-1Wg0g3BtQF7sSb27fJQAKck1HECM6zV1EB66j8JH9i3LCjYabJa0FSdiSgsD5K/RbrsR0SiraKacLB+T8ZVYAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/trusted-types": "*"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -962,7 +975,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1046,6 +1058,15 @@
       "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.8.1.tgz",
       "integrity": "sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw==",
       "license": "MIT"
+    },
+    "node_modules/dompurify": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.3.tgz",
+      "integrity": "sha512-VVwJidIJcp1hpg2OMXML3ZVRPYSZiq4aX7qBh83BSIpOaRDqI+qxhXjjIWnpzkOXhmp0L81lnoME1mnCc9H48A==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
     },
     "node_modules/esbuild": {
       "version": "0.25.12",
@@ -1145,6 +1166,15 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/highlight.js": {
+      "version": "11.11.1",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.11.1.tgz",
+      "integrity": "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/is-reference": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-3.0.3.tgz",
@@ -1186,6 +1216,18 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/marked": {
+      "version": "18.0.3",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.3.tgz",
+      "integrity": "sha512-7VT90JOkDeaRWpfjOReRGPEKn0ecdARBkDGL+tT1wZY0efPPqkUxLUSmzy/C7TIylQYJC9STISEsCHrqb/7VIA==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
       }
     },
     "node_modules/mri": {
@@ -1237,7 +1279,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -1361,7 +1402,6 @@
       "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.55.7.tgz",
       "integrity": "sha512-ymI5ykLPwIHW839E053FQbI1G+jnRFJEw3Kv5Y4njixVWywQBx+NUFpkkKyk5LIb36Fg9DVXSYpqiGekLD0hyw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jridgewell/remapping": "^2.3.4",
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -1438,7 +1478,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -1453,7 +1492,6 @@
       "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",

--- a/tauri-app/ui/package.json
+++ b/tauri-app/ui/package.json
@@ -12,6 +12,7 @@
   "devDependencies": {
     "@sveltejs/vite-plugin-svelte": "^5.0.0",
     "@tsconfig/svelte": "^5.0.0",
+    "@types/dompurify": "^3.0.5",
     "svelte": "^5.0.0",
     "svelte-check": "^4.0.0",
     "tslib": "^2.7.0",
@@ -22,6 +23,9 @@
     "@tauri-apps/api": "^2.0.0",
     "@tauri-apps/plugin-clipboard-manager": "^2.0.0",
     "@tauri-apps/plugin-notification": "^2.0.0",
-    "lucide-svelte": "^0.577.0"
+    "dompurify": "^3.4.3",
+    "highlight.js": "^11.11.1",
+    "lucide-svelte": "^0.577.0",
+    "marked": "^18.0.3"
   }
 }

--- a/tauri-app/ui/src/App.svelte
+++ b/tauri-app/ui/src/App.svelte
@@ -1,3 +1,4 @@
+
 <script lang="ts">
   import CommandInput from "./lib/components/CommandInput.svelte";
   import ConfirmDialog from "./lib/components/ConfirmDialog.svelte";
@@ -20,6 +21,25 @@
   import { onDestroy, tick } from "svelte";
   import { writeText } from "@tauri-apps/plugin-clipboard-manager";
   import { Copy } from "lucide-svelte";
+  import { marked } from "marked";
+  import DOMPurify from "dompurify";
+  import { highlight } from "./lib/highlighter";
+
+  const renderer = new marked.Renderer();
+  renderer.code = function(code, language) {
+    const lang = language || "";
+    const result = highlight(code, lang);
+    const langLabel = result.language !== "plaintext" ? result.language : "";
+    const langBadge = langLabel ? `<span class="hlx-lang-badge">${langLabel}</span>` : "";
+    return `<div class="hlx-code-wrapper"><div class="hlx-code-header">${langBadge}<button class="hlx-copy-btn" data-        code="${encodeURIComponent(code)}">Copy</button></div><pre class="hlx-pre"><code class="hljs language-${result.language}">${result.value}         </code></pre></div>`;
+  };
+  marked.setOptions({ renderer, gfm: true, breaks: true });
+
+  function renderMarkdown(text) {
+    if (!text) return "";
+    const raw = marked.parse(text);
+    return DOMPurify.sanitize(raw);
+  }
 
   let activeTab: "chat" | "log" | "settings" | "plugins" = $state("chat");
   let isDragging = $state(false);
@@ -337,9 +357,11 @@
               </span>
             </div>
             {#if ar.success && ar.output}
-              <pre class="ar-output">{ar.output.trim()}</pre>
-            {/if}
-            {#if !ar.success && ar.error}
+  		<div class="ar-output">
+    		      {@html renderMarkdown(ar.output.trim())}
+  		</div>
+	    {/if}            
+	    {#if !ar.success && ar.error}
               <pre class="ar-error">{ar.error}</pre>
             {/if}
           </div>
@@ -393,7 +415,9 @@
   {:else}
     <div class="message system-msg has-copy">
       <span class="msg-label">HELIOX</span>
-      <span class="msg-text">{msg.text}</span>
+      <div class="msg-text">
+           {@html renderMarkdown(msg.text || "")}
+      </div>
       <button class="copy-button" type="button" aria-label="Copy message" title="Copy" onclick={() => copyMessage(msg)}>
         <Copy size={14} />
       </button>
@@ -933,5 +957,60 @@
     0%, 20% { content: "."; }
     40% { content: ".."; }
     60%, 100% { content: "..."; }
+  }
+  
+  .hlx-code-wrapper {
+    margin: 8px 0;
+    border-radius: var(--radius-sm);
+    overflow: hidden;
+    border: 1px solid var(--border);
+    background: #1a1a24;
+  }
+  .hlx-code-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 4px 10px;
+    background: rgba(0,0,0,0.3);
+    border-bottom: 1px solid var(--border);
+    min-height: 26px;
+  }
+  .hlx-lang-badge {
+    font-size: 10px;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--accent);
+    opacity: 0.85;
+  }
+  .hlx-copy-btn {
+    font-size: 10px;
+    padding: 2px 8px;
+    background: rgba(255,255,255,0.05);
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    color: var(--text-muted);
+    cursor: pointer;
+    font-family: var(--font-sans);
+    transition: all 0.15s;
+  }
+  .hlx-copy-btn:hover {
+    background: var(--accent-muted);
+    border-color: var(--accent);
+    color: var(--accent);
+  }
+  .hlx-pre {
+    margin: 0;
+    padding: 12px 14px;
+    overflow-x: auto;
+    font-size: 12px;
+    line-height: 1.6;
+    background: transparent;
+  }
+  .hlx-pre code {
+    font-family: var(--font-mono);
+    background: none;
+    border: none;
+    padding: 0;
   }
 </style>

--- a/tauri-app/ui/src/app.css
+++ b/tauri-app/ui/src/app.css
@@ -1,3 +1,4 @@
+@import './styles/highlight.css';
 :root {
   --bg-primary: #0f0f14;
   --bg-secondary: #16161e;

--- a/tauri-app/ui/src/components/LogMessage.svelte
+++ b/tauri-app/ui/src/components/LogMessage.svelte
@@ -1,0 +1,359 @@
+<!--
+  LogMessage.svelte
+  -----------------
+  Renders a single agent log message with full Markdown support and
+  syntax-highlighted code blocks.
+
+  Place at: tauri-app/ui/src/components/LogMessage.svelte
+
+  Props
+  ──────────────────────────────────────────────────────────────────────────
+  content   string   Raw message text (may contain Markdown)
+  role      string   "agent" | "user" | "system"
+  timestamp string   ISO timestamp string (optional)
+
+  Features
+  ──────────────────────────────────────────────────────────────────────────
+  • Parses full Markdown via marked.js
+  • Syntax highlights fenced code blocks via highlight.js (atom-one-dark)
+  • Auto-detects language when no language tag is present
+  • One-click copy button on every code block
+  • Sanitises HTML output with DOMPurify before injection (XSS safety)
+  • Graceful fallback: plain-text messages render without any markdown overhead
+  • Re-uses Heliox's existing clipboard Tauri command for the copy action
+-->
+
+<script lang="ts">
+  import { onMount, tick } from "svelte";
+  import { marked, type Renderer } from "marked";
+  import DOMPurify from "dompurify";
+  import { highlight } from "$lib/highlighter";
+  import { writeText } from "@tauri-apps/plugin-clipboard-manager";
+
+  // ── Props ────────────────────────────────────────────────────────────────
+  export let content: string = "";
+  export let role: "agent" | "user" | "system" = "agent";
+  export let timestamp: string = "";
+
+  // ── State ────────────────────────────────────────────────────────────────
+  let renderedHtml = "";
+  let messageEl: HTMLElement;
+  /** Tracks which code block UIDs have been copied (for button feedback) */
+  let copiedBlocks = new Set<string>();
+
+  // ── Markdown detection ───────────────────────────────────────────────────
+  /**
+   * Only run through the full marked pipeline when the message actually
+   * contains Markdown constructs. Plain-text messages skip the parser
+   * entirely to avoid unnecessary work.
+   */
+  function looksLikeMarkdown(text: string): boolean {
+    return (
+      text.includes("```") ||
+      text.includes("`") ||
+      text.includes("**") ||
+      text.includes("# ") ||
+      text.includes("- ") ||
+      text.includes("1. ") ||
+      text.includes("[") ||
+      text.includes("> ")
+    );
+  }
+
+  // ── Custom marked renderer ────────────────────────────────────────────────
+  /**
+   * Override the code block renderer so highlight.js handles colouring and
+   * we inject our copy-button wrapper around each block.
+   */
+  function buildRenderer(): Partial<Renderer> {
+    return {
+      code(code: string, language: string | undefined): string {
+        const lang = language ?? "";
+        const { value: highlighted, language: detected } = highlight(code, lang);
+
+        // Stable UID for this block (used by the copy handler)
+        const uid = `hlx-${Math.random().toString(36).slice(2, 9)}`;
+
+        const langLabel = detected !== "plaintext" ? detected : "";
+        const langBadge = langLabel
+          ? `<span class="hlx-lang-badge">${langLabel}</span>`
+          : "";
+
+        return `
+          <div class="hlx-code-wrapper" data-uid="${uid}">
+            <div class="hlx-code-header">
+              ${langBadge}
+              <button
+                class="hlx-copy-btn"
+                data-uid="${uid}"
+                data-code="${encodeURIComponent(code)}"
+                aria-label="Copy code to clipboard"
+                title="Copy"
+              >
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none"
+                     stroke="currentColor" stroke-width="2"
+                     stroke-linecap="round" stroke-linejoin="round">
+                  <rect x="9" y="9" width="13" height="13" rx="2" ry="2"/>
+                  <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/>
+                </svg>
+                <span class="hlx-copy-label">Copy</span>
+              </button>
+            </div>
+            <pre class="hlx-pre"><code class="hljs language-${detected}">${highlighted}</code></pre>
+          </div>
+        `;
+      },
+    };
+  }
+
+  // ── Render pipeline ──────────────────────────────────────────────────────
+  async function render(text: string): Promise<string> {
+    if (!text) return "";
+
+    if (!looksLikeMarkdown(text)) {
+      // Fast path: escape HTML and return plain text
+      return text
+        .replace(/&/g, "&amp;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;");
+    }
+
+    marked.use({
+      renderer: buildRenderer() as Renderer,
+      gfm: true,        // GitHub Flavored Markdown
+      breaks: true,     // Single newlines become <br>
+    });
+
+    const raw = await marked.parse(text);
+
+    // Sanitise with DOMPurify — defence-in-depth even for local agent output
+    return DOMPurify.sanitize(raw, {
+      ADD_TAGS: ["svg", "path", "rect"],
+      ADD_ATTR: [
+        "viewBox", "fill", "stroke", "stroke-width",
+        "stroke-linecap", "stroke-linejoin",
+        "width", "height", "x", "y", "rx", "ry", "d",
+        "data-uid", "data-code",
+      ],
+    });
+  }
+
+  // ── Copy handler ─────────────────────────────────────────────────────────
+  async function handleCopyClick(e: MouseEvent): Promise<void> {
+    const btn = (e.target as HTMLElement).closest<HTMLButtonElement>(".hlx-copy-btn");
+    if (!btn) return;
+
+    const encoded = btn.dataset.code ?? "";
+    const uid     = btn.dataset.uid ?? "";
+    const code    = decodeURIComponent(encoded);
+
+    try {
+      // Use Tauri's clipboard API (matches existing Heliox clipboard_write action)
+      await writeText(code);
+    } catch {
+      // Fallback for browser dev mode (npm run dev without Tauri shell)
+      await navigator.clipboard.writeText(code);
+    }
+
+    copiedBlocks.add(uid);
+    copiedBlocks = copiedBlocks; // trigger Svelte reactivity
+
+    const label = btn.querySelector<HTMLSpanElement>(".hlx-copy-label");
+    if (label) label.textContent = "Copied!";
+
+    setTimeout(() => {
+      copiedBlocks.delete(uid);
+      copiedBlocks = copiedBlocks;
+      if (label) label.textContent = "Copy";
+    }, 2000);
+  }
+
+  // ── Lifecycle ────────────────────────────────────────────────────────────
+  onMount(async () => {
+    renderedHtml = await render(content);
+    await tick();
+    // Attach click delegation on the message container
+    messageEl?.addEventListener("click", handleCopyClick);
+  });
+
+  // Re-render if content prop changes (streaming messages)
+  $: (async () => {
+    renderedHtml = await render(content);
+  })();
+</script>
+
+<!-- ── Template ─────────────────────────────────────────────────────────── -->
+<div
+  class="hlx-message hlx-message--{role}"
+  bind:this={messageEl}
+>
+  {#if timestamp}
+    <span class="hlx-timestamp">{new Date(timestamp).toLocaleTimeString()}</span>
+  {/if}
+
+  <!-- svelte-ignore a11y-no-static-element-interactions -->
+  <div
+    class="hlx-content"
+    role="log"
+    aria-live="polite"
+  >
+    <!-- eslint-disable-next-line svelte/no-at-html-tags -->
+    {@html renderedHtml}
+  </div>
+</div>
+
+<!-- ── Styles ────────────────────────────────────────────────────────────── -->
+<style>
+  /* ── Message wrapper ──────────────────────────────────────────────────── */
+  .hlx-message {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    padding: 6px 0;
+    font-family: "JetBrains Mono", "Fira Code", "Cascadia Code", monospace;
+    font-size: 13px;
+    line-height: 1.6;
+    color: var(--color-text, #e2e8f0);
+  }
+
+  .hlx-message--agent  { border-left: 2px solid var(--accent); padding-left: 10px; }
+  .hlx-message--user   { border-left: 2px solid var(--color-muted,  #64748b); padding-left: 10px; }
+  .hlx-message--system { border-left: 2px solid var(--color-warn,   #f59e0b); padding-left: 10px; opacity: 0.75; }
+
+  .hlx-timestamp {
+    font-size: 10px;
+    color: var(--color-muted, #64748b);
+    letter-spacing: 0.04em;
+  }
+
+  /* ── Prose ────────────────────────────────────────────────────────────── */
+  .hlx-content :global(p)      { margin: 4px 0; }
+  .hlx-content :global(ul),
+  .hlx-content :global(ol)     { margin: 4px 0; padding-left: 20px; }
+  .hlx-content :global(li)     { margin: 2px 0; }
+  .hlx-content :global(strong) { color: var(--accent); }
+  .hlx-content :global(em)     { color: var(--color-text-dim, #94a3b8); }
+  .hlx-content :global(a)      { color: var(--color-link, #7dd3fc); text-decoration: underline; }
+
+  /* Inline code */
+  .hlx-content :global(:not(pre) > code) {
+    background: rgba(255, 255, 255, 0.07);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    border-radius: 3px;
+    padding: 1px 5px;
+    font-size: 12px;
+    color: var(--color-inline-code, #f472b6);
+    font-family: inherit;
+  }
+
+  /* Blockquote */
+  .hlx-content :global(blockquote) {
+    margin: 6px 0;
+    padding: 4px 12px;
+    border-left: 3px solid var(--accent);
+    background: rgba(56, 189, 248, 0.06);
+    color: var(--color-text-dim, #94a3b8);
+    font-style: italic;
+  }
+
+  /* Tables */
+  .hlx-content :global(table) {
+    border-collapse: collapse;
+    width: 100%;
+    margin: 8px 0;
+    font-size: 12px;
+  }
+  .hlx-content :global(th),
+  .hlx-content :global(td) {
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    padding: 5px 10px;
+    text-align: left;
+  }
+  .hlx-content :global(th) {
+    background: rgba(255, 255, 255, 0.05);
+    color: var(--accent);
+    font-weight: 600;
+  }
+
+  /* ── Code block wrapper ────────────────────────────────────────────────── */
+  .hlx-content :global(.hlx-code-wrapper) {
+    margin: 10px 0;
+    border-radius: 6px;
+    overflow: hidden;
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    background: #282c34; /* atom-one-dark base */
+  }
+
+  /* Header bar (lang badge + copy button) */
+  .hlx-content :global(.hlx-code-header) {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 4px 10px;
+    background: rgba(0, 0, 0, 0.25);
+    border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+    min-height: 28px;
+  }
+
+  .hlx-content :global(.hlx-lang-badge) {
+    font-size: 10px;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--accent);
+    opacity: 0.8;
+  }
+
+  /* Copy button */
+  .hlx-content :global(.hlx-copy-btn) {
+    display: flex;
+    align-items: center;
+    gap: 5px;
+    padding: 3px 8px;
+    background: rgba(255, 255, 255, 0.06);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    border-radius: 4px;
+    color: var(--color-text-dim, #94a3b8);
+    font-size: 11px;
+    font-family: inherit;
+    cursor: pointer;
+    transition: background 0.15s, color 0.15s, border-color 0.15s;
+    line-height: 1;
+  }
+  .hlx-content :global(.hlx-copy-btn:hover) {
+    background: rgba(56, 189, 248, 0.12);
+    border-color: rgba(56, 189, 248, 0.3);
+    color: var(--accent);
+  }
+  .hlx-content :global(.hlx-copy-btn:active) {
+    transform: scale(0.96);
+  }
+
+  /* Highlighted <pre> block */
+  .hlx-content :global(.hlx-pre) {
+    margin: 0;
+    padding: 14px 16px;
+    overflow-x: auto;
+    font-size: 12.5px;
+    line-height: 1.65;
+    background: transparent;
+
+    /* Custom scrollbar to match dark UI */
+    scrollbar-width: thin;
+    scrollbar-color: rgba(255,255,255,0.15) transparent;
+  }
+  .hlx-content :global(.hlx-pre::-webkit-scrollbar) { height: 5px; }
+  .hlx-content :global(.hlx-pre::-webkit-scrollbar-track) { background: transparent; }
+  .hlx-content :global(.hlx-pre::-webkit-scrollbar-thumb) {
+    background: rgba(255,255,255,0.15);
+    border-radius: 3px;
+  }
+
+  .hlx-content :global(.hlx-pre code) {
+    font-family: "JetBrains Mono", "Fira Code", "Cascadia Code", monospace;
+    background: none;
+    border: none;
+    padding: 0;
+    color: inherit;
+  }
+</style>

--- a/tauri-app/ui/src/lib/highlighter.ts
+++ b/tauri-app/ui/src/lib/highlighter.ts
@@ -1,0 +1,76 @@
+/**
+ * highlighter.ts
+ * --------------
+ * Thin wrapper around highlight.js that registers only the language packs
+ * relevant to Heliox OS agent output, keeping the bundle lean.
+ *
+ * Place at: tauri-app/ui/src/lib/highlighter.ts
+ */
+
+import hljs from "highlight.js/lib/core";
+
+// ── Language packs (add more here as needed) ──────────────────────────────
+import python     from "highlight.js/lib/languages/python";
+import javascript from "highlight.js/lib/languages/javascript";
+import typescript from "highlight.js/lib/languages/typescript";
+import json       from "highlight.js/lib/languages/json";
+import bash       from "highlight.js/lib/languages/bash";
+import shell      from "highlight.js/lib/languages/shell";
+import xml        from "highlight.js/lib/languages/xml";   // HTML / XML
+import css        from "highlight.js/lib/languages/css";
+import yaml       from "highlight.js/lib/languages/yaml";
+import toml       from "highlight.js/lib/languages/ini";   // hljs uses ini for TOML
+import powershell from "highlight.js/lib/languages/powershell";
+import plaintext  from "highlight.js/lib/languages/plaintext";
+
+hljs.registerLanguage("python",      python);
+hljs.registerLanguage("javascript",  javascript);
+hljs.registerLanguage("js",          javascript);
+hljs.registerLanguage("typescript",  typescript);
+hljs.registerLanguage("ts",          typescript);
+hljs.registerLanguage("json",        json);
+hljs.registerLanguage("bash",        bash);
+hljs.registerLanguage("sh",          bash);
+hljs.registerLanguage("shell",       shell);
+hljs.registerLanguage("xml",         xml);
+hljs.registerLanguage("html",        xml);
+hljs.registerLanguage("css",         css);
+hljs.registerLanguage("yaml",        yaml);
+hljs.registerLanguage("yml",         yaml);
+hljs.registerLanguage("toml",        toml);
+hljs.registerLanguage("powershell",  powershell);
+hljs.registerLanguage("ps1",         powershell);
+hljs.registerLanguage("plaintext",   plaintext);
+hljs.registerLanguage("text",        plaintext);
+
+export default hljs;
+
+/**
+ * Highlight a code string.
+ *
+ * @param code     Raw source code string.
+ * @param language Language tag from the fenced code block (may be empty/unknown).
+ * @returns        Object with `value` (highlighted HTML) and `language` (detected).
+ */
+export function highlight(
+  code: string,
+  language: string
+): { value: string; language: string } {
+  const lang = language.toLowerCase().trim();
+
+  // Known language → deterministic highlight
+  if (lang && hljs.getLanguage(lang)) {
+    const result = hljs.highlight(code, { language: lang, ignoreIllegals: true });
+    return { value: result.value, language: lang };
+  }
+
+  // Unknown / missing tag → auto-detect (handles raw JSON dumps etc.)
+  const result = hljs.highlightAuto(code, [
+    "python", "javascript", "typescript", "json",
+    "bash", "shell", "powershell", "yaml", "toml", "xml", "css",
+  ]);
+  return {
+    value: result.value,
+    language: result.language ?? "plaintext",
+  };
+}

--- a/tauri-app/ui/src/styles/highlight.css
+++ b/tauri-app/ui/src/styles/highlight.css
@@ -1,0 +1,90 @@
+/*
+ * highlight.css
+ * -------------
+ * Imports highlight.js's atom-one-dark theme and applies minor overrides
+ * to blend seamlessly with Heliox OS's Arc Reactor dark UI palette.
+ *
+ * Place at: tauri-app/ui/src/styles/highlight.css
+ * Import in: tauri-app/ui/src/app.css  (or main entry)
+ *
+ *   @import './styles/highlight.css';
+ */
+
+@import "highlight.js/styles/atom-one-dark.css";
+
+/* ── Heliox palette overrides ─────────────────────────────────────────────
+   atom-one-dark uses #282c34 as background which matches Heliox perfectly.
+   We only adjust a handful of tokens to align with the cyan accent (#7c6fe0)
+   used in the Arc Reactor UI.
+   ─────────────────────────────────────────────────────────────────────── */
+
+.hljs {
+  background: transparent; /* wrapper .hlx-code-wrapper sets the bg */
+  color: #abb2bf;
+}
+
+/* Keywords → Heliox cyan */
+.hljs-keyword,
+.hljs-selector-tag,
+.hljs-built_in,
+.hljs-name,
+.hljs-tag {
+  color: #7c6fe0;
+}
+
+/* Strings → soft green (matches Heliox terminal palette) */
+.hljs-string,
+.hljs-title,
+.hljs-section,
+.hljs-attribute,
+.hljs-literal,
+.hljs-template-tag,
+.hljs-template-variable,
+.hljs-type,
+.hljs-addition {
+  color: #86efac;
+}
+
+/* Numbers, booleans */
+.hljs-number,
+.hljs-symbol,
+.hljs-bullet,
+.hljs-variable,
+.hljs-constant {
+  color: #fb923c;
+}
+
+/* Comments → muted */
+.hljs-comment,
+.hljs-quote,
+.hljs-deletion,
+.hljs-meta {
+  color: #5c6370;
+  font-style: italic;
+}
+
+/* Functions / class names */
+.hljs-function .hljs-keyword,
+.hljs-class .hljs-keyword {
+  color: #c084fc;
+}
+
+.hljs-title.function_,
+.hljs-title.class_ {
+  color: #fbbf24;
+}
+
+/* JSON keys */
+.hljs-attr {
+  color: #7c6fe0;
+}
+
+/* Punctuation / operators */
+.hljs-punctuation,
+.hljs-operator {
+  color: #abb2bf;
+}
+
+/* Emphasis / strong inside comments */
+.hljs-emphasis { font-style: italic; }
+.hljs-strong   { font-weight: 700; }


### PR DESCRIPTION
## Summary
Closes #59

Integrates marked.js + highlight.js into the existing App.svelte to render 
agent code snippets and JSON structures with proper syntax highlighting 
instead of plain text.

## Changes
- `App.svelte` — added renderMarkdown() function, integrated into ar-output 
  and system message rendering via {@html}
- `highlighter.ts` — hljs core + 12 language packs, auto-detect for untagged blocks
- `highlight.css` — atom-one-dark theme tuned to Heliox purple accent (#7c6fe0)
- `app.css` — one-line import
- `LogMessage.svelte` — reusable message component for future use

## How to test
1. Start daemon: cd daemon && python -m pilot.server
2. Start frontend: cd tauri-app/ui && npm run dev
3. Send a prompt that returns a Python or JSON code block
4. Verify syntax highlighting renders with colors
5. Test a code block with no language tag — auto-detection kicks in

## Bundle impact
~56kb gzipped added (marked ~14kb, hljs core+langs ~35kb, DOMPurify ~7kb)

## No breaking changes
Pure frontend change — daemon, WebSocket format, and Python untouched.