### PR TITLE
feat: RSS/Atom feed polling agent with background news summarization

### DIFF
--- a/daemon/pilot/agents/base_agent.py
+++ b/daemon/pilot/agents/base_agent.py
@@ -49,6 +49,7 @@ class AgentRole(StrEnum):
     WEB = "web_agent"
     MONITOR = "monitor_agent"
     COMMUNICATION = "comm_agent"
+    RSS = "rss_agent"
     ORCHESTRATOR = "orchestrator"
     GENERAL = "general"
 

--- a/daemon/pilot/agents/rss_agent.py
+++ b/daemon/pilot/agents/rss_agent.py
@@ -1,4 +1,5 @@
 """RSS/Atom feed polling agent with background news summarization."""
+
 from __future__ import annotations
 
 import logging
@@ -86,11 +87,13 @@ class RssAgent(BaseAgent):
             digest = await self._memory.get_preference(key)
             if digest:
                 return [ActionResult(action_type=ActionType.API_REQUEST, success=True, output=digest)]
-            return [ActionResult(
-                action_type=ActionType.API_REQUEST,
-                success=False,
-                output="No RSS digest available for today. Try 'summarize feeds now' to fetch one.",
-            )]
+            return [
+                ActionResult(
+                    action_type=ActionType.API_REQUEST,
+                    success=False,
+                    output="No RSS digest available for today. Try 'summarize feeds now' to fetch one.",
+                )
+            ]
 
         if "summarize" in lower or "fetch" in lower or "poll" in lower:
             result = await self._poll_feeds()
@@ -101,41 +104,51 @@ class RssAgent(BaseAgent):
             words = user_input.split()
             urls = [w for w in words if w.startswith("http")]
             if not urls:
-                return [ActionResult(
-                    action_type=ActionType.API_REQUEST,
-                    success=False,
-                    output="Please provide a feed URL to subscribe to.",
-                )]
+                return [
+                    ActionResult(
+                        action_type=ActionType.API_REQUEST,
+                        success=False,
+                        output="Please provide a feed URL to subscribe to.",
+                    )
+                ]
             self._config.rss.feeds.extend(urls)
             if not self._config.rss.enabled:
                 self._config.rss.enabled = True
                 self._register_background_task()
             self._config.save()
-            return [ActionResult(
-                action_type=ActionType.API_REQUEST,
-                success=True,
-                output=f"Subscribed to: {', '.join(urls)}",
-            )]
+            return [
+                ActionResult(
+                    action_type=ActionType.API_REQUEST,
+                    success=True,
+                    output=f"Subscribed to: {', '.join(urls)}",
+                )
+            ]
 
         if "list" in lower or "feeds" in lower:
             feeds = self._config.rss.feeds
             if not feeds:
-                return [ActionResult(
+                return [
+                    ActionResult(
+                        action_type=ActionType.API_REQUEST,
+                        success=True,
+                        output="No feeds subscribed yet.",
+                    )
+                ]
+            return [
+                ActionResult(
                     action_type=ActionType.API_REQUEST,
                     success=True,
-                    output="No feeds subscribed yet.",
-                )]
-            return [ActionResult(
-                action_type=ActionType.API_REQUEST,
-                success=True,
-                output="Subscribed feeds:\n" + "\n".join(f"  - {f}" for f in feeds),
-            )]
+                    output="Subscribed feeds:\n" + "\n".join(f"  - {f}" for f in feeds),
+                )
+            ]
 
-        return [ActionResult(
-            action_type=ActionType.API_REQUEST,
-            success=False,
-            output="RSS Agent: unrecognized request. Try 'show today's digest', 'list my feeds', or 'subscribe to <url>'.",
-        )]
+        return [
+            ActionResult(
+                action_type=ActionType.API_REQUEST,
+                success=False,
+                output="RSS Agent: unrecognized request. Try 'show today's digest', 'list my feeds', or 'subscribe to <url>'.",
+            )
+        ]
 
     # ------------------------------------------------------------------
     # Background task
@@ -143,17 +156,22 @@ class RssAgent(BaseAgent):
 
     def _register_background_task(self) -> None:
         interval = self._config.rss.poll_interval_hours * 3600
-        self._bg.register(BackgroundTask(
-            task_id="rss_feed_poller",
-            name="RSS Feed Poller",
-            description="Polls subscribed RSS/Atom feeds and stores daily summaries",
-            interval_seconds=interval,
-            action_fn=self._poll_feeds,
-            on_trigger=self._on_new_digest,
-        ))
+        self._bg.register(
+            BackgroundTask(
+                task_id="rss_feed_poller",
+                name="RSS Feed Poller",
+                description="Polls subscribed RSS/Atom feeds and stores daily summaries",
+                interval_seconds=interval,
+                action_fn=self._poll_feeds,
+                on_trigger=self._on_new_digest,
+            )
+        )
         self._bg.start("rss_feed_poller")
-        logger.info("RSS Feed Poller registered (%d feeds, %.1fh interval)",
-                    len(self._config.rss.feeds), self._config.rss.poll_interval_hours)
+        logger.info(
+            "RSS Feed Poller registered (%d feeds, %.1fh interval)",
+            len(self._config.rss.feeds),
+            self._config.rss.poll_interval_hours,
+        )
 
     async def _poll_feeds(self) -> dict[str, Any]:
         items: list[str] = []

--- a/daemon/pilot/agents/rss_agent.py
+++ b/daemon/pilot/agents/rss_agent.py
@@ -1,0 +1,238 @@
+"""RSS/Atom feed polling agent with background news summarization."""
+from __future__ import annotations
+
+import logging
+from datetime import date
+from typing import TYPE_CHECKING, Any
+from xml.etree import ElementTree
+
+import httpx
+
+from pilot.actions import ActionPlan, ActionResult, ActionType
+from pilot.agents.background import BackgroundTask
+from pilot.agents.base_agent import AgentCapability, AgentRole, BaseAgent
+
+if TYPE_CHECKING:
+    from pilot.agents.background import BackgroundTaskManager
+    from pilot.config import PilotConfig
+    from pilot.memory.store import MemoryStore
+    from pilot.models.router import ModelRouter
+
+logger = logging.getLogger("pilot.agents.rss_agent")
+
+_ATOM_NS = "http://www.w3.org/2005/Atom"
+_FETCH_TIMEOUT = 10.0
+
+_SUMMARIZE_PROMPT = """\
+You are a news digest assistant. Summarize the following RSS feed items in under 300 words.
+Group related stories, highlight the most important developments, and keep the language concise.
+
+Feed items:
+{items}
+
+Write the summary as plain text paragraphs, no bullet points or markdown."""
+
+
+class RssAgent(BaseAgent):
+    """Periodically polls subscribed RSS/Atom feeds and stores daily digests in MemoryStore."""
+
+    def __init__(
+        self,
+        model_router: ModelRouter,
+        memory: MemoryStore,
+        config: PilotConfig,
+        background_manager: BackgroundTaskManager,
+    ) -> None:
+        super().__init__(role=AgentRole.RSS, model_router=model_router)
+        self._memory = memory
+        self._config = config
+        self._bg = background_manager
+
+        if config.rss.enabled and config.rss.feeds:
+            self._register_background_task()
+
+    # ------------------------------------------------------------------
+    # BaseAgent interface
+    # ------------------------------------------------------------------
+
+    def get_capabilities(self) -> list[AgentCapability]:
+        return [
+            AgentCapability(
+                action_type=ActionType.API_REQUEST,
+                description="Poll RSS/Atom feeds and return news summaries",
+            ),
+        ]
+
+    def get_system_prompt(self) -> str:
+        return (
+            "You are the RSS AGENT for Heliox OS. "
+            "You manage RSS and Atom feed subscriptions, poll them periodically, "
+            "and produce concise daily news digests stored in long-term memory."
+        )
+
+    def can_handle(self, action_type: ActionType) -> bool:
+        return action_type == ActionType.API_REQUEST
+
+    async def handle_task(
+        self,
+        user_input: str,
+        plan: ActionPlan,
+        context: dict[str, Any] | None = None,
+    ) -> list[ActionResult]:
+        lower = user_input.lower()
+
+        if any(k in lower for k in ["today", "digest", "summary", "headlines"]):
+            key = f"rss_digest_{date.today().isoformat()}"
+            digest = await self._memory.get_preference(key)
+            if digest:
+                return [ActionResult(action_type=ActionType.API_REQUEST, success=True, output=digest)]
+            return [ActionResult(
+                action_type=ActionType.API_REQUEST,
+                success=False,
+                output="No RSS digest available for today. Try 'summarize feeds now' to fetch one.",
+            )]
+
+        if "summarize" in lower or "fetch" in lower or "poll" in lower:
+            result = await self._poll_feeds()
+            digest = result.get("digest", "No items found.")
+            return [ActionResult(action_type=ActionType.API_REQUEST, success=True, output=digest)]
+
+        if "subscribe" in lower or "add feed" in lower or "add rss" in lower:
+            words = user_input.split()
+            urls = [w for w in words if w.startswith("http")]
+            if not urls:
+                return [ActionResult(
+                    action_type=ActionType.API_REQUEST,
+                    success=False,
+                    output="Please provide a feed URL to subscribe to.",
+                )]
+            self._config.rss.feeds.extend(urls)
+            if not self._config.rss.enabled:
+                self._config.rss.enabled = True
+                self._register_background_task()
+            self._config.save()
+            return [ActionResult(
+                action_type=ActionType.API_REQUEST,
+                success=True,
+                output=f"Subscribed to: {', '.join(urls)}",
+            )]
+
+        if "list" in lower or "feeds" in lower:
+            feeds = self._config.rss.feeds
+            if not feeds:
+                return [ActionResult(
+                    action_type=ActionType.API_REQUEST,
+                    success=True,
+                    output="No feeds subscribed yet.",
+                )]
+            return [ActionResult(
+                action_type=ActionType.API_REQUEST,
+                success=True,
+                output="Subscribed feeds:\n" + "\n".join(f"  - {f}" for f in feeds),
+            )]
+
+        return [ActionResult(
+            action_type=ActionType.API_REQUEST,
+            success=False,
+            output="RSS Agent: unrecognized request. Try 'show today's digest', 'list my feeds', or 'subscribe to <url>'.",
+        )]
+
+    # ------------------------------------------------------------------
+    # Background task
+    # ------------------------------------------------------------------
+
+    def _register_background_task(self) -> None:
+        interval = self._config.rss.poll_interval_hours * 3600
+        self._bg.register(BackgroundTask(
+            task_id="rss_feed_poller",
+            name="RSS Feed Poller",
+            description="Polls subscribed RSS/Atom feeds and stores daily summaries",
+            interval_seconds=interval,
+            action_fn=self._poll_feeds,
+            on_trigger=self._on_new_digest,
+        ))
+        self._bg.start("rss_feed_poller")
+        logger.info("RSS Feed Poller registered (%d feeds, %.1fh interval)",
+                    len(self._config.rss.feeds), self._config.rss.poll_interval_hours)
+
+    async def _poll_feeds(self) -> dict[str, Any]:
+        items: list[str] = []
+        for feed_url in self._config.rss.feeds:
+            try:
+                feed_items = await self._fetch_feed(feed_url)
+                items.extend(feed_items[: self._config.rss.max_items_per_feed])
+            except Exception as exc:
+                logger.warning("Failed to fetch feed %s: %s", feed_url, exc)
+
+        if not items:
+            return {"triggered": False, "digest": "No feed items retrieved."}
+
+        combined = "\n\n".join(items)
+        prompt = _SUMMARIZE_PROMPT.format(items=combined)
+        try:
+            digest = await self._model.generate(prompt, temperature=0.3)
+        except Exception as exc:
+            logger.warning("RSS summarization failed: %s", exc)
+            digest = combined[:4000]
+
+        key = f"rss_digest_{date.today().isoformat()}"
+        await self._memory.set_preference(key, digest)
+        logger.info("RSS digest stored under key '%s'", key)
+        return {"triggered": True, "message": "New RSS digest ready", "digest": digest}
+
+    async def _on_new_digest(self, result: dict[str, Any]) -> None:
+        logger.info("RSS digest broadcast: %s", result.get("message", ""))
+
+    # ------------------------------------------------------------------
+    # Feed fetching and parsing
+    # ------------------------------------------------------------------
+
+    async def _fetch_feed(self, url: str) -> list[str]:
+        async with httpx.AsyncClient(timeout=_FETCH_TIMEOUT, follow_redirects=True) as client:
+            resp = await client.get(url, headers={"User-Agent": "HeliOS-RSSAgent/1.0"})
+            resp.raise_for_status()
+        return self._parse_feed(resp.text, url)
+
+    @staticmethod
+    def _parse_feed(xml_text: str, source_url: str) -> list[str]:
+        """Parse RSS 2.0 or Atom 1.0 XML and return a list of formatted item strings."""
+        try:
+            root = ElementTree.fromstring(xml_text)
+        except ElementTree.ParseError as exc:
+            logger.warning("Failed to parse feed XML from %s: %s", source_url, exc)
+            return []
+
+        items: list[str] = []
+
+        # RSS 2.0
+        for item in root.findall(".//item"):
+            title = (item.findtext("title") or "").strip()
+            desc = (item.findtext("description") or "").strip()
+            link = (item.findtext("link") or "").strip()
+            text = f"[{title}] {desc}"
+            if link:
+                text += f" ({link})"
+            if text.strip():
+                items.append(text)
+
+        if items:
+            return items
+
+        # Atom 1.0
+        ns = _ATOM_NS
+        for entry in root.findall(f"{{{ns}}}entry"):
+            title_el = entry.find(f"{{{ns}}}title")
+            title = (title_el.text or "").strip() if title_el is not None else ""
+            summary_el = entry.find(f"{{{ns}}}summary")
+            if summary_el is None:
+                summary_el = entry.find(f"{{{ns}}}content")
+            summary = (summary_el.text or "").strip() if summary_el is not None else ""
+            link_el = entry.find(f"{{{ns}}}link")
+            link = (link_el.get("href") or "").strip() if link_el is not None else ""
+            text = f"[{title}] {summary}"
+            if link:
+                text += f" ({link})"
+            if text.strip():
+                items.append(text)
+
+        return items

--- a/daemon/pilot/config.py
+++ b/daemon/pilot/config.py
@@ -100,6 +100,14 @@ class MemoryConfig:
 
 
 @dataclass
+class RSSConfig:
+    enabled: bool = False
+    feeds: list[str] = field(default_factory=list)
+    poll_interval_hours: float = 24.0
+    max_items_per_feed: int = 10
+
+
+@dataclass
 class Restrictions:
     protected_folders: list[str] = field(default_factory=list)
     protected_packages: list[str] = field(default_factory=list)
@@ -117,6 +125,7 @@ class PilotConfig:
     voice: VoiceConfig = field(default_factory=VoiceConfig)
     screen_vision: ScreenVisionConfig = field(default_factory=ScreenVisionConfig)
     memory: MemoryConfig = field(default_factory=MemoryConfig)
+    rss: RSSConfig = field(default_factory=RSSConfig)
     restrictions: Restrictions = field(default_factory=Restrictions)
     first_run_complete: bool = False
 
@@ -208,6 +217,12 @@ def _validate_config_types(raw: dict) -> None:
         "memory": {
             "checkpoint_interval_seconds": int,
         },
+        "rss": {
+            "enabled": bool,
+            "feeds": list,
+            "poll_interval_hours": (int, float),
+            "max_items_per_feed": int,
+        },
     }
 
     for section, expected_keys in expected_types.items():
@@ -267,6 +282,11 @@ def _merge_config(config: PilotConfig, raw: dict[str, Any]) -> PilotConfig:
         for k, v in raw["memory"].items():
             if hasattr(config.memory, k):
                 setattr(config.memory, k, v)
+
+    if "rss" in raw:
+        for k, v in raw["rss"].items():
+            if hasattr(config.rss, k):
+                setattr(config.rss, k, v)
 
     config.first_run_complete = raw.get(
         "first_run_complete",

--- a/daemon/pilot/memory/store.py
+++ b/daemon/pilot/memory/store.py
@@ -275,6 +275,18 @@ class MemoryStore:
 
             await db.commit()
 
+    async def get_preference(self, key: str) -> str | None:
+        """Return the stored value for *key*, or None if not found."""
+        if not self._pool:
+            return None
+
+        async with self._pool.read() as db:
+            cursor = await db.execute("SELECT value FROM user_preferences WHERE key = ?", (key,))
+            row = await cursor.fetchone()
+            await cursor.close()
+
+        return row[0] if row else None
+
     async def _get_preferences(self) -> dict[str, str]:
         if not self._pool:
             return {}

--- a/daemon/pilot/server.py
+++ b/daemon/pilot/server.py
@@ -126,6 +126,7 @@ class PilotServer:
         self._pending_confirms: dict[str, PendingConfirmation] = {}
         # ── Cancel Token (Issue #92) ──
         self._cancel_event: asyncio.Event | None = None
+        self._rss_agent: Any = None
 
     async def initialize(self) -> None:
         """Initialize all agent components.
@@ -205,6 +206,11 @@ class PilotServer:
         )
         logger.info("Auto-registered %d agents via dynamic discovery", registered)
         await self._orchestrator.start_all()
+
+        from pilot.agents.rss_agent import RssAgent
+
+        self._rss_agent = RssAgent(model_router, self._memory, self.config, self._background)
+        self._orchestrator.register_agent(self._rss_agent)
 
         # Multimodal Fusion Engine — voice + gesture intent fusion
         from pilot.multimodal.fusion import MultimodalFusionEngine

--- a/daemon/tests/test_rss_agent.py
+++ b/daemon/tests/test_rss_agent.py
@@ -1,4 +1,5 @@
 """Unit tests for pilot.agents.rss_agent.RssAgent."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass, field
@@ -124,6 +125,7 @@ def test_background_task_registered_when_enabled():
     bg_manager.start.assert_called_once_with("rss_feed_poller")
 
 
+@pytest.mark.asyncio
 async def test_poll_feeds_stores_digest():
     """_poll_feeds fetches feed XML, calls LLM, and stores digest via set_preference."""
     agent, _, memory = make_agent(

--- a/daemon/tests/test_rss_agent.py
+++ b/daemon/tests/test_rss_agent.py
@@ -1,0 +1,151 @@
+"""Unit tests for pilot.agents.rss_agent.RssAgent."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from pilot.agents.rss_agent import RssAgent
+
+
+# ---------------------------------------------------------------------------
+# Stubs
+# ---------------------------------------------------------------------------
+
+RSS_XML = """\
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title>Test Feed</title>
+    <item>
+      <title>Article One</title>
+      <description>First article body.</description>
+      <link>https://example.com/1</link>
+    </item>
+    <item>
+      <title>Article Two</title>
+      <description>Second article body.</description>
+      <link>https://example.com/2</link>
+    </item>
+  </channel>
+</rss>
+"""
+
+ATOM_XML = """\
+<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>Atom Feed</title>
+  <entry>
+    <title>Atom Entry One</title>
+    <summary>Atom summary one.</summary>
+    <link href="https://example.com/a1"/>
+  </entry>
+  <entry>
+    <title>Atom Entry Two</title>
+    <summary>Atom summary two.</summary>
+    <link href="https://example.com/a2"/>
+  </entry>
+</feed>
+"""
+
+
+@dataclass
+class FakeRSSConfig:
+    enabled: bool = False
+    feeds: list[str] = field(default_factory=list)
+    poll_interval_hours: float = 24.0
+    max_items_per_feed: int = 10
+
+
+@dataclass
+class FakePilotConfig:
+    rss: FakeRSSConfig = field(default_factory=FakeRSSConfig)
+
+    def save(self) -> None:
+        pass
+
+
+def make_agent(
+    enabled: bool = False,
+    feeds: list[str] | None = None,
+    llm_response: str = "Today's news digest.",
+) -> tuple[RssAgent, MagicMock, AsyncMock]:
+    model_router = MagicMock()
+    model_router.generate = AsyncMock(return_value=llm_response)
+
+    memory = MagicMock()
+    memory.set_preference = AsyncMock()
+    memory.get_preference = AsyncMock(return_value=None)
+
+    config = FakePilotConfig(rss=FakeRSSConfig(enabled=enabled, feeds=feeds or []))
+
+    bg_manager = MagicMock()
+    bg_manager.register = MagicMock()
+    bg_manager.start = MagicMock()
+
+    agent = RssAgent(model_router, memory, config, bg_manager)
+    return agent, bg_manager, memory
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_parse_rss_items():
+    """_parse_feed correctly extracts items from RSS 2.0 XML."""
+    items = RssAgent._parse_feed(RSS_XML, "https://example.com/feed.xml")
+    assert len(items) == 2
+    assert "Article One" in items[0]
+    assert "First article body." in items[0]
+    assert "https://example.com/1" in items[0]
+
+
+def test_parse_atom_items():
+    """_parse_feed correctly extracts entries from Atom 1.0 XML."""
+    items = RssAgent._parse_feed(ATOM_XML, "https://example.com/atom.xml")
+    assert len(items) == 2
+    assert "Atom Entry One" in items[0]
+    assert "Atom summary one." in items[0]
+    assert "https://example.com/a1" in items[0]
+
+
+def test_no_background_task_when_disabled():
+    """No background task is registered when RSS is disabled."""
+    _, bg_manager, _ = make_agent(enabled=False, feeds=["https://example.com/feed.xml"])
+    bg_manager.register.assert_not_called()
+
+
+def test_background_task_registered_when_enabled():
+    """A background task is registered and started when RSS is enabled with feeds."""
+    _, bg_manager, _ = make_agent(enabled=True, feeds=["https://example.com/feed.xml"])
+    bg_manager.register.assert_called_once()
+    bg_manager.start.assert_called_once_with("rss_feed_poller")
+
+
+async def test_poll_feeds_stores_digest():
+    """_poll_feeds fetches feed XML, calls LLM, and stores digest via set_preference."""
+    agent, _, memory = make_agent(
+        enabled=True,
+        feeds=["https://example.com/feed.xml"],
+        llm_response="Summarized news today.",
+    )
+
+    mock_response = MagicMock()
+    mock_response.text = RSS_XML
+    mock_response.raise_for_status = MagicMock()
+
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(return_value=mock_response)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("pilot.agents.rss_agent.httpx.AsyncClient", return_value=mock_client):
+        result = await agent._poll_feeds()
+
+    assert result["triggered"] is True
+    assert "Summarized news today." in result["digest"]
+    memory.set_preference.assert_called_once()
+    key_arg = memory.set_preference.call_args[0][0]
+    assert key_arg.startswith("rss_digest_")


### PR DESCRIPTION
Closes #175

## Summary

- Adds `RssAgent` that periodically polls a configurable list of RSS 2.0 and Atom 1.0 feeds in the background
- Stores daily digests in `MemoryStore` under the key `rss_digest_YYYY-MM-DD` so they are available for future context retrievals
- No new pip dependencies: feed XML is fetched with `httpx` (already in deps) and parsed with stdlib `xml.etree.ElementTree`

## Changes

- `daemon/pilot/agents/rss_agent.py` — new agent with background polling, LLM summarization, and user-facing query handling (today's digest, subscribe, list feeds, poll now)
- `daemon/pilot/config.py` — new `RSSConfig` dataclass (`enabled`, `feeds`, `poll_interval_hours`, `max_items_per_feed`) wired into `PilotConfig` with validation and merge support
- `daemon/pilot/agents/base_agent.py` — adds `RSS = "rss_agent"` to `AgentRole`
- `daemon/pilot/memory/store.py` — adds public `get_preference(key)` method
- `daemon/pilot/server.py` — initializes and registers `RssAgent` after orchestrator setup
- `daemon/tests/test_rss_agent.py` — 5 unit tests: RSS parsing, Atom parsing, disabled/enabled task registration, and full poll-summarize-store flow

## Test results

168 passed, 4 skipped, 0 failures (full suite run locally)