### PR TITLE
feat: terminal agent with persistent PTY sessions (closes #96)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ vault.enc
 test_*.py
 !daemon/tests/test_react_latency.py
 !daemon/tests/test_ipc_integration.py
+!daemon/tests/test_pty_session.py
 test_*.txt
 test_*.json
 test_*.html

--- a/daemon/pilot/actions.py
+++ b/daemon/pilot/actions.py
@@ -48,6 +48,7 @@ class ActionType(StrEnum):
     # -- Shell / command execution --
     SHELL_COMMAND = "shell_command"
     SHELL_SCRIPT = "shell_script"  # Run a multi-line script
+    PTY_EXEC = "pty_exec"  # Run command in a persistent PTY shell session
 
     # -- Open URL / Application / Notify (original) --
     OPEN_URL = "open_url"
@@ -359,6 +360,14 @@ class ShellScriptParams(BaseModel):
     elevated: bool = False
 
 
+class PtyExecParams(BaseModel):
+    """Run a command inside a persistent PTY shell session."""
+
+    session_id: str = "default"
+    command: str = ""
+    timeout: int = 30
+
+
 class OpenUrlParams(BaseModel):
     url: str = ""
 
@@ -620,6 +629,7 @@ ActionParameters = (
     | DBusParams
     | ShellCommandParams
     | ShellScriptParams
+    | PtyExecParams
     | OpenUrlParams
     | OpenApplicationParams
     | NotifyParams

--- a/daemon/pilot/agents/code_agent.py
+++ b/daemon/pilot/agents/code_agent.py
@@ -24,6 +24,7 @@ CODE_ACTION_TYPES: set[ActionType] = {
     ActionType.CODE_GENERATE_AND_RUN,
     ActionType.SHELL_COMMAND,
     ActionType.SHELL_SCRIPT,
+    ActionType.PTY_EXEC,
 }
 
 
@@ -51,6 +52,10 @@ class CodeAgent(BaseAgent):
             AgentCapability(
                 action_type=ActionType.SHELL_SCRIPT,
                 description="Run multi-line dev scripts",
+            ),
+            AgentCapability(
+                action_type=ActionType.PTY_EXEC,
+                description="Run a command in a persistent PTY shell session, preserving env and cwd",
             ),
         ]
 

--- a/daemon/pilot/agents/executor.py
+++ b/daemon/pilot/agents/executor.py
@@ -38,6 +38,7 @@ from pilot.actions import (
     PackageParams,
     PowerParams,
     ProcessParams,
+    PtyExecParams,
     RegistryParams,
     ScheduleParams,
     ScreenshotParams,
@@ -113,6 +114,7 @@ class Executor:
             # -- Shell commands --
             ActionType.SHELL_COMMAND: self._exec_shell_command,
             ActionType.SHELL_SCRIPT: self._exec_shell_script,
+            ActionType.PTY_EXEC: self._exec_pty_exec,
             # -- Open URL / App / Notify --
             ActionType.OPEN_URL: self._exec_open_url,
             ActionType.OPEN_APPLICATION: self._exec_open_application,
@@ -729,6 +731,13 @@ class Executor:
         if code != 0:
             raise RuntimeError(f"Script failed (exit {code}): {err.strip()}")
         return out
+
+    async def _exec_pty_exec(self, action: Action) -> str:
+        params: PtyExecParams = action.parameters  # type: ignore[assignment]
+        from pilot.system.pty_session import PtySessionManager
+
+        session = PtySessionManager.get_session(params.session_id)
+        return await session.exec(params.command, timeout=params.timeout)
 
     # ======================================================================
     # OPEN URL / APPLICATION / NOTIFY

--- a/daemon/pilot/server.py
+++ b/daemon/pilot/server.py
@@ -1817,6 +1817,9 @@ class PilotServer:
         # Unload TRIBE v2 model
         if self._tribe_engine and self._tribe_engine.is_loaded:
             self._tribe_engine.unload_model()
+        from pilot.system.pty_session import PtySessionManager
+
+        PtySessionManager.close_all()
         logger.info("Pilot daemon stopped")
 
     # ── Budget Tracking Handlers ──

--- a/daemon/pilot/system/pty_session.py
+++ b/daemon/pilot/system/pty_session.py
@@ -1,0 +1,200 @@
+"""Persistent PTY session management for the Terminal Agent.
+
+Wraps ptyprocess to maintain a live bash shell across multiple commands,
+preserving environment variables, working directory, and shell state.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import select
+import sys
+import time
+from typing import ClassVar
+
+logger = logging.getLogger("pilot.system.pty_session")
+
+_SENTINEL = "PILOT_PTY_DONE"
+_INIT_MARKER = "PILOT_INIT_READY"
+
+# One compound command so only ONE line is echoed by the terminal before
+# stty -echo takes effect.  Both the sentinel and the init marker are
+# assembled at runtime from two shell variables so neither string appears
+# as a contiguous literal in the echoed command line — preventing false-
+# positive matches inside _read_until before the actual output arrives.
+#
+# Echoed line will contain:  _P1=PILOT_; _P2=PTY_DONE  and  _A=PILOT_IN; _B=IT_READY
+# — neither "PILOT_PTY_DONE" nor "PILOT_INIT_READY" appears there.
+_INIT_CMD = (
+    "stty -echo; "
+    '_P1=PILOT_; _P2=PTY_DONE; export PS1="${_P1}${_P2} "; '
+    "export VIRTUAL_ENV_DISABLE_PROMPT=1; "
+    '_A=PILOT_IN; _B=IT_READY; echo "${_A}${_B}"\n'
+)
+
+
+class PtySession:
+    """A single persistent bash PTY session."""
+
+    def __init__(self) -> None:
+        import asyncio
+
+        self._proc: object = None  # ptyprocess.PtyProcess
+        self._lock = asyncio.Lock()
+        self._alive = False
+
+    # ------------------------------------------------------------------
+    # Blocking helpers — run in a thread via run_in_executor
+    # ------------------------------------------------------------------
+
+    def _read_until(self, marker: str, timeout: float) -> tuple[str, bool]:
+        """Read PTY output until marker appears or timeout expires.
+
+        Uses select() so reads never block longer than 0.1 s at a time,
+        making the overall deadline reliable without busy-looping.
+
+        Returns (accumulated_output, found_marker).
+        """
+        buf = b""
+        marker_b = marker.encode()
+        deadline = time.monotonic() + timeout
+        fd = self._proc.fd  # type: ignore[attr-defined]
+
+        while time.monotonic() < deadline:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                break
+            rlist, _, _ = select.select([fd], [], [], min(remaining, 0.1))
+            if not rlist:
+                continue
+            try:
+                chunk = os.read(fd, 4096)
+            except OSError:
+                self._alive = False
+                break
+            if chunk:
+                buf += chunk
+                if marker_b in buf:
+                    return buf.decode("utf-8", errors="replace"), True
+
+        return buf.decode("utf-8", errors="replace"), False
+
+    def _spawn(self) -> None:
+        import ptyprocess  # type: ignore[import-untyped]
+
+        env = {
+            **os.environ,
+            "TERM": "dumb",                      # no ANSI escape sequences
+            "BASH_ENV": "/dev/null",              # no ENV file
+            "VIRTUAL_ENV_DISABLE_PROMPT": "1",   # venv must not prepend to PS1
+        }
+
+        self._proc = ptyprocess.PtyProcess.spawn(
+            ["bash", "--norc", "--noprofile"],
+            env=env,
+        )
+        self._alive = True
+
+        self._proc.write(_INIT_CMD.encode())  # type: ignore[attr-defined]
+
+        # _INIT_MARKER appears in the actual echo output but NOT in the echoed
+        # command line (it's hidden behind $_M), so this won't match too early.
+        raw, found = self._read_until(_INIT_MARKER, timeout=10)
+        if not found:
+            raise RuntimeError("PTY session init timed out")
+
+        # Drain the sentinel prompt that follows PILOT_INIT_READY
+        if _SENTINEL not in raw:
+            self._read_until(_SENTINEL, timeout=5)
+
+    def _run_command(self, command: str, timeout: float) -> str:
+        self._proc.write((command + "\n").encode())  # type: ignore[attr-defined]
+        raw, found = self._read_until(_SENTINEL, timeout=timeout)
+
+        if not found:
+            # Interrupt and attempt to recover the session
+            try:
+                self._proc.write(b"\x03\n")  # Ctrl+C
+                self._read_until(_SENTINEL, timeout=3)
+            except Exception:
+                self._alive = False
+            return f"ERROR: command timed out after {timeout:.0f}s"
+
+        idx = raw.rfind(_SENTINEL)
+        output = raw[:idx].rstrip() if idx != -1 else raw.rstrip()
+        return output or "(no output)"
+
+    # ------------------------------------------------------------------
+    # Public async API
+    # ------------------------------------------------------------------
+
+    async def exec(self, command: str, timeout: int = 30) -> str:
+        """Send a command to the shell and return its output."""
+        import asyncio
+
+        loop = asyncio.get_event_loop()
+
+        async with self._lock:
+            if not self._alive or self._proc is None or not self._proc.isalive():  # type: ignore[attr-defined]
+                await loop.run_in_executor(None, self._spawn)
+
+            def _run() -> str:
+                return self._run_command(command, float(timeout))
+
+            # run_in_executor timeout is generous — _run_command self-limits via select
+            return await asyncio.wait_for(
+                loop.run_in_executor(None, _run),
+                timeout=timeout + 10,
+            )
+
+    def close(self) -> None:
+        if self._proc is not None:
+            try:
+                self._proc.write(b"exit\n")  # type: ignore[attr-defined]
+            except Exception:
+                pass
+            try:
+                self._proc.terminate(force=True)  # type: ignore[attr-defined]
+            except Exception:
+                pass
+            self._proc = None
+            self._alive = False
+
+    def is_alive(self) -> bool:
+        return (
+            self._alive
+            and self._proc is not None
+            and self._proc.isalive()  # type: ignore[attr-defined]
+        )
+
+
+class PtySessionManager:
+    """Singleton registry of named PTY sessions."""
+
+    _sessions: ClassVar[dict[str, PtySession]] = {}
+
+    @classmethod
+    def get_session(cls, session_id: str = "default") -> PtySession:
+        if sys.platform == "win32":
+            raise RuntimeError(
+                "PTY sessions are not supported on Windows; use SHELL_COMMAND instead"
+            )
+        if session_id not in cls._sessions or not cls._sessions[session_id].is_alive():
+            logger.info("Creating new PTY session: %s", session_id)
+            cls._sessions[session_id] = PtySession()
+        return cls._sessions[session_id]
+
+    @classmethod
+    def close_session(cls, session_id: str) -> None:
+        session = cls._sessions.pop(session_id, None)
+        if session:
+            session.close()
+            logger.info("Closed PTY session: %s", session_id)
+
+    @classmethod
+    def close_all(cls) -> None:
+        for session_id, session in list(cls._sessions.items()):
+            session.close()
+            logger.info("Closed PTY session: %s", session_id)
+        cls._sessions.clear()

--- a/daemon/pilot/system/pty_session.py
+++ b/daemon/pilot/system/pty_session.py
@@ -85,9 +85,9 @@ class PtySession:
 
         env = {
             **os.environ,
-            "TERM": "dumb",                      # no ANSI escape sequences
-            "BASH_ENV": "/dev/null",              # no ENV file
-            "VIRTUAL_ENV_DISABLE_PROMPT": "1",   # venv must not prepend to PS1
+            "TERM": "dumb",  # no ANSI escape sequences
+            "BASH_ENV": "/dev/null",  # no ENV file
+            "VIRTUAL_ENV_DISABLE_PROMPT": "1",  # venv must not prepend to PS1
         }
 
         self._proc = ptyprocess.PtyProcess.spawn(
@@ -163,9 +163,7 @@ class PtySession:
 
     def is_alive(self) -> bool:
         return (
-            self._alive
-            and self._proc is not None
-            and self._proc.isalive()  # type: ignore[attr-defined]
+            self._alive and self._proc is not None and self._proc.isalive()  # type: ignore[attr-defined]
         )
 
 
@@ -177,9 +175,7 @@ class PtySessionManager:
     @classmethod
     def get_session(cls, session_id: str = "default") -> PtySession:
         if sys.platform == "win32":
-            raise RuntimeError(
-                "PTY sessions are not supported on Windows; use SHELL_COMMAND instead"
-            )
+            raise RuntimeError("PTY sessions are not supported on Windows; use SHELL_COMMAND instead")
         if session_id not in cls._sessions or not cls._sessions[session_id].is_alive():
             logger.info("Creating new PTY session: %s", session_id)
             cls._sessions[session_id] = PtySession()

--- a/daemon/pyproject.toml
+++ b/daemon/pyproject.toml
@@ -45,6 +45,9 @@ vision = [
 browser = [
     "playwright>=1.40",
 ]
+pty = [
+    "ptyprocess>=0.7; sys_platform != 'win32'",
+]
 
 # Tier 2: Multipliers
 documents = [

--- a/daemon/tests/test_pty_session.py
+++ b/daemon/tests/test_pty_session.py
@@ -1,0 +1,73 @@
+"""Tests for persistent PTY session management."""
+
+import sys
+import warnings
+
+import pytest
+
+# forkpty() warning is a pytest multi-threading artefact; the daemon is single-threaded
+warnings.filterwarnings("ignore", message=".*forkpty.*", category=DeprecationWarning)
+
+if sys.platform == "win32":
+    pytest.skip("PTY sessions are Unix-only", allow_module_level=True)
+
+from pilot.system.pty_session import PtySession, PtySessionManager
+
+
+@pytest.fixture(autouse=True)
+def isolate_sessions():
+    """Reset the session registry between tests."""
+    PtySessionManager.close_all()
+    yield
+    PtySessionManager.close_all()
+
+
+async def test_session_exec_basic():
+    session = PtySession()
+    output = await session.exec("echo hello")
+    session.close()
+    assert "hello" in output
+
+
+async def test_session_state_persistence():
+    session = PtySession()
+    await session.exec("export PILOT_TEST_VAR=persistent")
+    output = await session.exec("echo $PILOT_TEST_VAR")
+    session.close()
+    assert "persistent" in output
+
+
+async def test_session_cwd_persistence():
+    session = PtySession()
+    await session.exec("cd /tmp")
+    output = await session.exec("pwd")
+    session.close()
+    assert "/tmp" in output
+
+
+async def test_separate_sessions_are_isolated():
+    session_a = PtySessionManager.get_session("a")
+    session_b = PtySessionManager.get_session("b")
+
+    await session_a.exec("export PILOT_ISOLATED=only_in_a")
+    output_b = await session_b.exec("echo ${PILOT_ISOLATED:-not_set}")
+
+    assert "only_in_a" not in output_b
+
+
+async def test_session_timeout():
+    session = PtySession()
+    output = await session.exec("sleep 60", timeout=1)
+    session.close()
+    assert "timed out" in output.lower() or "error" in output.lower()
+
+
+async def test_close_and_reopen():
+    session_id = "reopen_test"
+    session = PtySessionManager.get_session(session_id)
+    await session.exec("echo before_close")
+    PtySessionManager.close_session(session_id)
+
+    new_session = PtySessionManager.get_session(session_id)
+    output = await new_session.exec("echo after_reopen")
+    assert "after_reopen" in output

--- a/daemon/tests/test_pty_session.py
+++ b/daemon/tests/test_pty_session.py
@@ -5,13 +5,13 @@ import warnings
 
 import pytest
 
+from pilot.system.pty_session import PtySession, PtySessionManager
+
 # forkpty() warning is a pytest multi-threading artefact; the daemon is single-threaded
 warnings.filterwarnings("ignore", message=".*forkpty.*", category=DeprecationWarning)
 
 if sys.platform == "win32":
     pytest.skip("PTY sessions are Unix-only", allow_module_level=True)
-
-from pilot.system.pty_session import PtySession, PtySessionManager
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
## What this does

The CODE agent previously ran every command in a fresh subprocess, so shell state like environment variables, working directory, and shell functions was lost between calls. This PR fixes that by introducing persistent PTY sessions backed by `ptyprocess`.

Each session is a real `bash` process that stays alive for the lifetime of the daemon. Commands are sent into it one at a time and the shell remembers everything in between. Sessions are named (`default` or any custom ID) so multiple isolated shells can coexist.

## Changes

- `daemon/pilot/system/pty_session.py` (new) - `PtySession` and `PtySessionManager`. Uses `select()` for deadline-bounded reads so nothing blocks indefinitely. Timed-out commands send Ctrl+C and attempt session recovery. The sentinel prompt is assembled from shell variables at runtime so it never appears literally in the echoed command line, preventing false-positive matches.
- `daemon/pilot/actions.py` - new `PTY_EXEC` action type and `PtyExecParams` model
- `daemon/pilot/agents/executor.py` - dispatch handler for `PTY_EXEC`
- `daemon/pilot/agents/code_agent.py` - registers `PTY_EXEC` as a capability
- `daemon/pilot/server.py` - closes all open sessions cleanly on daemon shutdown
- `daemon/pyproject.toml` - adds `ptyprocess>=0.7` as optional dep under `[pty]` extra. Windows raises a clear error pointing to `SHELL_COMMAND` instead.
- `daemon/tests/test_pty_session.py` (new) - 6 tests covering basic exec, env var persistence, cwd persistence, session isolation, timeout recovery, and session restart

## Test plan

- [ ] `pytest tests/test_pty_session.py -v` passes (6/6)
- [ ] `pytest tests/ -v` passes with no regressions
- [ ] `ruff check pilot/` is clean

Closes #96