### PR TITLE
Add diagnostics log export CLI

### DIFF
--- a/daemon/pilot/server.py
+++ b/daemon/pilot/server.py
@@ -12,8 +12,9 @@ import secrets
 import signal
 import sys
 import uuid
+import zipfile
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
@@ -21,7 +22,17 @@ import aiosqlite
 import websockets
 from websockets.asyncio.server import Server, ServerConnection
 
-from pilot.config import DATA_DIR, DB_FILE, LOG_FILE, STATE_DIR, PilotConfig, ensure_dirs
+from pilot.config import (
+    AUDIT_FILE,
+    CONFIG_FILE,
+    DATA_DIR,
+    DB_FILE,
+    LOG_FILE,
+    PERMISSION_AUDIT_DB_FILE,
+    STATE_DIR,
+    PilotConfig,
+    ensure_dirs,
+)
 
 logger = logging.getLogger("pilot.server")
 
@@ -2764,6 +2775,59 @@ def _setup_logging() -> None:
     )
 
 
+def _default_export_dir() -> Path:
+    desktop = Path.home() / "Desktop"
+    return desktop if desktop.exists() else Path.cwd()
+
+
+def _add_file_to_archive(archive: zipfile.ZipFile, path: Path, arcname: str) -> bool:
+    if not path.is_file():
+        return False
+    archive.write(path, arcname)
+    return True
+
+
+def export_logs_archive(destination_dir: Path | None = None) -> Path:
+    """Package logs and diagnostic state into a zip for issue reports."""
+    destination = destination_dir or _default_export_dir()
+    destination.mkdir(parents=True, exist_ok=True)
+    now = datetime.now(UTC)
+    timestamp = now.strftime("%Y%m%d-%H%M%S")
+    archive_path = destination / f"heliox-diagnostics-{timestamp}.zip"
+
+    included: list[str] = []
+    with zipfile.ZipFile(archive_path, "w", compression=zipfile.ZIP_DEFLATED) as archive:
+        if STATE_DIR.exists():
+            for path in sorted(STATE_DIR.rglob("*")):
+                if path.is_file():
+                    arcname = Path("logs") / path.relative_to(STATE_DIR)
+                    archive.write(path, arcname.as_posix())
+                    included.append(arcname.as_posix())
+
+        diagnostic_files = (
+            (CONFIG_FILE, "config/config.toml"),
+            (AUDIT_FILE, "audit/audit.jsonl"),
+            (PERMISSION_AUDIT_DB_FILE, "audit/permission_audit.db"),
+        )
+        for path, arcname in diagnostic_files:
+            if _add_file_to_archive(archive, path, arcname):
+                included.append(arcname)
+
+        manifest = {
+            "created_at": now.isoformat(timespec="seconds").replace("+00:00", "Z"),
+            "included_files": included,
+            "source_paths": {
+                "state_dir": str(STATE_DIR),
+                "config_file": str(CONFIG_FILE),
+                "audit_file": str(AUDIT_FILE),
+                "permission_audit_db": str(PERMISSION_AUDIT_DB_FILE),
+            },
+        }
+        archive.writestr("manifest.json", json.dumps(manifest, indent=2, sort_keys=True))
+
+    return archive_path
+
+
 def main() -> None:
     """Entry point for the pilot-daemon command."""
     ensure_dirs()
@@ -2771,7 +2835,16 @@ def main() -> None:
     config = PilotConfig.load()
     parser = argparse.ArgumentParser(prog="pilot.server")
     parser.add_argument("--dry-run", action="store_true", help="Simulate actions without executing them")
+    parser.add_argument(
+        "--export-logs",
+        action="store_true",
+        help="Create a diagnostics zip with logs, config, and audit trails, then exit",
+    )
     args, _ = parser.parse_known_args()
+    if args.export_logs:
+        archive_path = export_logs_archive()
+        print(f"Exported diagnostics archive: {archive_path}")
+        return
     if args.dry_run:
         config.security.dry_run = True
         logger.info("Dry-run mode enabled via CLI flag")

--- a/daemon/tests/test_export_logs_cli.py
+++ b/daemon/tests/test_export_logs_cli.py
@@ -1,0 +1,64 @@
+import json
+import zipfile
+
+from pilot import server
+
+
+def test_export_logs_archive_includes_logs_config_and_audit(monkeypatch, tmp_path):
+    state_dir = tmp_path / "state"
+    data_dir = tmp_path / "data"
+    config_dir = tmp_path / "config"
+    export_dir = tmp_path / "exports"
+
+    (state_dir / "nested").mkdir(parents=True)
+    data_dir.mkdir()
+    config_dir.mkdir()
+    (state_dir / "pilot.log").write_text("daemon log\n", encoding="utf-8")
+    (state_dir / "nested" / "trace.log").write_text("trace\n", encoding="utf-8")
+    config_file = config_dir / "config.toml"
+    audit_file = data_dir / "audit.jsonl"
+    permission_audit = data_dir / "permission_audit.db"
+    config_file.write_text("server = {}\n", encoding="utf-8")
+    audit_file.write_text('{"event":"start"}\n', encoding="utf-8")
+    permission_audit.write_bytes(b"sqlite")
+
+    monkeypatch.setattr(server, "STATE_DIR", state_dir)
+    monkeypatch.setattr(server, "CONFIG_FILE", config_file)
+    monkeypatch.setattr(server, "AUDIT_FILE", audit_file)
+    monkeypatch.setattr(server, "PERMISSION_AUDIT_DB_FILE", permission_audit)
+
+    archive_path = server.export_logs_archive(export_dir)
+
+    assert archive_path.parent == export_dir
+    assert archive_path.name.startswith("heliox-diagnostics-")
+    with zipfile.ZipFile(archive_path) as archive:
+        names = set(archive.namelist())
+        assert {
+            "logs/pilot.log",
+            "logs/nested/trace.log",
+            "config/config.toml",
+            "audit/audit.jsonl",
+            "audit/permission_audit.db",
+            "manifest.json",
+        }.issubset(names)
+        manifest = json.loads(archive.read("manifest.json"))
+
+    assert "logs/pilot.log" in manifest["included_files"]
+    assert manifest["source_paths"]["state_dir"] == str(state_dir)
+
+
+def test_export_logs_archive_succeeds_when_optional_files_are_missing(monkeypatch, tmp_path):
+    state_dir = tmp_path / "missing-state"
+    export_dir = tmp_path / "exports"
+    monkeypatch.setattr(server, "STATE_DIR", state_dir)
+    monkeypatch.setattr(server, "CONFIG_FILE", tmp_path / "missing.toml")
+    monkeypatch.setattr(server, "AUDIT_FILE", tmp_path / "missing-audit.jsonl")
+    monkeypatch.setattr(server, "PERMISSION_AUDIT_DB_FILE", tmp_path / "missing-audit.db")
+
+    archive_path = server.export_logs_archive(export_dir)
+
+    with zipfile.ZipFile(archive_path) as archive:
+        assert archive.namelist() == ["manifest.json"]
+        manifest = json.loads(archive.read("manifest.json"))
+
+    assert manifest["included_files"] == []


### PR DESCRIPTION
## Summary
- add `--export-logs` to create a diagnostics zip for bug reports
- include daemon state logs, `config.toml`, audit logs, permission audit DB, and a manifest with source paths
- fall back to the current working directory when Desktop is unavailable
- add regression tests for archive contents and missing optional files

Fixes #182

## Requested labels
- `gssoc:approved`
- `level:beginner` / `level1`
- `quality:clean`
- `type:feature`
- `type:devops`
- `nsoc26`

## Testing
- `PYTHONPATH=daemon /Users/saurabhkumarbajpaiai/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 -m pytest daemon/tests/test_export_logs_cli.py daemon/tests/test_workflow_checkpoints.py -q` ✅ 5 passed
- `/Users/saurabhkumarbajpaiai/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 -m ruff check daemon/pilot/server.py daemon/tests/test_export_logs_cli.py` ✅
- `PYTHONPATH=daemon /Users/saurabhkumarbajpaiai/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 -m compileall -q daemon/pilot/server.py daemon/tests/test_export_logs_cli.py` ✅
- `git diff --check` ✅
- Manual CLI smoke test with isolated XDG dirs and Desktop target ✅
