### PR TITLE
feat(ui): export ReAct pipeline trace to JSON

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ test_*.py
 !daemon/tests/test_ipc_integration.py
 !daemon/tests/test_pty_session.py
 !daemon/tests/test_dom_diff.py
+!daemon/tests/test_export_react_trace.py
 test_*.txt
 test_*.json
 test_*.html

--- a/daemon/pilot/server.py
+++ b/daemon/pilot/server.py
@@ -346,6 +346,7 @@ class PilotServer:
             "execute": self._handle_execute,
             "resume_plan": self._handle_resume_plan,
             "export_session_chat": self._handle_export_session_chat,
+            "export_react_trace": self._handle_export_react_trace,
             "confirm": self._handle_confirm,
             # ── Cancel Token (Issue #92) ──
             "abort": self._handle_abort,
@@ -1491,6 +1492,36 @@ class PilotServer:
             "path": str(out_path),
             "count": len(messages),
             "format": fmt,
+        }
+
+    async def _handle_export_react_trace(self, params: dict, ws: ServerConnection) -> dict:
+        """Export the UI ReAct pipeline trace (stages, thoughts, events) to JSON."""
+        trace = params.get("trace")
+        if not isinstance(trace, dict):
+            return {"status": "error", "message": "trace must be an object"}
+
+        ts = datetime.now().strftime("%Y%m%d-%H%M%S")
+        filename = f"heliox-react-trace-{ts}.json"
+
+        downloads_dir = Path.home() / "Downloads"
+        export_dir = downloads_dir if downloads_dir.exists() else (DATA_DIR / "exports")
+        export_dir.mkdir(parents=True, exist_ok=True)
+        out_path = export_dir / filename
+
+        try:
+            out_path.write_text(json.dumps(trace, ensure_ascii=False, indent=2), encoding="utf-8")
+        except Exception as e:
+            logger.exception("Failed to export ReAct trace")
+            return {"status": "error", "message": f"Export failed: {e}"}
+
+        summary = trace.get("summary", {})
+        event_count = summary.get("eventCount") if isinstance(summary, dict) else len(trace.get("events", []))
+
+        return {
+            "status": "ok",
+            "path": str(out_path),
+            "event_count": event_count,
+            "format": "json",
         }
 
     # -- API key management --

--- a/daemon/tests/test_export_react_trace.py
+++ b/daemon/tests/test_export_react_trace.py
@@ -1,0 +1,42 @@
+"""Tests for ReAct trace JSON export handler."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from pilot.server import PilotServer
+
+
+@pytest.mark.asyncio
+async def test_export_react_trace_writes_json(tmp_path, monkeypatch):
+    monkeypatch.setattr("pilot.server.Path.home", lambda: tmp_path)
+
+    server = PilotServer.__new__(PilotServer)
+    trace = {
+        "version": 1,
+        "exportedAt": "2026-05-18T00:00:00.000Z",
+        "summary": {"eventCount": 2},
+        "stages": [],
+        "events": [{"timestamp": 1, "method": "status", "payload": {"phase": "planning"}}],
+    }
+
+    result = await server._handle_export_react_trace({"trace": trace}, MagicMock())
+
+    assert result["status"] == "ok"
+    assert result["format"] == "json"
+    out_path = Path(result["path"])
+    assert out_path.exists()
+    assert out_path.suffix == ".json"
+    loaded = json.loads(out_path.read_text(encoding="utf-8"))
+    assert loaded["summary"]["eventCount"] == 2
+
+
+@pytest.mark.asyncio
+async def test_export_react_trace_rejects_invalid_payload():
+    server = PilotServer.__new__(PilotServer)
+    result = await server._handle_export_react_trace({"trace": "not-an-object"}, MagicMock())
+    assert result["status"] == "error"

--- a/tauri-app/ui/src/lib/components/ReActPipeline.svelte
+++ b/tauri-app/ui/src/lib/components/ReActPipeline.svelte
@@ -9,7 +9,8 @@
    */
 
   import { session } from "../stores/session";
-  import { onNotification, offNotification } from "../api/daemon";
+  import { call, onNotification, offNotification } from "../api/daemon";
+  import { buildReactTraceExport, type TraceEventRecord } from "../utils/reactTraceExport";
   import { fade, slide } from "svelte/transition";
   import { onMount, onDestroy } from "svelte";
 
@@ -77,6 +78,15 @@
   let stageDecisions = $state<Record<string, string>>({});
   let stageTiming = $state<Record<string, number>>({});
   let thoughtStream = $state<ThoughtEntry[]>([]);
+  let traceEvents = $state<TraceEventRecord[]>([]);
+  let exportInFlight = $state(false);
+
+  function appendTraceEvent(method: string, payload: Record<string, unknown>) {
+    traceEvents = [
+      ...traceEvents,
+      { timestamp: Date.now(), method, payload },
+    ];
+  }
 
   function resetPipeline() {
     stages = stages.map(s => ({ ...s, status: "idle" as StageStatus, detail: "", startTime: 0, endTime: 0 }));
@@ -86,6 +96,7 @@
     stageDecisions = {};
     stageTiming = {};
     thoughtStream = [];
+    traceEvents = [];
     showSkeleton = false;
     showThoughts = false;
     expandedThoughtStages = {};
@@ -113,6 +124,10 @@
 
   function handleNotification(method: string, params: unknown) {
     const p = params as Record<string, any>;
+
+    if (pipelineMethods.has(method)) {
+      appendTraceEvent(method, p);
+    }
 
     if (showSkeleton && pipelineMethods.has(method)) {
       showSkeleton = false;
@@ -376,6 +391,47 @@
   let toggleCollapse = () => { collapsed = !collapsed; };
   let toggleThoughts = () => { showThoughts = !showThoughts; };
 
+  const canExportTrace = $derived(
+    stages.some((s) => s.status !== "idle") || thoughtStream.length > 0 || traceEvents.length > 0
+  );
+
+  async function exportReactTrace() {
+    if (exportInFlight || !canExportTrace) return;
+
+    exportInFlight = true;
+    const payload = buildReactTraceExport({
+      stages,
+      stageTiming,
+      stageDecisions,
+      executionActions,
+      thoughtStream,
+      traceEvents,
+      agentRouting,
+      progress,
+      totalDuration,
+    });
+
+    try {
+      const res = (await call("export_react_trace", { trace: payload })) as {
+        status: string;
+        path?: string;
+        message?: string;
+      };
+
+      if (res.status === "ok" && res.path) {
+        session.addSystemMessage(`ReAct trace exported to: ${res.path}`);
+      } else {
+        session.addSystemMessage(`ReAct export failed: ${res.message ?? "unknown error"}`);
+      }
+    } catch (err) {
+      session.addSystemMessage(
+        `ReAct export failed: ${String(err instanceof Error ? err.message : err)}`
+      );
+    } finally {
+      exportInFlight = false;
+    }
+  }
+
   // ── Keyboard Shortcut: Ctrl+Shift+L toggles the ReAct Pipeline panel ──
   function handleKeydown(e: KeyboardEvent): void {
     if (e.ctrlKey && e.shiftKey && e.key === 'L') {
@@ -485,6 +541,15 @@
           aria-expanded={showThoughts}
         >
           ◫
+        </button>
+        <button
+          class="export-trace-btn"
+          onclick={(e) => { e.stopPropagation(); void exportReactTrace(); }}
+          disabled={!canExportTrace || exportInFlight}
+          title="Export ReAct trace to JSON"
+          aria-label="Export ReAct trace to JSON"
+        >
+          {exportInFlight ? "…" : "⤓"}
         </button>
         <button class="dismiss-btn" onclick={(e) => { e.stopPropagation(); dismiss(); }} title="Dismiss">✕</button>
       </div>
@@ -786,6 +851,32 @@
     background: rgba(255, 50, 50, 0.2);
     color: #ff5555;
     border-color: rgba(255, 50, 50, 0.3);
+  }
+
+  .export-trace-btn {
+    background: rgba(255, 255, 255, 0.05);
+    border: 1px solid rgba(0, 240, 255, 0.2);
+    color: rgba(0, 240, 255, 0.65);
+    border-radius: 4px;
+    width: 22px;
+    height: 22px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    font-size: 0.7rem;
+    transition: all 0.2s;
+  }
+
+  .export-trace-btn:hover:not(:disabled) {
+    background: rgba(0, 240, 255, 0.12);
+    color: #00f0ff;
+    border-color: rgba(0, 240, 255, 0.45);
+  }
+
+  .export-trace-btn:disabled {
+    opacity: 0.35;
+    cursor: not-allowed;
   }
 
   /* Progress bar */

--- a/tauri-app/ui/src/lib/utils/reactTraceExport.ts
+++ b/tauri-app/ui/src/lib/utils/reactTraceExport.ts
@@ -1,0 +1,107 @@
+/** Types and helpers for exporting the ReAct pipeline trace to JSON. */
+
+export type StageStatus = "idle" | "active" | "success" | "error" | "skipped";
+
+export interface PipelineStageSnapshot {
+  id: string;
+  label: string;
+  status: StageStatus;
+  detail: string;
+  startTime: number;
+  endTime: number;
+  timingMs?: number;
+  decision?: string;
+}
+
+export interface ExecutionActionSnapshot {
+  type: string;
+  target: string;
+  status: string;
+}
+
+export interface ThoughtEntrySnapshot {
+  seq: number;
+  stage: string;
+  stageId: string;
+  text: string;
+  type: string;
+}
+
+export interface TraceEventRecord {
+  timestamp: number;
+  method: string;
+  payload: Record<string, unknown>;
+}
+
+export interface ReactTraceExportPayload {
+  version: 1;
+  exportedAt: string;
+  summary: {
+    progressPercent: number;
+    totalDurationMs: number;
+    stageCount: number;
+    thoughtCount: number;
+    actionCount: number;
+    eventCount: number;
+  };
+  agentRouting: {
+    assigned_agents: string[];
+    is_multi_agent: boolean;
+  } | null;
+  stages: PipelineStageSnapshot[];
+  executionActions: ExecutionActionSnapshot[];
+  thoughts: ThoughtEntrySnapshot[];
+  events: TraceEventRecord[];
+}
+
+export function buildReactTraceExport(input: {
+  stages: Array<{
+    id: string;
+    label: string;
+    status: StageStatus;
+    detail: string;
+    startTime: number;
+    endTime: number;
+  }>;
+  stageTiming: Record<string, number>;
+  stageDecisions: Record<string, string>;
+  executionActions: ExecutionActionSnapshot[];
+  thoughtStream: ThoughtEntrySnapshot[];
+  traceEvents: TraceEventRecord[];
+  agentRouting: { assigned_agents: string[]; is_multi_agent: boolean } | null;
+  progress: number;
+  totalDuration: number;
+}): ReactTraceExportPayload {
+  const stages: PipelineStageSnapshot[] = input.stages.map((stage) => ({
+    id: stage.id,
+    label: stage.label,
+    status: stage.status,
+    detail: stage.detail,
+    startTime: stage.startTime,
+    endTime: stage.endTime,
+    ...(input.stageTiming[stage.id] !== undefined
+      ? { timingMs: input.stageTiming[stage.id] }
+      : {}),
+    ...(input.stageDecisions[stage.id]
+      ? { decision: input.stageDecisions[stage.id] }
+      : {}),
+  }));
+
+  return {
+    version: 1,
+    exportedAt: new Date().toISOString(),
+    summary: {
+      progressPercent: input.progress,
+      totalDurationMs: input.totalDuration,
+      stageCount: stages.length,
+      thoughtCount: input.thoughtStream.length,
+      actionCount: input.executionActions.length,
+      eventCount: input.traceEvents.length,
+    },
+    agentRouting: input.agentRouting,
+    stages,
+    executionActions: input.executionActions,
+    thoughts: input.thoughtStream,
+    events: input.traceEvents,
+  };
+}


### PR DESCRIPTION
## Summary
- Adds a ReAct Pipeline export button (⤓) to save the full agent loop trace as JSON
- Captures all pipeline WebSocket events (not truncated like the on-screen thought stream)
- Adds `export_react_trace` daemon handler that writes to Downloads (same UX as chat export)

Closes #227

## Test plan
- [x] Run a command and open the ReAct Pipeline panel
- [x] Click the export (⤓) button after stages populate
- [x] Verify `heliox-react-trace-*.json` appears in Downloads with stages, thoughts, and events
- [x] Run `pytest daemon/tests/test_export_react_trace.py`