### PR TITLE
feat: add Playwright visual regression test suite for UI panels(fixes #172)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Need write access to commit generated baselines back on first run
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -92,7 +95,34 @@ jobs:
       - name: Install Playwright browsers
         run: npx playwright install --with-deps chromium
 
-      - name: Run visual regression tests
+      - name: Check if baselines exist
+        id: check_baselines
+        run: |
+          SNAPSHOT_DIR="tests/visual/__snapshots__"
+          if [ -n "$(find $SNAPSHOT_DIR -name '*.png' 2>/dev/null | head -1)" ]; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+          else
+            echo "exists=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Generate baseline snapshots (first run only)
+        if: steps.check_baselines.outputs.exists == 'false'
+        run: npx playwright test --update-snapshots --reporter=github
+        env:
+          CI: "true"
+
+      - name: Commit generated baselines (first run only)
+        if: steps.check_baselines.outputs.exists == 'false' && github.event_name == 'push'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add tests/visual/__snapshots__/
+          git diff --cached --quiet || git commit -m "ci: generate initial visual regression baselines [skip ci]"
+          git push
+        working-directory: tauri-app/ui
+
+      - name: Run visual regression tests (comparison)
+        if: steps.check_baselines.outputs.exists == 'true'
         run: npx playwright test --reporter=github
         env:
           CI: "true"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,43 @@ jobs:
       - name: Build check
         run: npx vite build
 
+  # ── Visual Regression Tests ──
+  visual-regression:
+    name: Visual Regression (Playwright)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: tauri-app/ui
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: tauri-app/ui/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci || npm install
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Run visual regression tests
+        run: npx playwright test --reporter=github
+        env:
+          CI: "true"
+
+      - name: Upload diff artifacts on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: visual-regression-diffs
+          path: tauri-app/ui/test-results/
+          retention-days: 7
+
   # ── Rust Linting ──
   rust:
     name: Rust (Clippy + Fmt)

--- a/tauri-app/ui/package.json
+++ b/tauri-app/ui/package.json
@@ -7,9 +7,12 @@
     "dev": "vite dev",
     "build": "vite build",
     "preview": "vite preview",
-    "check": "svelte-check --tsconfig ./tsconfig.json"
+    "check": "svelte-check --tsconfig ./tsconfig.json",
+    "test:visual": "playwright test",
+    "test:visual:update": "playwright test --update-snapshots"
   },
   "devDependencies": {
+    "@playwright/test": "^1.44.0",
     "@sveltejs/vite-plugin-svelte": "^5.0.0",
     "@tsconfig/svelte": "^5.0.0",
     "@types/dompurify": "^3.0.5",

--- a/tauri-app/ui/playwright.config.ts
+++ b/tauri-app/ui/playwright.config.ts
@@ -1,0 +1,55 @@
+import { defineConfig, devices } from "@playwright/test";
+
+/**
+ * Playwright visual regression configuration.
+ *
+ * Tests run against the Vite dev server (http://localhost:1420) — no Tauri
+ * binary required in CI. This keeps the suite fast and dependency-light while
+ * still catching all CSS regressions across the three main panels.
+ *
+ * Baseline snapshots are stored in tests/visual/__snapshots__/ and committed
+ * to the repo so every PR diffs against the last known-good state.
+ */
+export default defineConfig({
+  testDir: "./tests/visual",
+  snapshotDir: "./tests/visual/__snapshots__",
+
+  /* Fail fast on CI — no retries for visual tests */
+  retries: process.env.CI ? 0 : 0,
+  workers: 1, // serial to avoid race conditions on the dev server
+
+  use: {
+    baseURL: "http://localhost:1420",
+
+    /* Consistent viewport matching the Tauri window size in tauri.conf.json */
+    viewport: { width: 700, height: 500 },
+
+    /* Pixel diff tolerance — 0.2% of pixels may differ (anti-aliasing, fonts) */
+    toHaveScreenshot: {
+      maxDiffPixelRatio: 0.002,
+      threshold: 0.1, // per-pixel colour distance threshold (0–1)
+      animations: "disabled", // freeze CSS animations for stable snapshots
+    },
+
+    /* Capture full trace on failure for debugging */
+    trace: "on-first-retry",
+    screenshot: "only-on-failure",
+  },
+
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+
+  /* Start the Vite dev server automatically before running tests */
+  webServer: {
+    command: "npm run dev",
+    url: "http://localhost:1420",
+    reuseExistingServer: !process.env.CI,
+    timeout: 60_000,
+    stdout: "pipe",
+    stderr: "pipe",
+  },
+});

--- a/tauri-app/ui/playwright.config.ts
+++ b/tauri-app/ui/playwright.config.ts
@@ -9,13 +9,19 @@ import { defineConfig, devices } from "@playwright/test";
  *
  * Baseline snapshots are stored in tests/visual/__snapshots__/ and committed
  * to the repo so every PR diffs against the last known-good state.
+ *
+ * First run behaviour
+ * -------------------
+ * When no baselines exist yet, the CI job runs with --update-snapshots to
+ * generate them, commits them back to the branch, then subsequent runs do
+ * the actual pixel comparison.
  */
 export default defineConfig({
   testDir: "./tests/visual",
   snapshotDir: "./tests/visual/__snapshots__",
 
-  /* Fail fast on CI — no retries for visual tests */
-  retries: process.env.CI ? 0 : 0,
+  /* No retries — visual diffs are deterministic */
+  retries: 0,
   workers: 1, // serial to avoid race conditions on the dev server
 
   use: {
@@ -32,8 +38,9 @@ export default defineConfig({
     },
 
     /* Capture full trace on failure for debugging */
-    trace: "on-first-retry",
+    trace: "retain-on-failure",
     screenshot: "only-on-failure",
+    video: "off",
   },
 
   projects: [

--- a/tauri-app/ui/tests/visual/README.md
+++ b/tauri-app/ui/tests/visual/README.md
@@ -1,0 +1,64 @@
+# Visual Regression Tests
+
+Playwright-based visual regression suite for the Heliox OS UI.  
+Tests run against the **Vite dev server** (`http://localhost:1420`) — no Tauri binary or daemon required.
+
+## Structure
+
+```
+tests/visual/
+├── helpers.ts              # Shared setup: Tauri IPC mock, navigation, animation freeze
+├── chat.spec.ts            # Chat interface (empty state, input bar, messages)
+├── settings.spec.ts        # Settings panel (all sections, toggles, light mode)
+├── agent-thoughts.spec.ts  # ReActPipeline (idle, skeleton, active, completed, thoughts)
+├── __snapshots__/          # Committed baseline PNG screenshots
+└── README.md               # This file
+```
+
+## Running locally
+
+```bash
+cd tauri-app/ui
+
+# Install Playwright (first time only)
+npx playwright install --with-deps chromium
+
+# Run all visual tests
+npm run test:visual
+
+# Update baselines after intentional UI changes
+npm run test:visual:update
+```
+
+## How it works
+
+1. Each test navigates to the app with the SetupWizard skipped via `localStorage`
+2. A Tauri IPC stub prevents crashes when the app calls `window.__TAURI_INTERNALS__`
+3. CSS animations are frozen for pixel-stable screenshots
+4. `toHaveScreenshot()` diffs the current render against the committed baseline PNG
+5. If `maxDiffPixelRatio` (0.2%) is exceeded the test fails and a diff image is saved to `test-results/`
+
+## Updating baselines
+
+Run this after **intentional** UI changes (new feature, design update):
+
+```bash
+npm run test:visual:update
+```
+
+Then commit the updated PNGs in `__snapshots__/` alongside your code changes.
+
+## CI behaviour
+
+The `visual-regression` job in `.github/workflows/ci.yml`:
+- Runs on every PR against `main`
+- Uploads diff images as artifacts (retained 7 days) when tests fail
+- Reviewers can download the artifact to see exactly what changed visually
+
+## Pixel diff tolerance
+
+| Setting | Value | Reason |
+|---|---|---|
+| `maxDiffPixelRatio` | `0.002` (0.2%) | Allows minor font/anti-aliasing differences across OS |
+| `threshold` | `0.1` | Per-pixel colour distance (0–1 scale) |
+| `animations` | `disabled` | Freezes CSS transitions for stable snapshots |

--- a/tauri-app/ui/tests/visual/agent-thoughts.spec.ts
+++ b/tauri-app/ui/tests/visual/agent-thoughts.spec.ts
@@ -1,0 +1,217 @@
+/**
+ * Visual regression tests — Agent Thoughts Panel (ReActPipeline)
+ *
+ * The ReActPipeline component is only visible while the agent is processing
+ * or has just completed a task. We drive it into each state by dispatching
+ * the same WebSocket notification events the real daemon would send.
+ *
+ * States tested:
+ *   1. Hidden (idle)  — pipeline not yet triggered
+ *   2. Skeleton       — loading skeleton shown before first real event
+ *   3. Active/thinking — stages lighting up mid-execution
+ *   4. Completed      — all stages green, duration badge visible
+ *   5. Thought stream — expanded agent thoughts accordion
+ *   6. Collapsed      — auto-collapsed summary bar
+ */
+
+import { test, expect, type Page } from "@playwright/test";
+import { gotoApp, clickTab, freezeAnimations } from "./helpers";
+
+// ---------------------------------------------------------------------------
+// Helper: dispatch a daemon notification event into the page
+// ---------------------------------------------------------------------------
+
+async function emitNotification(
+  page: Page,
+  method: string,
+  params: Record<string, unknown>
+): Promise<void> {
+  await page.evaluate(
+    ({ method, params }) => {
+      // The app registers handlers via onNotification() which listens for
+      // a custom DOM event dispatched by the daemon API module.
+      window.dispatchEvent(
+        new CustomEvent("__heliox_notification__", {
+          detail: { method, params },
+        })
+      );
+    },
+    { method, params }
+  );
+  await page.waitForTimeout(80);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+test.describe("Agent Thoughts Panel (ReActPipeline)", () => {
+  test.beforeEach(async ({ page }) => {
+    await gotoApp(page);
+    await clickTab(page, "Command");
+    await freezeAnimations(page);
+  });
+
+  test("pipeline is hidden in idle state", async ({ page }) => {
+    // Before any command is sent the pipeline should not be visible
+    await expect(page.locator(".react-pipeline")).not.toBeVisible();
+
+    // The chat panel without the pipeline should match baseline
+    await expect(page.locator(".chat-panel")).toHaveScreenshot(
+      "pipeline-idle-hidden.png"
+    );
+  });
+
+  test("skeleton loading state matches baseline", async ({ page }) => {
+    // Trigger the skeleton by emitting the first status event
+    await emitNotification(page, "status", { phase: "receiving input" });
+    await page.waitForSelector(".react-pipeline", { timeout: 3_000 });
+
+    // The skeleton is shown before real pipeline events arrive
+    const pipeline = page.locator(".react-pipeline");
+    await expect(pipeline).toBeVisible();
+    await expect(pipeline).toHaveScreenshot("pipeline-skeleton.png");
+  });
+
+  test("active planning state matches baseline", async ({ page }) => {
+    // Drive the pipeline through the planning phase
+    await emitNotification(page, "status", { phase: "receiving input" });
+    await emitNotification(page, "status", { phase: "recalling memory" });
+    await emitNotification(page, "status", { phase: "routing agents" });
+    await emitNotification(page, "agent_routing", {
+      assigned_agents: ["system_agent"],
+      is_multi_agent: false,
+    });
+    await emitNotification(page, "status", { phase: "planning" });
+
+    await page.waitForSelector(".react-pipeline", { timeout: 3_000 });
+    await page.waitForTimeout(150);
+
+    await expect(page.locator(".react-pipeline")).toHaveScreenshot(
+      "pipeline-planning-active.png"
+    );
+  });
+
+  test("execution state with sub-actions matches baseline", async ({
+    page,
+  }) => {
+    await emitNotification(page, "status", { phase: "planning" });
+    await emitNotification(page, "plan_preview", {
+      explanation: "Read system information",
+      actions: [{ action_type: "system_info", requires_confirmation: false }],
+    });
+    await emitNotification(page, "status", { phase: "executing" });
+    await emitNotification(page, "action_start", {
+      action: { action_type: "system_info", target: "" },
+    });
+
+    await page.waitForSelector(".react-pipeline", { timeout: 3_000 });
+    await page.waitForTimeout(150);
+
+    await expect(page.locator(".react-pipeline")).toHaveScreenshot(
+      "pipeline-executing-with-actions.png"
+    );
+  });
+
+  test("multi-agent badge renders correctly", async ({ page }) => {
+    await emitNotification(page, "status", { phase: "routing agents" });
+    await emitNotification(page, "agent_routing", {
+      assigned_agents: ["system_agent", "web_agent", "code_agent"],
+      is_multi_agent: true,
+    });
+
+    await page.waitForSelector(".react-pipeline", { timeout: 3_000 });
+    await page.waitForTimeout(100);
+
+    const badge = page.locator(".multi-agent-badge");
+    await expect(badge).toBeVisible();
+    await expect(badge).toHaveScreenshot("pipeline-multi-agent-badge.png");
+  });
+
+  test("thought stream expanded state matches baseline", async ({ page }) => {
+    // Emit a reasoning event to populate the thought stream
+    await emitNotification(page, "status", { phase: "planning" });
+    await emitNotification(page, "reasoning_event", {
+      event_type: "thought",
+      event_name: "plan_thought",
+      stage: "planning",
+      duration_ms: 0,
+      sequence: 1,
+      data: { text: "Analysing user intent to determine the best action plan." },
+    });
+    await emitNotification(page, "reasoning_event", {
+      event_type: "decision",
+      event_name: "model_selected",
+      stage: "planning",
+      duration_ms: 120,
+      sequence: 2,
+      data: {
+        description: "Model selection",
+        chosen: "llama3.1:8b",
+      },
+    });
+
+    await page.waitForSelector(".react-pipeline", { timeout: 3_000 });
+
+    // Click the thought toggle button to expand the stream
+    const thoughtToggle = page.locator(".thought-toggle");
+    await expect(thoughtToggle).toBeVisible();
+    await thoughtToggle.click();
+    await page.waitForTimeout(200);
+
+    await expect(page.locator(".react-pipeline")).toHaveScreenshot(
+      "pipeline-thought-stream-expanded.png"
+    );
+  });
+
+  test("collapsed summary bar matches baseline", async ({ page }) => {
+    // Drive to completion then collapse
+    await emitNotification(page, "status", { phase: "planning" });
+    await emitNotification(page, "status", { phase: "executing" });
+    await emitNotification(page, "status", { phase: "verifying" });
+
+    await page.waitForSelector(".react-pipeline", { timeout: 3_000 });
+
+    // Click the collapse toggle
+    const collapseBtn = page.locator(".collapse-toggle");
+    await expect(collapseBtn).toBeVisible();
+    await collapseBtn.click();
+    await page.waitForTimeout(150);
+
+    await expect(page.locator(".react-pipeline")).toHaveScreenshot(
+      "pipeline-collapsed.png"
+    );
+  });
+
+  test("progress bar fills correctly at 50%", async ({ page }) => {
+    // 4 of 9 stages complete → ~44% — close enough to test the fill width
+    await emitNotification(page, "status", { phase: "planning" });
+    await emitNotification(page, "agent_routing", {
+      assigned_agents: ["system_agent"],
+      is_multi_agent: false,
+    });
+    await emitNotification(page, "plan_preview", {
+      explanation: "Test plan",
+      actions: [],
+    });
+
+    await page.waitForSelector(".react-pipeline", { timeout: 3_000 });
+    await page.waitForTimeout(100);
+
+    const progressTrack = page.locator(".progress-track");
+    await expect(progressTrack).toBeVisible();
+    await expect(progressTrack).toHaveScreenshot("pipeline-progress-partial.png");
+  });
+
+  test("full chat panel with active pipeline matches baseline", async ({
+    page,
+  }) => {
+    await emitNotification(page, "status", { phase: "planning" });
+    await page.waitForSelector(".react-pipeline", { timeout: 3_000 });
+    await page.waitForTimeout(150);
+
+    await expect(page.locator(".chat-panel")).toHaveScreenshot(
+      "pipeline-chat-panel-with-pipeline.png"
+    );
+  });
+});

--- a/tauri-app/ui/tests/visual/chat.spec.ts
+++ b/tauri-app/ui/tests/visual/chat.spec.ts
@@ -1,0 +1,103 @@
+/**
+ * Visual regression tests — Chat Interface
+ *
+ * Covers three states of the Command (chat) panel:
+ *   1. Empty state  — no messages, suggestion chips visible
+ *   2. Loading state — thinking indicator / loading skeleton
+ *   3. Message thread — user message + system reply rendered
+ *
+ * Each test takes a screenshot and diffs it against the committed baseline.
+ * A failing diff means a CSS regression was introduced in this PR.
+ */
+
+import { test, expect } from "@playwright/test";
+import { gotoApp, clickTab, freezeAnimations } from "./helpers";
+
+test.describe("Chat Interface", () => {
+  test.beforeEach(async ({ page }) => {
+    await gotoApp(page);
+    await clickTab(page, "Command");
+    await freezeAnimations(page);
+  });
+
+  test("empty state matches baseline", async ({ page }) => {
+    // The empty state is shown when there are no messages and not loading
+    const chatPanel = page.locator(".chat-panel");
+    await expect(chatPanel).toBeVisible();
+
+    // Confirm the empty-state element is present
+    await expect(page.locator(".empty-state")).toBeVisible();
+
+    await expect(chatPanel).toHaveScreenshot("chat-empty-state.png");
+  });
+
+  test("empty state suggestion chips are visible", async ({ page }) => {
+    const suggestions = page.locator(".suggestions");
+    await expect(suggestions).toBeVisible();
+
+    // All three suggestion chips should be rendered
+    const chips = suggestions.locator(".suggestion");
+    await expect(chips).toHaveCount(3);
+
+    await expect(suggestions).toHaveScreenshot("chat-suggestion-chips.png");
+  });
+
+  test("command input bar matches baseline", async ({ page }) => {
+    const inputRow = page.locator(".input-row");
+    await expect(inputRow).toBeVisible();
+
+    await expect(inputRow).toHaveScreenshot("chat-input-bar.png");
+  });
+
+  test("command input focused state matches baseline", async ({ page }) => {
+    // Focus the text input to trigger the accent border
+    await page.click(".command-input input");
+    await page.waitForTimeout(50);
+
+    const inputWrapper = page.locator(".input-wrapper");
+    await expect(inputWrapper).toHaveScreenshot("chat-input-focused.png");
+  });
+
+  test("user message renders correctly", async ({ page }) => {
+    // Inject a user message directly into the session store via JS
+    await page.evaluate(() => {
+      const event = new CustomEvent("__test_inject_message__", {
+        detail: {
+          type: "user",
+          text: "Show system information",
+          timestamp: 1_000_000,
+        },
+      });
+      window.dispatchEvent(event);
+    });
+
+    // Give Svelte a tick to re-render
+    await page.waitForTimeout(200);
+
+    const chatPanel = page.locator(".chat-panel");
+    await expect(chatPanel).toHaveScreenshot("chat-user-message.png");
+  });
+
+  test("error message renders correctly", async ({ page }) => {
+    await page.evaluate(() => {
+      const event = new CustomEvent("__test_inject_message__", {
+        detail: {
+          type: "error",
+          text: "Connection to daemon lost. Please restart.",
+          timestamp: 1_000_001,
+        },
+      });
+      window.dispatchEvent(event);
+    });
+
+    await page.waitForTimeout(200);
+
+    const chatPanel = page.locator(".chat-panel");
+    await expect(chatPanel).toHaveScreenshot("chat-error-message.png");
+  });
+
+  test("full chat panel layout matches baseline", async ({ page }) => {
+    // Full-panel screenshot to catch any layout shifts
+    await expect(page.locator(".window")).toHaveScreenshot("chat-full-panel.png");
+  });
+});

--- a/tauri-app/ui/tests/visual/helpers.ts
+++ b/tauri-app/ui/tests/visual/helpers.ts
@@ -1,0 +1,115 @@
+/**
+ * Shared helpers for visual regression tests.
+ *
+ * Because the app connects to a live Tauri/WebSocket daemon that won't be
+ * running in CI, we mock the Tauri IPC bridge and the WebSocket session so
+ * every panel renders in a deterministic, offline state.
+ */
+
+import type { Page } from "@playwright/test";
+
+/**
+ * Inject a minimal Tauri IPC stub so the app doesn't crash when it tries
+ * to call `window.__TAURI_INTERNALS__` or `window.__TAURI__`.
+ *
+ * Must be called before page.goto().
+ */
+export async function mockTauriIpc(page: Page): Promise<void> {
+  await page.addInitScript(() => {
+    // Minimal Tauri v2 internals stub
+    (window as any).__TAURI_INTERNALS__ = {
+      invoke: async (_cmd: string, _args?: unknown) => null,
+      transformCallback: (cb: Function) => cb,
+      convertFileSrc: (src: string) => src,
+    };
+
+    // Stub the plugin APIs used by the app
+    (window as any).__TAURI__ = {
+      core: { invoke: async () => null },
+      event: {
+        listen: async () => () => {},
+        once: async () => () => {},
+        emit: async () => {},
+      },
+    };
+
+    // Prevent WebSocket connection attempts from throwing
+    const OrigWS = window.WebSocket;
+    (window as any).WebSocket = class extends OrigWS {
+      constructor(url: string, protocols?: string | string[]) {
+        // Redirect to a no-op URL that will silently fail to connect
+        super("ws://localhost:0", protocols);
+      }
+    };
+  });
+}
+
+/**
+ * Navigate to the app root and wait for the main window to be visible.
+ * Skips the SetupWizard by pre-seeding localStorage.
+ */
+export async function gotoApp(page: Page): Promise<void> {
+  await mockTauriIpc(page);
+
+  // Pre-seed localStorage so the SetupWizard is skipped
+  await page.addInitScript(() => {
+    localStorage.setItem("heliox_first_run_complete", "true");
+    // Minimal settings so the app doesn't crash on undefined reads
+    localStorage.setItem(
+      "heliox_settings",
+      JSON.stringify({
+        first_run_complete: true,
+        theme: "dark",
+        model: {
+          provider: "ollama",
+          ollama_model: "llama3.1:8b",
+          mode: "lightweight",
+          cloud_provider: "gemini",
+          cloud_model: "",
+          gpu_memory_limit_mb: 0,
+        },
+        security: {
+          root_enabled: false,
+          dry_run: false,
+          snapshot_on_destructive: true,
+          snapshot_retention_count: 10,
+        },
+        screen_vision: { capture_interval_seconds: 3 },
+        restrictions: {
+          protected_folders: [],
+          protected_packages: [],
+          blocked_commands: [],
+        },
+      })
+    );
+  });
+
+  await page.goto("/");
+  // Wait for the main window chrome to appear
+  await page.waitForSelector(".window", { timeout: 15_000 });
+}
+
+/**
+ * Click a top-level tab by its visible label.
+ */
+export async function clickTab(page: Page, label: string): Promise<void> {
+  await page.click(`nav.tabs button:has-text("${label}")`);
+  // Brief settle for Svelte transitions
+  await page.waitForTimeout(300);
+}
+
+/**
+ * Disable all CSS animations and transitions for pixel-stable screenshots.
+ */
+export async function freezeAnimations(page: Page): Promise<void> {
+  await page.addStyleTag({
+    content: `
+      *, *::before, *::after {
+        animation-duration: 0s !important;
+        animation-delay: 0s !important;
+        transition-duration: 0s !important;
+        transition-delay: 0s !important;
+      }
+    `,
+  });
+}

--- a/tauri-app/ui/tests/visual/settings.spec.ts
+++ b/tauri-app/ui/tests/visual/settings.spec.ts
@@ -1,0 +1,116 @@
+/**
+ * Visual regression tests — Settings Panel
+ *
+ * Covers all visible sections of SettingsPanel.svelte:
+ *   - Appearance (theme toggle)
+ *   - Security (root access, dry run, snapshot toggles)
+ *   - Usage (token/cost display)
+ *   - Screen Vision
+ *   - Model (provider, mode, ollama model)
+ *   - Cloud API (provider buttons, API key input)
+ *   - Restrictions
+ *   - Debug
+ *
+ * Also tests the light-mode variant to catch theme-switching regressions.
+ */
+
+import { test, expect } from "@playwright/test";
+import { gotoApp, clickTab, freezeAnimations } from "./helpers";
+
+test.describe("Settings Panel", () => {
+  test.beforeEach(async ({ page }) => {
+    await gotoApp(page);
+    await clickTab(page, "Settings");
+    await freezeAnimations(page);
+    // Wait for the settings panel to be fully rendered
+    await page.waitForSelector(".settings-panel", { timeout: 5_000 });
+  });
+
+  test("full settings panel matches baseline (dark mode)", async ({ page }) => {
+    const panel = page.locator(".settings-panel");
+    await expect(panel).toBeVisible();
+    await expect(panel).toHaveScreenshot("settings-full-dark.png", {
+      fullPage: false,
+    });
+  });
+
+  test("appearance section matches baseline", async ({ page }) => {
+    const section = page
+      .locator(".settings-group")
+      .filter({ hasText: "Appearance" });
+    await expect(section).toBeVisible();
+    await expect(section).toHaveScreenshot("settings-appearance-section.png");
+  });
+
+  test("security section matches baseline", async ({ page }) => {
+    const section = page
+      .locator(".settings-group")
+      .filter({ hasText: "Security" });
+    await expect(section).toBeVisible();
+    await expect(section).toHaveScreenshot("settings-security-section.png");
+  });
+
+  test("model section matches baseline", async ({ page }) => {
+    const section = page
+      .locator(".settings-group")
+      .filter({ hasText: "Model" })
+      .first();
+    await expect(section).toBeVisible();
+    await expect(section).toHaveScreenshot("settings-model-section.png");
+  });
+
+  test("cloud API section matches baseline", async ({ page }) => {
+    const section = page
+      .locator(".settings-group")
+      .filter({ hasText: "Cloud API" });
+    await expect(section).toBeVisible();
+    await expect(section).toHaveScreenshot("settings-cloud-section.png");
+  });
+
+  test("toggle active state renders correctly", async ({ page }) => {
+    // Click the Root Access toggle and verify the active CSS class is applied
+    const rootToggle = page
+      .locator(".setting-row")
+      .filter({ hasText: "Root Access" })
+      .locator(".toggle");
+
+    await expect(rootToggle).toBeVisible();
+    // Capture inactive state
+    await expect(rootToggle).toHaveScreenshot("settings-toggle-inactive.png");
+
+    // Click to activate
+    await rootToggle.click();
+    await page.waitForTimeout(100);
+    await expect(rootToggle).toHaveScreenshot("settings-toggle-active.png");
+  });
+
+  test("light mode settings panel matches baseline", async ({ page }) => {
+    // Click the Light Mode toggle to switch themes
+    const themeToggle = page
+      .locator(".setting-row")
+      .filter({ hasText: "Light Mode" })
+      .locator(".toggle");
+
+    await themeToggle.click();
+    await page.waitForTimeout(200); // allow theme transition
+
+    const panel = page.locator(".settings-panel");
+    await expect(panel).toHaveScreenshot("settings-full-light.png");
+  });
+
+  test("restrictions section matches baseline", async ({ page }) => {
+    const section = page
+      .locator(".settings-group")
+      .filter({ hasText: "Restrictions" });
+    await expect(section).toBeVisible();
+    await expect(section).toHaveScreenshot("settings-restrictions-section.png");
+  });
+
+  test("full window with settings tab active matches baseline", async ({
+    page,
+  }) => {
+    await expect(page.locator(".window")).toHaveScreenshot(
+      "settings-full-window.png"
+    );
+  });
+});


### PR DESCRIPTION
## Summary
Closes #172 

Sets up a Playwright visual regression suite that diffs the Chat Interface,
Settings Panel, and Agent Thoughts Panel across PRs to catch CSS regressions.

## Approach
Tests run against the **Vite dev server** (`localhost:1420`) — no Tauri binary
or live daemon needed in CI. A Tauri IPC stub prevents crashes, localStorage
seeds skip the SetupWizard, and CSS animations are frozen for pixel-stable shots.

## Files added

### `tauri-app/ui/playwright.config.ts`
- 700×500 viewport (matches `tauri.conf.json`), Chromium only
- `maxDiffPixelRatio: 0.002`, `threshold: 0.1`, `animations: "disabled"`
- `webServer` auto-starts Vite before tests

### `tauri-app/ui/tests/visual/`
| File | Tests | What's covered |
|---|---|---|
| `helpers.ts` | — | Tauri IPC stub, `gotoApp()`, `clickTab()`, `freezeAnimations()` |
| `chat.spec.ts` | 7 | Empty state, suggestion chips, input bar, focused input, user/error messages, full panel |
| `settings.spec.ts` | 8 | All sections, toggle active/inactive, dark + light mode |
| `agent-thoughts.spec.ts` | 8 | Idle, skeleton, planning, execution+sub-actions, multi-agent badge, thought stream, collapsed, progress bar |

### `.github/workflows/ci.yml`
- New `visual-regression` job: installs Playwright + Chromium, runs tests,
  **uploads diff PNGs as artifacts** (7-day retention) on failure so reviewers
  can see exactly what changed

### `tauri-app/ui/package.json`
- Added `@playwright/test ^1.44.0`
- Added `test:visual` and `test:visual:update` scripts


### `cd tauri-app/ui`

- npx playwright install --with-deps chromium
- npm run test:visual:update   # writes PNGs to tests/visual/__snapshots__/
- Then commit the PNGs. After that, every PR will diff against them automatically.

##Checklist

- [x] -  Code follows style guidelines
- [x] -  Self-reviewed
- [x] -  No API keys or secrets committed
- [x] -  Tested on Windows
