### PR TITLE
Validate daemon data directory on startup

### DIFF
--- a/daemon/pilot/config.py
+++ b/daemon/pilot/config.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import contextlib
 import logging
 import os
 import sys
+import tempfile
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
@@ -155,6 +157,10 @@ class PilotConfig:
 logger = logging.getLogger("pilot.config")
 
 
+class DataDirNotWritableError(RuntimeError):
+    """Raised when the daemon data directory cannot safely store runtime state."""
+
+
 def _validate_config_types(raw: dict) -> None:
     """Validate that the user's config has no typos and uses correct types."""
     expected_types = {
@@ -280,6 +286,49 @@ def _config_to_dict(config: PilotConfig) -> dict[str, Any]:
 
 
 def ensure_dirs() -> None:
-    """Create all required XDG directories."""
-    for d in (CONFIG_DIR, DATA_DIR, STATE_DIR, RUNTIME_DIR):
+    """Create and validate all required XDG directories."""
+    for d in (CONFIG_DIR, STATE_DIR, RUNTIME_DIR):
         d.mkdir(parents=True, exist_ok=True)
+    validate_data_dir_writable(DATA_DIR)
+
+
+def validate_data_dir_writable(data_dir: Path = DATA_DIR) -> None:
+    """Ensure the data directory can persist SQLite databases and audit files."""
+    if data_dir.exists() and not data_dir.is_dir():
+        message = f"DATA_DIR is not writable: {data_dir} exists but is not a directory"
+        logger.error(message)
+        raise DataDirNotWritableError(message)
+
+    try:
+        data_dir.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        message = f"DATA_DIR is not writable: failed to create {data_dir}: {exc}"
+        logger.error(message)
+        raise DataDirNotWritableError(message) from exc
+
+    if not data_dir.is_dir():
+        message = f"DATA_DIR is not writable: {data_dir} exists but is not a directory"
+        logger.error(message)
+        raise DataDirNotWritableError(message)
+
+    probe_path: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            prefix=".pilot-write-test-",
+            dir=data_dir,
+            delete=False,
+        ) as probe:
+            probe.write("ok")
+            probe.flush()
+            os.fsync(probe.fileno())
+            probe_path = Path(probe.name)
+    except OSError as exc:
+        message = f"DATA_DIR is not writable: failed write probe in {data_dir}: {exc}"
+        logger.error(message)
+        raise DataDirNotWritableError(message) from exc
+    finally:
+        if probe_path is not None:
+            with contextlib.suppress(OSError):
+                probe_path.unlink()

--- a/daemon/pilot/server.py
+++ b/daemon/pilot/server.py
@@ -21,7 +21,15 @@ import aiosqlite
 import websockets
 from websockets.asyncio.server import Server, ServerConnection
 
-from pilot.config import DATA_DIR, DB_FILE, LOG_FILE, STATE_DIR, PilotConfig, ensure_dirs
+from pilot.config import (
+    DATA_DIR,
+    DB_FILE,
+    LOG_FILE,
+    STATE_DIR,
+    DataDirNotWritableError,
+    PilotConfig,
+    ensure_dirs,
+)
 
 logger = logging.getLogger("pilot.server")
 
@@ -2766,8 +2774,13 @@ def _setup_logging() -> None:
 
 def main() -> None:
     """Entry point for the pilot-daemon command."""
-    ensure_dirs()
     _setup_logging()
+    try:
+        ensure_dirs()
+    except DataDirNotWritableError as exc:
+        logger.critical("Pilot daemon cannot start: %s", exc)
+        raise SystemExit(1) from exc
+
     config = PilotConfig.load()
     parser = argparse.ArgumentParser(prog="pilot.server")
     parser.add_argument("--dry-run", action="store_true", help="Simulate actions without executing them")

--- a/daemon/tests/test_data_dir_validation.py
+++ b/daemon/tests/test_data_dir_validation.py
@@ -1,0 +1,42 @@
+from pathlib import Path
+
+import pytest
+
+from pilot import config
+from pilot.config import DataDirNotWritableError, ensure_dirs, validate_data_dir_writable
+
+
+def test_validate_data_dir_writable_creates_and_probes_directory(tmp_path: Path) -> None:
+    data_dir = tmp_path / "pilot-data"
+
+    validate_data_dir_writable(data_dir)
+
+    assert data_dir.is_dir()
+    assert not list(data_dir.glob(".pilot-write-test-*"))
+
+
+def test_validate_data_dir_writable_rejects_file_path(tmp_path: Path) -> None:
+    data_dir = tmp_path / "pilot-data"
+    data_dir.write_text("not a directory", encoding="utf-8")
+
+    with pytest.raises(DataDirNotWritableError, match="not a directory"):
+        validate_data_dir_writable(data_dir)
+
+
+def test_ensure_dirs_validates_configured_data_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    config_dir = tmp_path / "config"
+    data_dir = tmp_path / "data"
+    state_dir = tmp_path / "state"
+    runtime_dir = tmp_path / "runtime"
+
+    monkeypatch.setattr(config, "CONFIG_DIR", config_dir)
+    monkeypatch.setattr(config, "DATA_DIR", data_dir)
+    monkeypatch.setattr(config, "STATE_DIR", state_dir)
+    monkeypatch.setattr(config, "RUNTIME_DIR", runtime_dir)
+
+    ensure_dirs()
+
+    assert config_dir.is_dir()
+    assert data_dir.is_dir()
+    assert state_dir.is_dir()
+    assert runtime_dir.is_dir()


### PR DESCRIPTION
## Summary
- add fast startup validation for the daemon `DATA_DIR`
- create/probe the data directory before SQLite/checkpoint/audit stores initialize
- log a clear critical startup error and exit cleanly when `DATA_DIR` is not usable
- add regression coverage for writable directories, file-path collisions, and `ensure_dirs()` validation wiring

Fixes #181

## Testing
- `PYTHONPATH=daemon /Users/saurabhkumarbajpaiai/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 -m pytest daemon/tests/test_data_dir_validation.py daemon/tests/test_workflow_checkpoints.py -q` ✅ 6 passed
- `PYTHONPATH=daemon /Users/saurabhkumarbajpaiai/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 -m ruff check daemon/pilot/config.py daemon/pilot/server.py daemon/tests/test_data_dir_validation.py` ✅
- `PYTHONPATH=daemon /Users/saurabhkumarbajpaiai/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 -m compileall daemon/pilot/config.py daemon/pilot/server.py daemon/tests/test_data_dir_validation.py` ✅
- `git diff --check` ✅

## GSSoC / NSoC Labels Requested
Please add `gssoc:approved`, `level:intermediate`, `quality:clean`, `type:bug`, `type:devops`, `nsoc26`, and `level2` if this PR meets the program criteria.
