### PR TITLE
Add configurable memory WAL checkpointing

### DIFF
--- a/daemon/pilot/config.py
+++ b/daemon/pilot/config.py
@@ -95,6 +95,11 @@ class ScreenVisionConfig:
 
 
 @dataclass
+class MemoryConfig:
+    checkpoint_interval_seconds: int = 300
+
+
+@dataclass
 class Restrictions:
     protected_folders: list[str] = field(default_factory=list)
     protected_packages: list[str] = field(default_factory=list)
@@ -111,6 +116,7 @@ class PilotConfig:
     server: ServerConfig = field(default_factory=ServerConfig)
     voice: VoiceConfig = field(default_factory=VoiceConfig)
     screen_vision: ScreenVisionConfig = field(default_factory=ScreenVisionConfig)
+    memory: MemoryConfig = field(default_factory=MemoryConfig)
     restrictions: Restrictions = field(default_factory=Restrictions)
     first_run_complete: bool = False
 
@@ -199,6 +205,9 @@ def _validate_config_types(raw: dict) -> None:
         "screen_vision": {
             "capture_interval_seconds": (int, float),
         },
+        "memory": {
+            "checkpoint_interval_seconds": int,
+        },
     }
 
     for section, expected_keys in expected_types.items():
@@ -253,6 +262,11 @@ def _merge_config(config: PilotConfig, raw: dict[str, Any]) -> PilotConfig:
         for k, v in raw["screen_vision"].items():
             if hasattr(config.screen_vision, k):
                 setattr(config.screen_vision, k, float(v))
+
+    if "memory" in raw:
+        for k, v in raw["memory"].items():
+            if hasattr(config.memory, k):
+                setattr(config.memory, k, v)
 
     config.first_run_complete = raw.get(
         "first_run_complete",

--- a/daemon/pilot/memory/store.py
+++ b/daemon/pilot/memory/store.py
@@ -48,10 +48,12 @@ CREATE INDEX IF NOT EXISTS idx_prefs_key ON user_preferences(key);
 class MemoryStore:
     """Persistent memory with action history and semantic preference learning."""
 
-    def __init__(self) -> None:
+    def __init__(self, *, checkpoint_interval_seconds: int = 300) -> None:
         self._pool: AsyncSqlitePool | None = None
         self._chroma_collection: Any = None
         self._workspace_index = None
+        self._checkpoint_interval_seconds = checkpoint_interval_seconds
+        self._checkpoint_task: asyncio.Task[None] | None = None
 
     async def initialize(self) -> None:
         await aiofiles.os.makedirs(DATA_DIR, exist_ok=True)
@@ -62,6 +64,47 @@ class MemoryStore:
             await db.commit()
         await asyncio.to_thread(self._init_chroma)
         self._init_workspace_index()
+        self._start_periodic_checkpoint()
+
+    def _start_periodic_checkpoint(self) -> None:
+        if self._checkpoint_interval_seconds <= 0:
+            return
+        self._checkpoint_task = asyncio.create_task(self._periodic_checkpoint_loop())
+
+    async def _periodic_checkpoint_loop(self) -> None:
+        try:
+            while True:
+                await asyncio.sleep(self._checkpoint_interval_seconds)
+                try:
+                    await self.checkpoint()
+                except Exception:
+                    logger.exception("Periodic memory checkpoint failed")
+        except asyncio.CancelledError:
+            raise
+
+    async def checkpoint(self, *, mode: str = "TRUNCATE") -> dict[str, int | str]:
+        """Run a SQLite WAL checkpoint for the memory database."""
+        if not self._pool:
+            return {"status": "skipped", "reason": "memory store is not initialized"}
+
+        normalized_mode = mode.upper()
+        if normalized_mode not in {"PASSIVE", "FULL", "RESTART", "TRUNCATE"}:
+            raise ValueError("checkpoint mode must be PASSIVE, FULL, RESTART, or TRUNCATE")
+
+        async with self._pool.write() as db:
+            cursor = await db.execute(f"PRAGMA wal_checkpoint({normalized_mode})")
+            row = await cursor.fetchone()
+            await cursor.close()
+            await db.commit()
+
+        busy, log_frames, checkpointed_frames = row if row is not None else (0, 0, 0)
+        return {
+            "status": "ok",
+            "mode": normalized_mode,
+            "busy": int(busy),
+            "log_frames": int(log_frames),
+            "checkpointed_frames": int(checkpointed_frames),
+        }
 
     def _init_workspace_index(self) -> None:
         """Initialize the workspace RAG index."""
@@ -219,6 +262,14 @@ class MemoryStore:
         return await asyncio.to_thread(self._workspace_index.search, query, n_results)
 
     async def close(self) -> None:
+        if self._checkpoint_task:
+            self._checkpoint_task.cancel()
+            try:
+                await self._checkpoint_task
+            except asyncio.CancelledError:
+                pass
+            self._checkpoint_task = None
         if self._pool:
+            await self.checkpoint()
             await self._pool.close()
             self._pool = None

--- a/daemon/pilot/server.py
+++ b/daemon/pilot/server.py
@@ -171,7 +171,9 @@ class PilotServer:
         await self._checkpoint_store.initialize()
         validator = ActionValidator(self.config)
         permissions = PermissionChecker(self.config)
-        self._memory = MemoryStore()
+        self._memory = MemoryStore(
+            checkpoint_interval_seconds=self.config.memory.checkpoint_interval_seconds,
+        )
         await self._memory.initialize()
 
         self._planner = Planner(model_router, self._memory)
@@ -345,6 +347,7 @@ class PilotServer:
             "get_config": self._handle_get_config,
             "update_config": self._handle_update_config,
             "get_history": self._handle_get_history,
+            "memory_checkpoint": self._handle_memory_checkpoint,
             "store_api_key": self._handle_store_api_key,
             "delete_api_key": self._handle_delete_api_key,
             "list_api_keys": self._handle_list_api_keys,
@@ -1346,6 +1349,11 @@ class PilotServer:
         offset = params.get("offset", 0)
         entries = await self._memory.get_history(limit=limit, offset=offset)
         return {"entries": entries}
+
+    async def _handle_memory_checkpoint(self, params: dict, ws: ServerConnection) -> dict:
+        """Run a manual WAL checkpoint for the memory database."""
+        mode = str(params.get("mode", "TRUNCATE"))
+        return await self._memory.checkpoint(mode=mode)
 
     async def _handle_export_session_chat(self, params: dict, ws: ServerConnection) -> dict:
         """Export current UI session chat messages to JSON or CSV."""

--- a/daemon/tests/test_memory_store.py
+++ b/daemon/tests/test_memory_store.py
@@ -207,6 +207,33 @@ class TestRecord:
         assert len(called) >= 1
 
 
+class TestCheckpoint:
+    @pytest.mark.asyncio
+    async def test_checkpoint_returns_sqlite_wal_stats(self, store, fake_plan, fake_results):
+        """checkpoint() runs PRAGMA wal_checkpoint and returns normalized stats."""
+        with patch("pilot.memory.store.asyncio.to_thread", new_callable=AsyncMock):
+            await store.record("checkpoint me", fake_plan, fake_results)
+
+        result = await store.checkpoint()
+
+        assert result["status"] == "ok"
+        assert result["mode"] == "TRUNCATE"
+        assert {"busy", "log_frames", "checkpointed_frames"}.issubset(result)
+
+    @pytest.mark.asyncio
+    async def test_checkpoint_skips_when_store_is_not_initialized(self):
+        """checkpoint() is safe before initialize() wires the SQLite pool."""
+        result = await MemoryStore().checkpoint()
+
+        assert result == {"status": "skipped", "reason": "memory store is not initialized"}
+
+    @pytest.mark.asyncio
+    async def test_checkpoint_rejects_unknown_mode(self, store):
+        """checkpoint() only accepts SQLite WAL checkpoint modes."""
+        with pytest.raises(ValueError, match="checkpoint mode"):
+            await store.checkpoint(mode="VACUUM")
+
+
 # ---------------------------------------------------------------------------
 # Tests: get_history()
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add a configurable `[memory] checkpoint_interval_seconds` setting with a 5 minute default
- run periodic SQLite WAL checkpoints from `MemoryStore` and checkpoint once more on shutdown
- expose a `memory_checkpoint` JSON-RPC handler for manual checkpoint triggers
- add regression tests for checkpoint stats, uninitialized stores, and invalid modes

Fixes #139

## Requested labels
- `gssoc:approved`
- `level:intermediate` / `level2`
- `quality:clean`
- `type:devops`
- `type:feature`
- `nsoc26`

## Testing
- `PYTHONPATH=daemon /Users/saurabhkumarbajpaiai/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 -m pytest daemon/tests/test_memory_store.py daemon/tests/test_sqlite_pool.py -q` ✅ 35 passed
- `/Users/saurabhkumarbajpaiai/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 -m ruff check daemon/pilot/config.py daemon/pilot/memory/store.py daemon/pilot/server.py daemon/tests/test_memory_store.py` ✅
- `PYTHONPATH=daemon /Users/saurabhkumarbajpaiai/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 -m compileall -q daemon/pilot/config.py daemon/pilot/memory/store.py daemon/pilot/server.py daemon/tests/test_memory_store.py` ✅
- `git diff --check` ✅
