### PR TITLE
feat: add WebSocket connection status indicator to header

### DIFF
--- a/tauri-app/ui/src/App.svelte
+++ b/tauri-app/ui/src/App.svelte
@@ -21,6 +21,7 @@
   import { writeText } from "@tauri-apps/plugin-clipboard-manager";
   import { Copy } from "lucide-svelte";
   import ScrollToBottom from "./lib/components/ScrollToBottom.svelte";
+  import ConnectionStatus from "./lib/components/ConnectionStatus.svelte";
 
   let activeTab: "chat" | "log" | "settings" | "plugins" = $state("chat");
   let isDragging = $state(false);
@@ -196,8 +197,9 @@
       <button class="tab" class:active={activeTab === "settings"} title="Open Settings" onclick={() => activeTab = "settings"}>Settings</button>
     </nav>
     <div class="titlebar-right">
-      <AmbientHUD />
-    </div>
+  <ConnectionStatus />
+  <AmbientHUD />
+</div>
   </header>
 
     <div class="content">

--- a/tauri-app/ui/src/lib/components/ConnectionStatus.svelte
+++ b/tauri-app/ui/src/lib/components/ConnectionStatus.svelte
@@ -1,0 +1,60 @@
+<script lang="ts">
+  import { session } from "../stores/session";
+
+  // Track if we were ever connected, to distinguish
+  // "reconnecting" (yellow) from "never connected" (red)
+  let wasConnected = false;
+
+  $: if ($session.daemonConnected) {
+    wasConnected = true;
+  }
+
+  // Dot color: green = connected, yellow = reconnecting, red = disconnected
+  $: dotColor = $session.daemonConnected
+    ? "dot-green"
+    : wasConnected
+    ? "dot-yellow"
+    : "dot-red";
+
+  // Tooltip text shown on hover
+  $: dotTitle = $session.daemonConnected
+    ? "Daemon connected"
+    : wasConnected
+    ? "Reconnecting to daemon..."
+    : "Daemon disconnected";
+</script>
+
+<div class="status-indicator" title={dotTitle}>
+  <div class="status-dot {dotColor}"></div>
+</div>
+
+<style>
+  .status-indicator {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    cursor: default;
+  }
+
+  .status-dot {
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    transition: background-color 0.4s ease;
+  }
+
+  .dot-green {
+    background-color: #22c55e;
+    box-shadow: 0 0 6px #22c55e88;
+  }
+
+  .dot-yellow {
+    background-color: #facc15;
+    box-shadow: 0 0 6px #facc1588;
+  }
+
+  .dot-red {
+    background-color: #ef4444;
+    box-shadow: 0 0 6px #ef444488;
+  }
+</style>


### PR DESCRIPTION
Added a small colored dot to the titlebar header that shows the user whether the app is connected to the Python daemon or not.

Problem:
There was zero visual feedback when the daemon went down or had not started yet. Users had no way to tell if the connection was working.

Solution:
Created a new ConnectionStatus.svelte component that reads from the existing session.daemonConnected store and displays a colored dot. Green means connected, yellow means reconnecting, red means disconnected. The dot has a smooth color transition and shows a tooltip on hover explaining the status.

The component is added to the titlebar-right section of the header in App.svelte.

Closes #134



