### PR TITLE
Add deterministic workflow replay harness

### DIFF
--- a/daemon/pilot/models/router.py
+++ b/daemon/pilot/models/router.py
@@ -16,6 +16,7 @@ if TYPE_CHECKING:
     from pilot.config import PilotConfig
     from pilot.models.budget_tracker import BudgetTracker
     from pilot.security.vault import KeyVault
+    from pilot.workflows.replay import ReplayRecorder, ReplaySession
 
 logger = logging.getLogger("pilot.models.router")
 
@@ -38,6 +39,8 @@ class ModelRouter:
         self._resolved_ollama_model: str | None = None
         self._cache = LLMCache(DATA_DIR / "llm_cache.db")
         self._budget_tracker: BudgetTracker | None = None
+        self._replay_recorder: ReplayRecorder | None = None
+        self._replay_session: ReplaySession | None = None
 
         if config.model.cloud_provider:
             self._cloud = CloudClient(config, vault)
@@ -50,6 +53,14 @@ class ModelRouter:
 
     def set_budget_tracker(self, tracker: BudgetTracker) -> None:
         self._budget_tracker = tracker
+
+    def set_replay_recorder(self, recorder: ReplayRecorder | None) -> None:
+        """Capture successful model generations for deterministic replays."""
+        self._replay_recorder = recorder
+
+    def set_replay_session(self, session: ReplaySession | None) -> None:
+        """Replay model generations from a captured fixture instead of calling backends."""
+        self._replay_session = session
 
     async def generate(
         self,
@@ -72,12 +83,42 @@ class ModelRouter:
         4. Call backend (cloud or local)
         5. Store successful response in cache (skip if streaming)
         """
+        if self._replay_session is not None:
+            result = self._replay_session.next_llm_completion(
+                prompt=prompt,
+                system=system,
+                json_mode=json_mode,
+                temperature=temperature,
+            )
+            if stream_callback is not None:
+                maybe_awaitable = stream_callback(result)
+                if asyncio.iscoroutine(maybe_awaitable):
+                    await maybe_awaitable
+            return result
+
         if self._budget_tracker:
             self._budget_tracker.check_budget(self._config.model.provider)
 
         result = await self._generate_with_cache(
             prompt, system=system, json_mode=json_mode, temperature=temperature, stream_callback=stream_callback
         )
+
+        if self._replay_recorder is not None:
+            provider_key = (
+                self._config.model.cloud_provider
+                if self._config.model.provider == "cloud"
+                else self._config.model.provider
+            )
+            model_name = self._config.model.cloud_model or self._config.model.ollama_model
+            self._replay_recorder.record_llm_completion(
+                prompt=prompt,
+                output=result,
+                system=system,
+                json_mode=json_mode,
+                temperature=temperature,
+                provider=provider_key,
+                model=model_name,
+            )
 
         if self._budget_tracker:
             in_tokens = len(prompt) // 4

--- a/daemon/pilot/workflows/replay.py
+++ b/daemon/pilot/workflows/replay.py
@@ -1,0 +1,250 @@
+"""Deterministic JSONL replay utilities for agent workflow debugging."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass, field
+from datetime import UTC, datetime
+from enum import StrEnum
+from pathlib import Path
+from typing import Any
+
+
+class ReplayEventType(StrEnum):
+    """Supported replay event families."""
+
+    LLM_COMPLETION = "llm_completion"
+    TOOL_CALL = "tool_call"
+    TOOL_RESULT = "tool_result"
+    SYSTEM_REQUEST = "system_request"
+    SYSTEM_RESPONSE = "system_response"
+
+
+class ReplayMismatchError(RuntimeError):
+    """Raised when a replay fixture cannot satisfy the requested event."""
+
+
+@dataclass(frozen=True)
+class ReplayEvent:
+    """One deterministic replay event persisted as a JSONL record."""
+
+    session_id: str
+    sequence: int
+    event_type: ReplayEventType
+    name: str
+    payload: dict[str, Any]
+    metadata: dict[str, Any] = field(default_factory=dict)
+    timestamp: str = field(default_factory=lambda: datetime.now(UTC).isoformat())
+
+    def to_json(self) -> str:
+        data = asdict(self)
+        data["event_type"] = self.event_type.value
+        return json.dumps(data, sort_keys=True, separators=(",", ":"))
+
+    @classmethod
+    def from_json(cls, line: str) -> ReplayEvent:
+        data = json.loads(line)
+        data["event_type"] = ReplayEventType(data["event_type"])
+        return cls(**data)
+
+
+class ReplayRedactor:
+    """Recursively redacts common secret fields before replay data is persisted."""
+
+    DEFAULT_SECRET_MARKERS = (
+        "api_key",
+        "apikey",
+        "authorization",
+        "auth_header",
+        "bearer",
+        "client_secret",
+        "cookie",
+        "password",
+        "refresh_token",
+        "secret",
+        "session",
+        "token",
+    )
+
+    def __init__(
+        self,
+        secret_markers: tuple[str, ...] = DEFAULT_SECRET_MARKERS,
+        replacement: str = "[REDACTED]",
+    ) -> None:
+        self._secret_markers = tuple(marker.lower() for marker in secret_markers)
+        self._replacement = replacement
+
+    def redact(self, value: Any) -> Any:
+        if isinstance(value, dict):
+            return {
+                str(key): self._replacement if self._is_secret_key(str(key)) else self.redact(item)
+                for key, item in value.items()
+            }
+        if isinstance(value, list):
+            return [self.redact(item) for item in value]
+        if isinstance(value, tuple):
+            return tuple(self.redact(item) for item in value)
+        return value
+
+    def _is_secret_key(self, key: str) -> bool:
+        lowered = key.lower()
+        return any(marker in lowered for marker in self._secret_markers)
+
+
+class ReplayRecorder:
+    """Captures deterministic workflow events and optionally flushes them to JSONL."""
+
+    def __init__(
+        self,
+        session_id: str,
+        path: str | Path | None = None,
+        *,
+        redactor: ReplayRedactor | None = None,
+        auto_flush: bool = True,
+    ) -> None:
+        self.session_id = session_id
+        self.path = Path(path) if path is not None else None
+        self.redactor = redactor or ReplayRedactor()
+        self.auto_flush = auto_flush
+        self.events: list[ReplayEvent] = []
+
+    def record_event(
+        self,
+        event_type: ReplayEventType | str,
+        name: str,
+        payload: dict[str, Any],
+        *,
+        metadata: dict[str, Any] | None = None,
+    ) -> ReplayEvent:
+        event = ReplayEvent(
+            session_id=self.session_id,
+            sequence=len(self.events),
+            event_type=ReplayEventType(event_type),
+            name=name,
+            payload=self.redactor.redact(payload),
+            metadata=self.redactor.redact(metadata or {}),
+        )
+        self.events.append(event)
+        if self.auto_flush and self.path is not None:
+            self.flush()
+        return event
+
+    def record_llm_completion(
+        self,
+        *,
+        prompt: str,
+        output: str,
+        system: str = "",
+        json_mode: bool = False,
+        temperature: float = 0.1,
+        provider: str | None = None,
+        model: str | None = None,
+        name: str = "model.generate",
+    ) -> ReplayEvent:
+        return self.record_event(
+            ReplayEventType.LLM_COMPLETION,
+            name,
+            {
+                "request": {
+                    "prompt": prompt,
+                    "system": system,
+                    "json_mode": json_mode,
+                    "temperature": temperature,
+                    "provider": provider,
+                    "model": model,
+                },
+                "output": output,
+            },
+        )
+
+    def record_tool_call(self, name: str, arguments: dict[str, Any]) -> ReplayEvent:
+        return self.record_event(ReplayEventType.TOOL_CALL, name, {"arguments": arguments})
+
+    def record_tool_result(self, name: str, result: dict[str, Any]) -> ReplayEvent:
+        return self.record_event(ReplayEventType.TOOL_RESULT, name, {"result": result})
+
+    def record_system_response(self, name: str, response: dict[str, Any]) -> ReplayEvent:
+        return self.record_event(ReplayEventType.SYSTEM_RESPONSE, name, {"response": response})
+
+    def flush(self) -> None:
+        if self.path is None:
+            return
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self.path.write_text(self.to_jsonl(), encoding="utf-8")
+
+    def to_jsonl(self) -> str:
+        if not self.events:
+            return ""
+        return "\n".join(event.to_json() for event in self.events) + "\n"
+
+
+class ReplaySession:
+    """Consumes a captured replay fixture in sequence and validates requested events."""
+
+    def __init__(self, events: list[ReplayEvent]) -> None:
+        self._events = sorted(events, key=lambda event: event.sequence)
+        self._cursor = 0
+
+    @classmethod
+    def from_jsonl(cls, data: str) -> ReplaySession:
+        events = [ReplayEvent.from_json(line) for line in data.splitlines() if line.strip()]
+        return cls(events)
+
+    @classmethod
+    def from_path(cls, path: str | Path) -> ReplaySession:
+        return cls.from_jsonl(Path(path).read_text(encoding="utf-8"))
+
+    @property
+    def remaining(self) -> int:
+        return len(self._events) - self._cursor
+
+    def next_event(
+        self,
+        event_type: ReplayEventType | str,
+        *,
+        name: str | None = None,
+    ) -> ReplayEvent:
+        if self._cursor >= len(self._events):
+            raise ReplayMismatchError(f"No replay events remain for {ReplayEventType(event_type).value}.")
+
+        event = self._events[self._cursor]
+        expected_type = ReplayEventType(event_type)
+        if event.event_type != expected_type:
+            raise ReplayMismatchError(
+                f"Expected replay event {expected_type.value}, found {event.event_type.value} "
+                f"at sequence {event.sequence}."
+            )
+        if name is not None and event.name != name:
+            raise ReplayMismatchError(
+                f"Expected replay event named {name!r}, found {event.name!r} at sequence {event.sequence}."
+            )
+
+        self._cursor += 1
+        return event
+
+    def next_llm_completion(
+        self,
+        *,
+        prompt: str | None = None,
+        system: str | None = None,
+        json_mode: bool | None = None,
+        temperature: float | None = None,
+        name: str = "model.generate",
+    ) -> str:
+        event = self.next_event(ReplayEventType.LLM_COMPLETION, name=name)
+        request = event.payload.get("request", {})
+        expected = {
+            "prompt": prompt,
+            "system": system,
+            "json_mode": json_mode,
+            "temperature": temperature,
+        }
+        mismatches = [key for key, value in expected.items() if value is not None and request.get(key) != value]
+        if mismatches:
+            details = ", ".join(mismatches)
+            raise ReplayMismatchError(f"Replay LLM request mismatch for: {details}.")
+
+        output = event.payload.get("output")
+        if not isinstance(output, str):
+            raise ReplayMismatchError("Replay LLM completion is missing a string output.")
+        return output

--- a/daemon/tests/test_replay.py
+++ b/daemon/tests/test_replay.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import pytest
+
+from pilot.workflows.replay import (
+    ReplayEventType,
+    ReplayMismatchError,
+    ReplayRecorder,
+    ReplaySession,
+)
+
+
+def test_replay_recorder_redacts_secrets_and_round_trips_jsonl(tmp_path):
+    path = tmp_path / "session.jsonl"
+    recorder = ReplayRecorder("session-1", path)
+
+    recorder.record_tool_call(
+        "fetch-profile",
+        {
+            "user_id": "u_123",
+            "api_key": "sk-live",
+            "nested": {"Authorization": "Bearer secret"},
+        },
+    )
+    recorder.record_llm_completion(
+        prompt="Summarize the profile",
+        system="Be concise",
+        json_mode=True,
+        temperature=0,
+        output='{"summary":"ok"}',
+        provider="ollama",
+        model="llama3",
+    )
+
+    session = ReplaySession.from_path(path)
+    tool_event = session.next_event(ReplayEventType.TOOL_CALL, name="fetch-profile")
+
+    assert tool_event.payload["arguments"]["user_id"] == "u_123"
+    assert tool_event.payload["arguments"]["api_key"] == "[REDACTED]"
+    assert tool_event.payload["arguments"]["nested"]["Authorization"] == "[REDACTED]"
+    assert (
+        session.next_llm_completion(
+            prompt="Summarize the profile",
+            system="Be concise",
+            json_mode=True,
+            temperature=0,
+        )
+        == '{"summary":"ok"}'
+    )
+    assert session.remaining == 0
+
+
+def test_replay_session_enforces_event_order_and_name():
+    recorder = ReplayRecorder("session-1", auto_flush=False)
+    recorder.record_tool_result("search", {"items": [1]})
+    session = ReplaySession.from_jsonl(recorder.to_jsonl())
+
+    with pytest.raises(ReplayMismatchError, match="Expected replay event llm_completion"):
+        session.next_llm_completion(prompt="anything")
+
+    assert session.next_event(ReplayEventType.TOOL_RESULT, name="search").payload == {"result": {"items": [1]}}
+    assert session.remaining == 0
+
+
+def test_replay_session_detects_llm_request_drift():
+    recorder = ReplayRecorder("session-1", auto_flush=False)
+    recorder.record_llm_completion(
+        prompt="original prompt",
+        system="system",
+        json_mode=False,
+        temperature=0.2,
+        output="original output",
+    )
+    session = ReplaySession.from_jsonl(recorder.to_jsonl())
+
+    with pytest.raises(ReplayMismatchError, match="prompt"):
+        session.next_llm_completion(prompt="changed prompt", system="system")
+
+
+@pytest.mark.asyncio
+async def test_model_router_replays_without_calling_backend():
+    from pilot.config import PilotConfig
+    from pilot.models.router import ModelRouter
+
+    recorder = ReplayRecorder("session-1", auto_flush=False)
+    recorder.record_llm_completion(
+        prompt="Plan my day",
+        system="Return JSON",
+        json_mode=True,
+        temperature=0.3,
+        output='{"tasks":[]}',
+    )
+
+    router = ModelRouter(PilotConfig(), vault=object())  # type: ignore[arg-type]
+    router.set_replay_session(ReplaySession.from_jsonl(recorder.to_jsonl()))
+
+    assert (
+        await router.generate(
+            "Plan my day",
+            system="Return JSON",
+            json_mode=True,
+            temperature=0.3,
+        )
+        == '{"tasks":[]}'
+    )


### PR DESCRIPTION
## Summary
- add a deterministic JSONL replay harness for multi-agent workflow debugging
- capture LLM completions, tool calls/results, and system responses with recursive secret redaction
- add ModelRouter hooks to record live model generations or replay captured completions without calling backends
- cover JSONL round-tripping, secret redaction, ordering/name enforcement, prompt drift detection, and router replay behavior

Fixes #208

## Validation
- `/Users/saurabhkumarbajpaiai/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 -m pytest tests/test_replay.py tests/test_workflow_checkpoints.py -q` ✅ 7 passed
- `/Users/saurabhkumarbajpaiai/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 -m ruff check pilot/workflows/replay.py pilot/models/router.py tests/test_replay.py` ✅
- `/Users/saurabhkumarbajpaiai/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 -m ruff format --check pilot/workflows/replay.py pilot/models/router.py tests/test_replay.py` ✅
- `git diff --check` ✅

## Full suite note
I also tried the full daemon suite with `pytest -q`; it currently stops during collection because this environment is missing the existing optional dependency `tiktoken` for `tests/test_context_compressor.py`. The replay-specific and adjacent workflow checkpoint tests pass cleanly.

## Scoring labels
For GSSoC/NSoC scoring, please add the applicable labels when reviewing/merging: `gssoc:approved`, `level:advanced`, `type:testing`, `type:feature`, `nsoc26`, and `level3` if this matches your program labeling scheme.
