### PR TITLE
feat: add LAN mesh network for peer discovery, skill sync, and collab execution(fixes #214)

### DIFF
--- a/daemon/pilot/config.py
+++ b/daemon/pilot/config.py
@@ -110,6 +110,17 @@ class RSSConfig:
 
 
 @dataclass
+class NetworkConfig:
+    """LAN mesh network configuration for multi-instance collaboration."""
+
+    enabled: bool = False
+    port: int = 8786  # peer-to-peer WebSocket port (separate from client port)
+    peer_timeout_s: int = 30  # seconds before a silent peer is considered gone
+    skill_sync_enabled: bool = True  # broadcast/receive plugins from peers
+    collab_exec_enabled: bool = True  # distribute parallelizable action batches
+
+
+@dataclass
 class SshHostConfig:
     """One allowed SSH destination (referenced by alias in ssh_* actions)."""
 
@@ -148,6 +159,7 @@ class PilotConfig:
     screen_vision: ScreenVisionConfig = field(default_factory=ScreenVisionConfig)
     memory: MemoryConfig = field(default_factory=MemoryConfig)
     rss: RSSConfig = field(default_factory=RSSConfig)
+    network: NetworkConfig = field(default_factory=NetworkConfig)
     ssh: SshConfig = field(default_factory=SshConfig)
     restrictions: Restrictions = field(default_factory=Restrictions)
     first_run_complete: bool = False
@@ -248,6 +260,13 @@ def _validate_config_types(raw: dict) -> None:
             "poll_interval_hours": (int, float),
             "max_items_per_feed": int,
         },
+        "network": {
+            "enabled": bool,
+            "port": int,
+            "peer_timeout_s": int,
+            "skill_sync_enabled": bool,
+            "collab_exec_enabled": bool,
+        },
         "ssh": {
             "enabled": bool,
             "connect_timeout_seconds": int,
@@ -317,6 +336,11 @@ def _merge_config(config: PilotConfig, raw: dict[str, Any]) -> PilotConfig:
         for k, v in raw["rss"].items():
             if hasattr(config.rss, k):
                 setattr(config.rss, k, v)
+
+    if "network" in raw:
+        for k, v in raw["network"].items():
+            if hasattr(config.network, k):
+                setattr(config.network, k, v)
 
     if "ssh" in raw and isinstance(raw["ssh"], dict):
         ssh_raw = raw["ssh"]

--- a/daemon/pilot/network/__init__.py
+++ b/daemon/pilot/network/__init__.py
@@ -1,0 +1,14 @@
+"""LAN mesh network — peer discovery, skill sync, and collaborative execution.
+
+Enable in config.toml:
+
+    [network]
+    enabled = true
+    port = 8786
+    skill_sync_enabled = true
+    collab_exec_enabled = true
+"""
+
+from pilot.network.mesh import HelioxMesh
+
+__all__ = ["HelioxMesh"]

--- a/daemon/pilot/network/collab_executor.py
+++ b/daemon/pilot/network/collab_executor.py
@@ -193,13 +193,27 @@ class CollabExecutor:
 
         try:
             results = await asyncio.wait_for(future, timeout=_REMOTE_TIMEOUT)
-        except asyncio.TimeoutError:
+            # Integrity check: if the peer returned fewer results than actions
+            # in the batch (e.g. due to silent deserialisation failures), fall
+            # back to local execution to avoid silent task truncation.
+            if len(results) != len(batch):
+                logger.warning(
+                    "CollabExecutor: peer %s returned %d result(s) for %d action(s) "
+                    "(task %s) — falling back to local execution",
+                    peer_id,
+                    len(results),
+                    len(batch),
+                    task_id,
+                )
+                raise ValueError(f"Incomplete results from peer {peer_id}: expected {len(batch)}, got {len(results)}")
+        except (asyncio.TimeoutError, ValueError) as exc:
             logger.warning(
-                "CollabExecutor: peer %s timed out for task %s — running locally",
+                "CollabExecutor: peer %s failed for task %s (%s) — running locally",
                 peer_id,
                 task_id,
+                exc,
             )
-            del self._pending[task_id]
+            self._pending.pop(task_id, None)
             sub_plan = ActionPlan(
                 actions=batch,
                 explanation=plan.explanation,

--- a/daemon/pilot/network/collab_executor.py
+++ b/daemon/pilot/network/collab_executor.py
@@ -1,0 +1,268 @@
+"""Collaborative task execution across LAN peers.
+
+Distributes parallelizable action batches to available peers so that
+independent sub-tasks run concurrently on multiple machines.
+
+How it works
+------------
+1. ``Executor._analyze_dependencies()`` already splits an ``ActionPlan``
+   into batches of independent actions.
+2. ``CollabExecutor.distribute()`` takes those batches and assigns each
+   batch to either the local executor or a remote peer, based on peer
+   load and capability.
+3. Remote batches are sent as ``task_delegate`` messages.  The receiving
+   peer executes them and returns ``task_result`` messages.
+4. Results from all peers are merged and returned in original batch order.
+
+Fallback
+--------
+If no peers are available, or if ``collab_exec_enabled`` is False, all
+batches are executed locally — identical to the existing behaviour.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import uuid
+from typing import TYPE_CHECKING, Any
+
+from pilot.actions import Action, ActionPlan, ActionResult
+
+if TYPE_CHECKING:
+    from pilot.agents.executor import Executor
+    from pilot.network.mesh import HelioxMesh
+
+logger = logging.getLogger("pilot.network.collab_executor")
+
+# Maximum seconds to wait for a peer to return results
+_REMOTE_TIMEOUT = 60
+
+
+class CollabExecutor:
+    """Distributes independent action batches across available LAN peers.
+
+    Parameters
+    ----------
+    mesh:
+        The ``HelioxMesh`` instance for peer communication.
+    local_executor:
+        The local ``Executor`` used for batches that stay on this machine.
+    enabled:
+        Master switch — if False all batches run locally.
+    """
+
+    def __init__(
+        self,
+        mesh: HelioxMesh,
+        local_executor: Executor,
+        enabled: bool = True,
+    ) -> None:
+        self._mesh = mesh
+        self._local = local_executor
+        self._enabled = enabled
+        # Maps task_id → asyncio.Future[list[ActionResult]]
+        self._pending: dict[str, asyncio.Future[list[ActionResult]]] = {}
+
+    # ── Public API ────────────────────────────────────────────────────────────
+
+    async def distribute(
+        self,
+        plan: ActionPlan,
+        batches: list[list[Action]],
+    ) -> list[ActionResult]:
+        """Execute batches, distributing to peers where possible.
+
+        Parameters
+        ----------
+        plan:
+            The original ``ActionPlan`` (used for context/metadata).
+        batches:
+            Pre-computed independent action batches from
+            ``Executor._analyze_dependencies()``.
+
+        Returns
+        -------
+        list[ActionResult]
+            All results in the same order as the input batches.
+        """
+        if not self._enabled or not self._mesh.peer_ids:
+            # No peers — run everything locally
+            return await self._run_all_local(plan, batches)
+
+        available_peers = self._get_available_peers()
+        all_results: list[ActionResult] = []
+
+        for i, batch in enumerate(batches):
+            if not batch:
+                continue
+
+            # Assign to a peer if one is available and the batch is safe to delegate
+            peer_id = self._pick_peer(available_peers, batch)
+            if peer_id:
+                results = await self._delegate_to_peer(peer_id, batch, plan)
+            else:
+                sub_plan = ActionPlan(
+                    actions=batch,
+                    explanation=f"Collab batch {i + 1}/{len(batches)}",
+                    raw_input=plan.raw_input,
+                )
+                results = await self._local.execute(sub_plan)
+
+            all_results.extend(results)
+
+            # Stop distributing if a batch failed
+            if any(not r.success for r in results):
+                logger.warning("CollabExecutor: batch %d failed — running remaining batches locally", i + 1)
+                for remaining_batch in batches[i + 1 :]:
+                    sub_plan = ActionPlan(
+                        actions=remaining_batch,
+                        explanation=f"Collab batch (fallback) {i + 2}/{len(batches)}",
+                        raw_input=plan.raw_input,
+                    )
+                    all_results.extend(await self._local.execute(sub_plan))
+                break
+
+        return all_results
+
+    async def handle_task_result(self, peer_id: str, payload: dict[str, Any]) -> None:
+        """Called by HelioxMesh when a ``task_result`` message arrives.
+
+        Parameters
+        ----------
+        peer_id:
+            The peer that completed the task.
+        payload:
+            Dict with ``task_id`` and ``results`` (list of serialised ActionResult).
+        """
+        task_id = payload.get("task_id", "")
+        future = self._pending.get(task_id)
+        if future is None:
+            logger.warning("CollabExecutor: received result for unknown task_id %s", task_id)
+            return
+
+        raw_results = payload.get("results", [])
+        results = _deserialize_results(raw_results)
+        future.set_result(results)
+        logger.info(
+            "CollabExecutor: received %d result(s) from peer %s for task %s",
+            len(results),
+            peer_id,
+            task_id,
+        )
+
+    # ── Internal helpers ──────────────────────────────────────────────────────
+
+    async def _run_all_local(self, plan: ActionPlan, batches: list[list[Action]]) -> list[ActionResult]:
+        results: list[ActionResult] = []
+        for batch in batches:
+            if not batch:
+                continue
+            sub_plan = ActionPlan(
+                actions=batch,
+                explanation=plan.explanation,
+                raw_input=plan.raw_input,
+            )
+            results.extend(await self._local.execute(sub_plan))
+        return results
+
+    async def _delegate_to_peer(
+        self,
+        peer_id: str,
+        batch: list[Action],
+        plan: ActionPlan,
+    ) -> list[ActionResult]:
+        """Send a batch to a peer and wait for results."""
+        task_id = str(uuid.uuid4())[:8]
+        loop = asyncio.get_event_loop()
+        future: asyncio.Future[list[ActionResult]] = loop.create_future()
+        self._pending[task_id] = future
+
+        payload = {
+            "task_id": task_id,
+            "actions": [_serialize_action(a) for a in batch],
+            "raw_input": plan.raw_input,
+        }
+        await self._mesh.send_to(peer_id, "task_delegate", payload)
+        logger.info(
+            "CollabExecutor: delegated %d action(s) to peer %s (task %s)",
+            len(batch),
+            peer_id,
+            task_id,
+        )
+
+        try:
+            results = await asyncio.wait_for(future, timeout=_REMOTE_TIMEOUT)
+        except asyncio.TimeoutError:
+            logger.warning(
+                "CollabExecutor: peer %s timed out for task %s — running locally",
+                peer_id,
+                task_id,
+            )
+            del self._pending[task_id]
+            sub_plan = ActionPlan(
+                actions=batch,
+                explanation=plan.explanation,
+                raw_input=plan.raw_input,
+            )
+            results = await self._local.execute(sub_plan)
+        finally:
+            self._pending.pop(task_id, None)
+
+        return results
+
+    def _get_available_peers(self) -> list[str]:
+        """Return peer IDs that are connected and can execute tasks."""
+        available = []
+        for pid in self._mesh.peer_ids:
+            conn = self._mesh.get_connection(pid)
+            if conn and conn.connected:
+                caps = conn.peer_capabilities
+                if caps is None or caps.can_execute:
+                    available.append(pid)
+        return available
+
+    def _pick_peer(self, available: list[str], batch: list[Action]) -> str | None:
+        """Pick the least-loaded peer for a batch, or None to run locally.
+
+        Only delegates READ_ONLY and USER_WRITE tier actions — never
+        delegates SYSTEM_MODIFY, DESTRUCTIVE, or ROOT_CRITICAL actions.
+        """
+        from pilot.actions import PermissionTier
+
+        for action in batch:
+            if action.permission_tier >= PermissionTier.SYSTEM_MODIFY:
+                return None  # keep sensitive actions local
+
+        if not available:
+            return None
+
+        # Pick peer with lowest reported CPU load
+        best = min(
+            available,
+            key=lambda pid: (
+                self._mesh.get_connection(pid).peer_capabilities.cpu_load
+                if self._mesh.get_connection(pid) and self._mesh.get_connection(pid).peer_capabilities
+                else 1.0
+            ),
+        )
+        return best
+
+
+# ── Serialisation helpers ─────────────────────────────────────────────────────
+
+
+def _serialize_action(action: Action) -> dict[str, Any]:
+    """Convert an Action to a JSON-serialisable dict."""
+    return action.model_dump(mode="json")
+
+
+def _deserialize_results(raw: list[dict[str, Any]]) -> list[ActionResult]:
+    """Reconstruct ActionResult objects from peer response payload."""
+    results = []
+    for item in raw:
+        try:
+            results.append(ActionResult.model_validate(item))
+        except Exception as exc:
+            logger.warning("CollabExecutor: failed to deserialise result: %s", exc)
+    return results

--- a/daemon/pilot/network/mesh.py
+++ b/daemon/pilot/network/mesh.py
@@ -1,0 +1,349 @@
+"""HelioxMesh — LAN mesh orchestrator.
+
+Ties together peer discovery, peer connections, skill sync, and
+collaborative execution into a single object that ``PilotServer``
+starts and stops alongside the main WebSocket server.
+
+Lifecycle
+---------
+    mesh = HelioxMesh(config, executor, plugin_manager)
+    await mesh.start()          # begins mDNS advertising + browsing
+    ...
+    await mesh.stop()           # deregisters mDNS, closes all connections
+
+Architecture
+------------
+                    ┌─────────────────────────────────┐
+                    │           HelioxMesh             │
+                    │                                  │
+    mDNS ──────────►│  PeerDiscovery                   │
+                    │      │ on_peer_found              │
+                    │      ▼                            │
+                    │  PeerConnection pool              │
+                    │      │ on_message                 │
+                    │      ├──► SkillSync               │
+                    │      └──► CollabExecutor          │
+                    │                                  │
+                    │  P2P WebSocket server (inbound)  │
+                    └─────────────────────────────────┘
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import socket
+import uuid
+from typing import TYPE_CHECKING, Any
+
+from pilot.network.peer_connection import PeerCapabilities, PeerConnection
+
+if TYPE_CHECKING:
+    from pilot.agents.executor import Executor
+    from pilot.config import NetworkConfig
+    from pilot.system.plugins import PluginManager
+
+logger = logging.getLogger("pilot.network.mesh")
+
+
+class HelioxMesh:
+    """Central coordinator for the LAN mesh network.
+
+    Parameters
+    ----------
+    config:
+        ``NetworkConfig`` from ``PilotConfig``.
+    executor:
+        The local ``Executor`` instance (used by ``CollabExecutor``).
+    plugin_manager:
+        The global ``PluginManager`` (used by ``SkillSync``).
+    """
+
+    def __init__(
+        self,
+        config: NetworkConfig,
+        executor: Executor,
+        plugin_manager: PluginManager,
+    ) -> None:
+        self._config = config
+        self._executor = executor
+        self._plugin_manager = plugin_manager
+        self._instance_id = str(uuid.uuid4())[:8]
+
+        self._connections: dict[str, PeerConnection] = {}
+        self._discovery: Any = None  # PeerDiscovery (lazy import)
+        self._skill_sync: Any = None  # SkillSync (lazy import)
+        self._collab: Any = None  # CollabExecutor (lazy import)
+        self._p2p_server: Any = None  # inbound WebSocket server
+        self._running = False
+
+    # ── Properties ────────────────────────────────────────────────────────────
+
+    @property
+    def peer_ids(self) -> list[str]:
+        """IDs of all currently connected peers."""
+        return [pid for pid, conn in self._connections.items() if conn.connected]
+
+    def get_connection(self, peer_id: str) -> PeerConnection | None:
+        return self._connections.get(peer_id)
+
+    @property
+    def instance_id(self) -> str:
+        return self._instance_id
+
+    # ── Lifecycle ─────────────────────────────────────────────────────────────
+
+    async def start(self) -> None:
+        """Start the mesh: P2P server, discovery, skill sync, collab executor."""
+        if self._running:
+            return
+        self._running = True
+
+        # Lazy imports so missing optional deps don't crash the daemon
+        from pilot.network.collab_executor import CollabExecutor
+        from pilot.network.peer_discovery import PeerDiscovery
+        from pilot.network.skill_sync import SkillSync
+
+        self._skill_sync = SkillSync(self)
+        self._collab = CollabExecutor(
+            mesh=self,
+            local_executor=self._executor,
+            enabled=self._config.collab_exec_enabled,
+        )
+
+        # Start inbound P2P WebSocket server
+        asyncio.create_task(self._start_p2p_server())
+
+        # Start mDNS discovery
+        self._discovery = PeerDiscovery(
+            port=self._config.port,
+            instance_id=self._instance_id,
+        )
+        self._discovery.on_peer_found = self._on_peer_found
+        self._discovery.on_peer_lost = self._on_peer_lost
+        await self._discovery.start()
+
+        logger.info(
+            "HelioxMesh started (instance=%s, port=%d)",
+            self._instance_id,
+            self._config.port,
+        )
+
+    async def stop(self) -> None:
+        """Shut down all connections and deregister from mDNS."""
+        self._running = False
+
+        # Close all peer connections
+        for conn in list(self._connections.values()):
+            await conn.disconnect()
+        self._connections.clear()
+
+        # Stop discovery
+        if self._discovery:
+            await self._discovery.stop()
+
+        # Stop P2P server
+        if self._p2p_server:
+            self._p2p_server.close()
+            await self._p2p_server.wait_closed()
+
+        logger.info("HelioxMesh stopped")
+
+    # ── Messaging ─────────────────────────────────────────────────────────────
+
+    async def broadcast(self, msg_type: str, payload: dict[str, Any]) -> None:
+        """Send a message to all connected peers."""
+        for pid in list(self.peer_ids):
+            await self.send_to(pid, msg_type, payload)
+
+    async def send_to(self, peer_id: str, msg_type: str, payload: dict[str, Any]) -> None:
+        """Send a message to a specific peer."""
+        conn = self._connections.get(peer_id)
+        if conn and conn.connected:
+            await conn.send(msg_type, payload)
+        else:
+            logger.warning("HelioxMesh.send_to: peer %s not connected", peer_id)
+
+    # ── Peer events ───────────────────────────────────────────────────────────
+
+    def _on_peer_found(self, peer_info: Any) -> None:
+        """Called by PeerDiscovery when a new peer is found on the LAN."""
+        asyncio.ensure_future(self._connect_to_peer(peer_info))
+
+    def _on_peer_lost(self, peer_id: str) -> None:
+        """Called by PeerDiscovery when a peer deregisters."""
+        conn = self._connections.pop(peer_id, None)
+        if conn:
+            asyncio.ensure_future(conn.disconnect())
+        logger.info("HelioxMesh: peer %s left the mesh", peer_id)
+
+    async def _connect_to_peer(self, peer_info: Any) -> None:
+        """Establish an outbound connection to a newly discovered peer."""
+        peer_id = peer_info.peer_id
+        if peer_id in self._connections:
+            return  # already connected
+
+        own_caps = self._build_own_capabilities()
+        conn = PeerConnection(
+            peer_id=peer_id,
+            host=peer_info.host,
+            port=peer_info.port,
+            own_capabilities=own_caps,
+            on_message=self._on_peer_message,
+            on_disconnect=self._on_connection_lost,
+        )
+        success = await conn.connect()
+        if success:
+            self._connections[peer_id] = conn
+            logger.info("HelioxMesh: joined mesh with peer %s", peer_id)
+
+            # Broadcast our loaded plugins to the new peer
+            if self._config.skill_sync_enabled and self._skill_sync:
+                asyncio.create_task(self._sync_plugins_to_peer(peer_id))
+
+    def _on_connection_lost(self, peer_id: str) -> None:
+        """Called by PeerConnection when a connection drops unexpectedly."""
+        self._connections.pop(peer_id, None)
+        logger.info("HelioxMesh: connection to peer %s lost", peer_id)
+
+    # ── Message routing ───────────────────────────────────────────────────────
+
+    async def _on_peer_message(self, peer_id: str, msg_type: str, payload: dict[str, Any]) -> None:
+        """Route inbound peer messages to the appropriate handler."""
+        if msg_type == "skill_sync" and self._config.skill_sync_enabled:
+            if self._skill_sync:
+                await self._skill_sync.handle_incoming(peer_id, payload)
+
+        elif msg_type == "skill_ack":
+            logger.info(
+                "HelioxMesh: peer %s acknowledged plugin '%s' (%s)",
+                peer_id,
+                payload.get("name"),
+                payload.get("status"),
+            )
+
+        elif msg_type == "task_delegate" and self._config.collab_exec_enabled:
+            asyncio.create_task(self._handle_delegated_task(peer_id, payload))
+
+        elif msg_type == "task_result":
+            if self._collab:
+                await self._collab.handle_task_result(peer_id, payload)
+
+        else:
+            logger.debug("HelioxMesh: unhandled message type '%s' from %s", msg_type, peer_id)
+
+    # ── Inbound P2P server ────────────────────────────────────────────────────
+
+    async def _start_p2p_server(self) -> None:
+        """Start a WebSocket server that accepts inbound peer connections."""
+        try:
+            import websockets
+
+            self._p2p_server = await websockets.serve(
+                self._handle_inbound_peer,
+                "0.0.0.0",
+                self._config.port,
+            )
+            logger.info("HelioxMesh: P2P server listening on port %d", self._config.port)
+        except Exception as exc:
+            logger.error("HelioxMesh: failed to start P2P server: %s", exc)
+
+    async def _handle_inbound_peer(self, websocket: Any) -> None:
+        """Handle an inbound WebSocket connection from a peer."""
+        import json
+
+        peer_id: str | None = None
+        try:
+            async for raw in websocket:
+                msg = json.loads(raw)
+                msg_type = msg.get("type", "")
+                payload = msg.get("payload", {})
+
+                if msg_type == "peer_info":
+                    peer_id = payload.get("instance_id", str(uuid.uuid4())[:8])
+                    # Register a lightweight inbound connection wrapper
+                    if peer_id not in self._connections:
+                        own_caps = self._build_own_capabilities()
+                        conn = PeerConnection(
+                            peer_id=peer_id,
+                            host=websocket.remote_address[0],
+                            port=self._config.port,
+                            own_capabilities=own_caps,
+                            on_message=self._on_peer_message,
+                            on_disconnect=self._on_connection_lost,
+                        )
+                        # Attach the already-open websocket
+                        conn._ws = websocket
+                        conn._connected = True
+                        self._connections[peer_id] = conn
+                        logger.info("HelioxMesh: inbound peer %s connected", peer_id)
+                    continue
+
+                if peer_id:
+                    await self._on_peer_message(peer_id, msg_type, payload)
+        except Exception as exc:
+            logger.debug("HelioxMesh: inbound peer connection closed: %s", exc)
+        finally:
+            if peer_id:
+                self._connections.pop(peer_id, None)
+
+    # ── Delegated task execution ──────────────────────────────────────────────
+
+    async def _handle_delegated_task(self, peer_id: str, payload: dict[str, Any]) -> None:
+        """Execute a batch of actions delegated by a peer and return results."""
+        import json
+
+        from pilot.actions import Action, ActionPlan
+
+        task_id = payload.get("task_id", "")
+        raw_actions = payload.get("actions", [])
+        raw_input = payload.get("raw_input", "")
+
+        try:
+            actions = [Action.model_validate(a) for a in raw_actions]
+        except Exception as exc:
+            logger.warning("HelioxMesh: failed to deserialise delegated actions: %s", exc)
+            await self.send_to(peer_id, "task_result", {"task_id": task_id, "results": []})
+            return
+
+        plan = ActionPlan(actions=actions, raw_input=raw_input, explanation="Delegated by peer")
+        results = await self._executor.execute(plan)
+
+        serialised = [r.model_dump(mode="json") for r in results]
+        await self.send_to(peer_id, "task_result", {"task_id": task_id, "results": serialised})
+        logger.info(
+            "HelioxMesh: completed delegated task %s for peer %s (%d results)",
+            task_id,
+            peer_id,
+            len(results),
+        )
+
+    # ── Plugin sync helpers ───────────────────────────────────────────────────
+
+    async def _sync_plugins_to_peer(self, peer_id: str) -> None:
+        """Send all locally loaded plugins to a newly connected peer."""
+        if not self._skill_sync:
+            return
+        plugins = self._plugin_manager.list_plugins()
+        for plugin in plugins:
+            if plugin.get("loaded") and plugin.get("file_path"):
+                await self._skill_sync.broadcast_plugin(plugin["name"], plugin["file_path"])
+
+    def _build_own_capabilities(self) -> PeerCapabilities:
+        """Build a capability advertisement for this instance."""
+        try:
+            import psutil
+
+            cpu_load = psutil.cpu_percent(interval=None) / 100.0
+        except Exception:
+            cpu_load = 0.0
+
+        plugins = [p["name"] for p in self._plugin_manager.list_plugins() if p.get("loaded")]
+
+        return PeerCapabilities(
+            instance_id=self._instance_id,
+            hostname=socket.gethostname(),
+            can_execute=self._config.collab_exec_enabled,
+            cpu_load=cpu_load,
+            plugin_names=plugins,
+        )

--- a/daemon/pilot/network/peer_connection.py
+++ b/daemon/pilot/network/peer_connection.py
@@ -1,0 +1,213 @@
+"""Peer-to-peer WebSocket connection manager.
+
+Each ``PeerConnection`` manages a single persistent asyncio WebSocket
+connection to one remote Heliox OS instance.  Messages are framed as
+JSON-RPC 2.0 notifications (no request/response needed for most P2P traffic).
+
+Message types
+-------------
+``skill_sync``      — plugin source payload (name, source, metadata)
+``skill_ack``       — acknowledgement after installing a received plugin
+``task_delegate``   — an ActionPlan batch delegated for remote execution
+``task_result``     — ActionResult list returned after remote execution
+``heartbeat``       — keepalive ping
+``heartbeat_ack``   — keepalive pong
+``peer_info``       — capability advertisement sent on connect
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import time
+import uuid
+from dataclasses import dataclass, field
+from typing import Any, Callable
+
+logger = logging.getLogger("pilot.network.peer_connection")
+
+_HEARTBEAT_INTERVAL = 15  # seconds between heartbeat pings
+_HEARTBEAT_TIMEOUT = 45  # seconds before declaring a peer dead
+
+
+@dataclass
+class PeerCapabilities:
+    """What a peer can do — sent on handshake."""
+
+    instance_id: str
+    hostname: str = ""
+    version: str = "0.7"
+    can_execute: bool = True  # can accept delegated tasks
+    cpu_load: float = 0.0  # 0.0–1.0, used for load balancing
+    plugin_names: list[str] = field(default_factory=list)
+
+
+class PeerConnection:
+    """Manages a WebSocket connection to a single peer.
+
+    Parameters
+    ----------
+    peer_id:
+        The remote instance's unique ID.
+    host / port:
+        Address of the remote peer's P2P server.
+    own_capabilities:
+        This instance's capabilities, sent during handshake.
+    on_message:
+        Async callback invoked for every inbound message.
+        Signature: ``async def on_message(peer_id, msg_type, payload) -> None``
+    on_disconnect:
+        Sync callback invoked when the connection drops.
+    """
+
+    def __init__(
+        self,
+        peer_id: str,
+        host: str,
+        port: int,
+        own_capabilities: PeerCapabilities,
+        on_message: Callable[[str, str, dict[str, Any]], Any] | None = None,
+        on_disconnect: Callable[[str], None] | None = None,
+    ) -> None:
+        self.peer_id = peer_id
+        self.host = host
+        self.port = port
+        self._own_caps = own_capabilities
+        self._on_message = on_message
+        self._on_disconnect = on_disconnect
+
+        self._ws: Any = None  # websockets connection
+        self._connected = False
+        self._last_heartbeat = 0.0
+        self._peer_caps: PeerCapabilities | None = None
+        self._send_queue: asyncio.Queue[str] = asyncio.Queue()
+        self._task: asyncio.Task | None = None
+
+    @property
+    def connected(self) -> bool:
+        return self._connected
+
+    @property
+    def peer_capabilities(self) -> PeerCapabilities | None:
+        return self._peer_caps
+
+    async def connect(self) -> bool:
+        """Establish the WebSocket connection and start the I/O loop."""
+        try:
+            import websockets
+
+            uri = f"ws://{self.host}:{self.port}/peer"
+            self._ws = await websockets.connect(uri, open_timeout=5, ping_interval=None)
+            self._connected = True
+            self._last_heartbeat = time.time()
+            logger.info("PeerConnection: connected to %s @ %s:%d", self.peer_id, self.host, self.port)
+
+            # Send our capabilities on connect
+            await self._send_raw("peer_info", self._own_caps.__dict__)
+
+            # Start I/O tasks
+            self._task = asyncio.create_task(self._run())
+            return True
+        except Exception as exc:
+            logger.warning("PeerConnection: failed to connect to %s: %s", self.peer_id, exc)
+            self._connected = False
+            return False
+
+    async def disconnect(self) -> None:
+        """Gracefully close the connection."""
+        self._connected = False
+        if self._task:
+            self._task.cancel()
+        if self._ws:
+            try:
+                await self._ws.close()
+            except Exception:
+                pass
+        logger.info("PeerConnection: disconnected from %s", self.peer_id)
+
+    async def send(self, msg_type: str, payload: dict[str, Any]) -> None:
+        """Enqueue a message for sending."""
+        if not self._connected:
+            logger.warning("PeerConnection.send: not connected to %s", self.peer_id)
+            return
+        await self._send_queue.put(json.dumps({"type": msg_type, "payload": payload}))
+
+    async def _send_raw(self, msg_type: str, payload: dict[str, Any]) -> None:
+        """Send immediately (used for handshake before the queue loop starts)."""
+        if self._ws:
+            await self._ws.send(json.dumps({"type": msg_type, "payload": payload}))
+
+    async def _run(self) -> None:
+        """Main I/O loop: receive messages and drain the send queue."""
+        recv_task = asyncio.create_task(self._recv_loop())
+        send_task = asyncio.create_task(self._send_loop())
+        hb_task = asyncio.create_task(self._heartbeat_loop())
+
+        try:
+            done, pending = await asyncio.wait(
+                [recv_task, send_task, hb_task],
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+            for t in pending:
+                t.cancel()
+        except asyncio.CancelledError:
+            recv_task.cancel()
+            send_task.cancel()
+            hb_task.cancel()
+        finally:
+            self._connected = False
+            if self._on_disconnect:
+                self._on_disconnect(self.peer_id)
+
+    async def _recv_loop(self) -> None:
+        """Receive and dispatch inbound messages."""
+        try:
+            async for raw in self._ws:
+                try:
+                    msg = json.loads(raw)
+                    msg_type = msg.get("type", "")
+                    payload = msg.get("payload", {})
+
+                    if msg_type == "heartbeat":
+                        await self._send_raw("heartbeat_ack", {})
+                        self._last_heartbeat = time.time()
+                        continue
+                    if msg_type == "heartbeat_ack":
+                        self._last_heartbeat = time.time()
+                        continue
+                    if msg_type == "peer_info":
+                        self._peer_caps = PeerCapabilities(**payload)
+                        logger.debug("PeerConnection: received caps from %s", self.peer_id)
+                        continue
+
+                    if self._on_message:
+                        await self._on_message(self.peer_id, msg_type, payload)
+                except Exception as exc:
+                    logger.warning("PeerConnection: error handling message from %s: %s", self.peer_id, exc)
+        except Exception as exc:
+            logger.info("PeerConnection: recv loop ended for %s: %s", self.peer_id, exc)
+
+    async def _send_loop(self) -> None:
+        """Drain the outbound send queue."""
+        while self._connected:
+            try:
+                raw = await asyncio.wait_for(self._send_queue.get(), timeout=1.0)
+                await self._ws.send(raw)
+            except asyncio.TimeoutError:
+                continue
+            except Exception as exc:
+                logger.warning("PeerConnection: send error to %s: %s", self.peer_id, exc)
+                break
+
+    async def _heartbeat_loop(self) -> None:
+        """Send periodic heartbeats and detect dead peers."""
+        while self._connected:
+            await asyncio.sleep(_HEARTBEAT_INTERVAL)
+            if not self._connected:
+                break
+            elapsed = time.time() - self._last_heartbeat
+            if elapsed > _HEARTBEAT_TIMEOUT:
+                logger.warning("PeerConnection: peer %s timed out (%.0fs)", self.peer_id, elapsed)
+                break
+            await self._send_raw("heartbeat", {"ts": time.time()})

--- a/daemon/pilot/network/peer_discovery.py
+++ b/daemon/pilot/network/peer_discovery.py
@@ -1,0 +1,208 @@
+"""LAN peer discovery via mDNS/DNS-SD (zeroconf).
+
+Broadcasts a ``_helioxos._tcp.local.`` service record so every Heliox OS
+instance on the same LAN can find each other without any manual configuration.
+
+Usage
+-----
+    discovery = PeerDiscovery(port=8786, instance_id="abc123")
+    discovery.on_peer_found = lambda info: ...
+    discovery.on_peer_lost  = lambda peer_id: ...
+    await discovery.start()
+    ...
+    await discovery.stop()
+
+Graceful degradation
+--------------------
+If ``zeroconf`` is not installed the module logs a warning and all methods
+become no-ops so the rest of the daemon starts normally.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import socket
+import uuid
+from dataclasses import dataclass
+from typing import Callable
+
+logger = logging.getLogger("pilot.network.peer_discovery")
+
+_ZEROCONF_AVAILABLE = False
+try:
+    from zeroconf import ServiceBrowser, ServiceInfo, ServiceStateChange, Zeroconf
+    from zeroconf.asyncio import AsyncServiceBrowser, AsyncZeroconf
+
+    _ZEROCONF_AVAILABLE = True
+except ImportError:
+    logger.warning("zeroconf not installed — LAN peer discovery disabled. Install with: pip install zeroconf")
+
+_SERVICE_TYPE = "_helioxos._tcp.local."
+
+
+@dataclass
+class PeerInfo:
+    """Metadata about a discovered peer instance."""
+
+    peer_id: str  # unique instance UUID
+    host: str  # IPv4 address
+    port: int  # P2P WebSocket port
+    hostname: str = ""  # human-readable hostname
+
+
+class PeerDiscovery:
+    """Advertises this instance on the LAN and discovers other instances.
+
+    Callbacks
+    ---------
+    on_peer_found(PeerInfo)  — called when a new peer is discovered
+    on_peer_lost(peer_id)    — called when a peer deregisters or times out
+    """
+
+    def __init__(self, port: int, instance_id: str | None = None) -> None:
+        self._port = port
+        self._instance_id = instance_id or str(uuid.uuid4())[:8]
+        self._zc: AsyncZeroconf | None = None
+        self._browser: AsyncServiceBrowser | None = None
+        self._service_info: ServiceInfo | None = None
+        self._known_peers: dict[str, PeerInfo] = {}
+
+        # Public callbacks — set by HelioxMesh
+        self.on_peer_found: Callable[[PeerInfo], None] | None = None
+        self.on_peer_lost: Callable[[str], None] | None = None
+
+    @property
+    def instance_id(self) -> str:
+        return self._instance_id
+
+    @property
+    def known_peers(self) -> dict[str, PeerInfo]:
+        return dict(self._known_peers)
+
+    async def start(self) -> None:
+        """Start advertising and browsing."""
+        if not _ZEROCONF_AVAILABLE:
+            logger.warning("PeerDiscovery.start() skipped — zeroconf not available")
+            return
+
+        self._zc = AsyncZeroconf()
+
+        # Register our own service
+        hostname = socket.gethostname()
+        local_ip = _get_local_ip()
+        service_name = f"helioxos-{self._instance_id}.{_SERVICE_TYPE}"
+
+        self._service_info = ServiceInfo(
+            type_=_SERVICE_TYPE,
+            name=service_name,
+            addresses=[socket.inet_aton(local_ip)],
+            port=self._port,
+            properties={
+                "id": self._instance_id.encode(),
+                "host": hostname.encode(),
+            },
+            server=f"{hostname}.local.",
+        )
+
+        await self._zc.async_register_service(self._service_info)
+        logger.info(
+            "PeerDiscovery: registered as %s @ %s:%d",
+            self._instance_id,
+            local_ip,
+            self._port,
+        )
+
+        # Browse for other instances
+        self._browser = AsyncServiceBrowser(
+            self._zc.zeroconf,
+            _SERVICE_TYPE,
+            handlers=[self._on_service_state_change],
+        )
+        logger.info("PeerDiscovery: browsing for %s", _SERVICE_TYPE)
+
+    async def stop(self) -> None:
+        """Deregister and shut down."""
+        if not _ZEROCONF_AVAILABLE or self._zc is None:
+            return
+        if self._service_info:
+            await self._zc.async_unregister_service(self._service_info)
+        await self._zc.async_close()
+        self._zc = None
+        logger.info("PeerDiscovery: stopped")
+
+    def _on_service_state_change(
+        self,
+        zeroconf: Zeroconf,
+        service_type: str,
+        name: str,
+        state_change: ServiceStateChange,
+    ) -> None:
+        """Handle mDNS service state changes (runs in zeroconf's thread)."""
+        asyncio.get_event_loop().call_soon_threadsafe(
+            self._handle_state_change_sync, zeroconf, service_type, name, state_change
+        )
+
+    def _handle_state_change_sync(
+        self,
+        zeroconf: Zeroconf,
+        service_type: str,
+        name: str,
+        state_change: ServiceStateChange,
+    ) -> None:
+        asyncio.ensure_future(self._handle_state_change(zeroconf, service_type, name, state_change))
+
+    async def _handle_state_change(
+        self,
+        zeroconf: Zeroconf,
+        service_type: str,
+        name: str,
+        state_change: ServiceStateChange,
+    ) -> None:
+        if state_change is ServiceStateChange.Added:
+            info = ServiceInfo(service_type, name)
+            await info.async_request(zeroconf, timeout=3000)
+
+            if not info.addresses:
+                return
+
+            peer_id_bytes = info.properties.get(b"id", b"")
+            peer_id = peer_id_bytes.decode() if peer_id_bytes else name
+            host_bytes = info.properties.get(b"host", b"")
+            hostname = host_bytes.decode() if host_bytes else ""
+
+            # Skip ourselves
+            if peer_id == self._instance_id:
+                return
+
+            host = socket.inet_ntoa(info.addresses[0])
+            peer = PeerInfo(
+                peer_id=peer_id,
+                host=host,
+                port=info.port,
+                hostname=hostname,
+            )
+            self._known_peers[peer_id] = peer
+            logger.info("PeerDiscovery: found peer %s @ %s:%d", peer_id, host, info.port)
+
+            if self.on_peer_found:
+                self.on_peer_found(peer)
+
+        elif state_change is ServiceStateChange.Removed:
+            # Extract peer_id from service name: "helioxos-<id>._helioxos._tcp.local."
+            peer_id = name.split(".")[0].replace("helioxos-", "")
+            if peer_id in self._known_peers:
+                del self._known_peers[peer_id]
+                logger.info("PeerDiscovery: lost peer %s", peer_id)
+                if self.on_peer_lost:
+                    self.on_peer_lost(peer_id)
+
+
+def _get_local_ip() -> str:
+    """Return the primary LAN IPv4 address of this machine."""
+    try:
+        with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as s:
+            s.connect(("8.8.8.8", 80))
+            return s.getsockname()[0]
+    except Exception:
+        return "127.0.0.1"

--- a/daemon/pilot/network/skill_sync.py
+++ b/daemon/pilot/network/skill_sync.py
@@ -1,0 +1,125 @@
+"""Skill/plugin synchronisation across LAN peers.
+
+When a plugin is loaded locally it is broadcast to all connected peers.
+When a peer sends a plugin payload it is validated and installed into
+``~/.config/heliox-os/plugins/`` via the existing ``PluginManager``.
+
+Security model
+--------------
+- Plugin source is validated as syntactically correct Python before writing
+- File names are sanitised (alphanumeric + underscore only)
+- Plugins received from peers are stored in a dedicated ``peer_plugins/``
+  sub-directory so they can be audited or removed independently
+- No arbitrary code is executed during sync — the plugin is only *installed*;
+  it is loaded by the PluginManager on the next discovery cycle
+"""
+
+from __future__ import annotations
+
+import ast
+import logging
+import re
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from pilot.network.mesh import HelioxMesh
+
+logger = logging.getLogger("pilot.network.skill_sync")
+
+_SAFE_NAME_RE = re.compile(r"^[a-zA-Z0-9_]{1,64}$")
+_PEER_PLUGIN_SUBDIR = "peer_plugins"
+
+
+class SkillSync:
+    """Handles plugin serialisation, broadcast, and installation.
+
+    Parameters
+    ----------
+    mesh:
+        The ``HelioxMesh`` instance used to broadcast to peers.
+    plugin_base_dir:
+        Base directory for plugins (default: ``~/.config/heliox-os/plugins``).
+    """
+
+    def __init__(self, mesh: HelioxMesh, plugin_base_dir: str | None = None) -> None:
+        self._mesh = mesh
+        base = Path(plugin_base_dir or Path.home() / ".config" / "heliox-os" / "plugins")
+        self._peer_dir = base / _PEER_PLUGIN_SUBDIR
+        self._peer_dir.mkdir(parents=True, exist_ok=True)
+
+    # ── Outbound: broadcast a locally loaded plugin ───────────────────────────
+
+    async def broadcast_plugin(self, plugin_name: str, file_path: str) -> None:
+        """Read a plugin file and broadcast its source to all peers.
+
+        Parameters
+        ----------
+        plugin_name:
+            The plugin's canonical name (from ``PLUGIN_NAME``).
+        file_path:
+            Absolute path to the ``.py`` plugin file.
+        """
+        try:
+            source = Path(file_path).read_text(encoding="utf-8")
+        except OSError as exc:
+            logger.warning("SkillSync: cannot read plugin %s: %s", file_path, exc)
+            return
+
+        payload: dict[str, Any] = {
+            "name": plugin_name,
+            "filename": Path(file_path).name,
+            "source": source,
+        }
+        await self._mesh.broadcast("skill_sync", payload)
+        logger.info("SkillSync: broadcast plugin '%s' to %d peer(s)", plugin_name, len(self._mesh.peer_ids))
+
+    # ── Inbound: install a plugin received from a peer ────────────────────────
+
+    async def handle_incoming(self, peer_id: str, payload: dict[str, Any]) -> None:
+        """Validate and install a plugin received from a peer.
+
+        Parameters
+        ----------
+        peer_id:
+            The sending peer's instance ID (used for logging).
+        payload:
+            Dict with keys ``name``, ``filename``, ``source``.
+        """
+        name = payload.get("name", "")
+        filename = payload.get("filename", "")
+        source = payload.get("source", "")
+
+        # Validate name and filename
+        stem = Path(filename).stem
+        if not _SAFE_NAME_RE.match(stem):
+            logger.warning("SkillSync: rejected plugin from %s — unsafe filename '%s'", peer_id, filename)
+            return
+
+        if not filename.endswith(".py"):
+            logger.warning("SkillSync: rejected plugin from %s — not a .py file", peer_id)
+            return
+
+        # Validate Python syntax before writing
+        try:
+            ast.parse(source)
+        except SyntaxError as exc:
+            logger.warning("SkillSync: rejected plugin '%s' from %s — syntax error: %s", name, peer_id, exc)
+            return
+
+        dest = self._peer_dir / filename
+        # Never overwrite a locally authored plugin
+        local_plugin = self._peer_dir.parent / filename
+        if local_plugin.exists():
+            logger.info("SkillSync: skipping '%s' — local version already exists", filename)
+            return
+
+        dest.write_text(source, encoding="utf-8")
+        logger.info("SkillSync: installed plugin '%s' from peer %s → %s", name, peer_id, dest)
+
+        # Acknowledge back to the sender
+        await self._mesh.send_to(peer_id, "skill_ack", {"name": name, "status": "installed"})
+
+    def list_peer_plugins(self) -> list[str]:
+        """Return names of all plugins received from peers."""
+        return [p.stem for p in self._peer_dir.glob("*.py")]

--- a/daemon/pilot/network/skill_sync.py
+++ b/daemon/pilot/network/skill_sync.py
@@ -6,8 +6,10 @@ When a peer sends a plugin payload it is validated and installed into
 
 Security model
 --------------
+- Full filename validated against ``^[a-zA-Z0-9_]{1,64}\\.py$`` — prevents
+  directory traversal attacks (e.g. ``../../evil.py``) that would bypass a
+  stem-only check
 - Plugin source is validated as syntactically correct Python before writing
-- File names are sanitised (alphanumeric + underscore only)
 - Plugins received from peers are stored in a dedicated ``peer_plugins/``
   sub-directory so they can be audited or removed independently
 - No arbitrary code is executed during sync — the plugin is only *installed*;
@@ -27,7 +29,6 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger("pilot.network.skill_sync")
 
-_SAFE_NAME_RE = re.compile(r"^[a-zA-Z0-9_]{1,64}$")
 _PEER_PLUGIN_SUBDIR = "peer_plugins"
 
 
@@ -90,14 +91,15 @@ class SkillSync:
         filename = payload.get("filename", "")
         source = payload.get("source", "")
 
-        # Validate name and filename
-        stem = Path(filename).stem
-        if not _SAFE_NAME_RE.match(stem):
-            logger.warning("SkillSync: rejected plugin from %s — unsafe filename '%s'", peer_id, filename)
-            return
-
-        if not filename.endswith(".py"):
-            logger.warning("SkillSync: rejected plugin from %s — not a .py file", peer_id)
+        # Validate the full filename with a strict regex — this prevents directory
+        # traversal attacks (e.g. "../../evil.py") where Path().stem would pass the
+        # stem check but the full path would escape the peer_plugins directory.
+        if not re.match(r"^[a-zA-Z0-9_]{1,64}\.py$", filename):
+            logger.warning(
+                "SkillSync: rejected plugin from %s — unsafe or malformed filename '%s'",
+                peer_id,
+                filename,
+            )
             return
 
         # Validate Python syntax before writing

--- a/daemon/pilot/server.py
+++ b/daemon/pilot/server.py
@@ -127,6 +127,8 @@ class PilotServer:
         # ── Cancel Token (Issue #92) ──
         self._cancel_event: asyncio.Event | None = None
         self._rss_agent: Any = None
+        # ── LAN Mesh Network ──
+        self._mesh: Any = None
 
     async def initialize(self) -> None:
         """Initialize all agent components.
@@ -412,7 +414,25 @@ class PilotServer:
             "proactive_dismiss": self._handle_proactive_dismiss,
             "budget_stats": self._handle_budget_stats,
             "budget_reset": self._handle_budget_reset,
+            # ── LAN Mesh Network ──
+            "mesh_peers": self._handle_mesh_peers,
+            "mesh_status": self._handle_mesh_status,
         }
+
+        # ── LAN Mesh Network (opt-in via config) ──
+        if self.config.network.enabled:
+            try:
+                from pilot.network.mesh import HelioxMesh
+                from pilot.system.plugins import get_manager as get_plugin_manager
+
+                self._mesh = HelioxMesh(
+                    config=self.config.network,
+                    executor=self._executor,
+                    plugin_manager=get_plugin_manager(),
+                )
+                logger.info("HelioxMesh initialised (will start with server)")
+            except Exception:
+                logger.warning("HelioxMesh init failed (non-critical)", exc_info=True)
 
     async def _broadcast_notification(self, method: str, params: Any) -> None:
         """Broadcast a notification to all connected clients.
@@ -2253,6 +2273,10 @@ class PilotServer:
         )
         logger.info("Pilot daemon ready")
 
+        # ── Start LAN mesh if enabled ──
+        if self._mesh:
+            asyncio.create_task(self._mesh.start())
+
         if hasattr(self, "_new_features_announcement") and self._new_features_announcement:
             await asyncio.sleep(1)
             await self._broadcast_notification(
@@ -2266,6 +2290,9 @@ class PilotServer:
     async def stop(self) -> None:
         """Stop the Pilot daemon server and clean up all resources."""
         self._running = False
+        # ── Stop LAN mesh ──
+        if self._mesh:
+            await self._mesh.stop()
         if self._orchestrator:
             await self._orchestrator.stop_all()
         if self._background:
@@ -2319,6 +2346,60 @@ class PilotServer:
             return {"status": "ok"}
         await self._budget_tracker.reset_current_month()
         return {"status": "ok"}
+
+    # ── LAN Mesh Network Handlers ──
+
+    async def _handle_mesh_peers(self, params: dict, ws: ServerConnection) -> dict:
+        """Return a list of currently connected LAN peers.
+
+        Args:
+            params: JSON-RPC parameters (unused).
+            ws: The WebSocket connection.
+
+        Returns:
+            A dict with ``enabled`` flag and ``peers`` list.
+        """
+        if not self._mesh:
+            return {"enabled": False, "peers": []}
+
+        peers = []
+        for pid in self._mesh.peer_ids:
+            conn = self._mesh.get_connection(pid)
+            caps = conn.peer_capabilities if conn else None
+            peers.append(
+                {
+                    "peer_id": pid,
+                    "hostname": caps.hostname if caps else "",
+                    "can_execute": caps.can_execute if caps else False,
+                    "cpu_load": caps.cpu_load if caps else 0.0,
+                    "plugin_count": len(caps.plugin_names) if caps else 0,
+                }
+            )
+        return {"enabled": True, "peers": peers}
+
+    async def _handle_mesh_status(self, params: dict, ws: ServerConnection) -> dict:
+        """Return overall mesh status and configuration.
+
+        Args:
+            params: JSON-RPC parameters (unused).
+            ws: The WebSocket connection.
+
+        Returns:
+            A dict with mesh status, instance ID, and config summary.
+        """
+        if not self._mesh:
+            return {
+                "enabled": False,
+                "reason": "Set [network] enabled = true in config.toml to activate",
+            }
+        return {
+            "enabled": True,
+            "instance_id": self._mesh.instance_id,
+            "peer_count": len(self._mesh.peer_ids),
+            "skill_sync_enabled": self.config.network.skill_sync_enabled,
+            "collab_exec_enabled": self.config.network.collab_exec_enabled,
+            "port": self.config.network.port,
+        }
 
     # ── Cognitive Intelligence (TRIBE v2) Handlers ──
 

--- a/daemon/pyproject.toml
+++ b/daemon/pyproject.toml
@@ -29,6 +29,7 @@ full = [
     "chromadb>=0.5",
     "pyperclip>=1.8",
     "SecretStorage>=3.3; sys_platform == 'linux'",
+    "zeroconf>=0.131",
 ]
 llamacpp = ["llama-cpp-python>=0.3", "pynvml>=11.5"]
 
@@ -47,6 +48,11 @@ browser = [
 ]
 pty = [
     "ptyprocess>=0.7; sys_platform != 'win32'",
+]
+
+# LAN mesh networking
+network = [
+    "zeroconf>=0.131",
 ]
 
 # Remote execution
@@ -69,7 +75,7 @@ cognitive = [
 
 # Everything
 all = [
-    "pilot-daemon[full,automation,vision,browser,documents,cognitive,ssh]",
+    "pilot-daemon[full,automation,vision,browser,documents,cognitive,ssh,network]",
 ]
 
 dev = [


### PR DESCRIPTION
## Summary

Closes #214

Implements a decentralized LAN network using mDNS (zeroconf) for zero-config peer discovery, WebSocket connections for peer communication, automatic plugin/skill sharing, and collaborative parallel task execution.

---

## Architecture

mDNS (`_helioxos._tcp.local.`)

│  
▼

**PeerDiscovery**  
└──► **HelioxMesh**  
&nbsp;&nbsp;&nbsp;&nbsp;└──► **PeerConnection Pool**  

&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;├──► **SkillSync** *(plugin broadcast/install)*  
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;└──► **CollabExecutor** *(distributed action batches)*


---

## New files — `daemon/pilot/network/`

| File | What it does |
|---|---|
| `peer_discovery.py` | mDNS advertising + browsing via `zeroconf` |
| `peer_connection.py` | asyncio WebSocket per peer, heartbeat, capability handshake |
| `skill_sync.py` | Serialise + broadcast plugins; validate + install received ones |
| `collab_executor.py` | Distribute independent action batches to least-loaded peers |
| `mesh.py` | Central orchestrator: P2P server, message routing, lifecycle |

---

## Security

- Only `READ_ONLY` / `USER_WRITE` tier actions are delegated — `SYSTEM_MODIFY`, `DESTRUCTIVE`, `ROOT_CRITICAL` always run locally
- Received plugins are AST-validated before writing, stored in `peer_plugins/` subdirectory, never overwrite local plugins
- Mesh is **opt-in** (`enabled = false` by default)

---

## Enable it

```toml
[network]
enabled = true
port = 8786
skill_sync_enabled = true
collab_exec_enabled = true
```

## Graceful degradation

If zeroconf is not installed, peer discovery logs a warning and becomes a no-op — the daemon starts normally.

## Checklist

- [x]  Code follows style guidelines (ruff format + check — all passed)
- [x]  Self-reviewed
- [x]  Comments added for complex logic
- [x]  No API keys or secrets committed
- [x]  Tested on Windows

## GSSoC declaration

- [x]  This contribution is made under the GSSoC 2026 program
- [x]  I have not plagiarised code from other repositories