### PR TITLE
Add open logs folder button to activity log

### DIFF
--- a/tauri-app/src-tauri/Cargo.toml
+++ b/tauri-app/src-tauri/Cargo.toml
@@ -20,6 +20,7 @@ tokio = { version = "1", features = ["full"] }
 tokio-tungstenite = "0.24"
 futures-util = "0.3"
 dirs = "5"
+opener = "0.7"
 
 [features]
 default = ["custom-protocol"]

--- a/tauri-app/src-tauri/src/commands.rs
+++ b/tauri-app/src-tauri/src/commands.rs
@@ -128,3 +128,17 @@ async fn send_rpc(window: tauri::Window, request: serde_json::Value) -> Result<(
     window.emit("llm-complete", "DONE").map_err(|e| e.to_string())?;
     Ok(())
 }
+#[tauri::command]
+pub fn open_logs_folder(app: tauri::AppHandle) -> Result<(), String> {
+    let log_dir = app
+        .path()
+        .app_log_dir()
+        .map_err(|e| e.to_string())?;
+
+    if !log_dir.exists() {
+        std::fs::create_dir_all(&log_dir).map_err(|e| e.to_string())?;
+    }
+
+    opener::open(&log_dir).map_err(|e| e.to_string())?;
+    Ok(())
+}

--- a/tauri-app/src-tauri/src/main.rs
+++ b/tauri-app/src-tauri/src/main.rs
@@ -183,6 +183,7 @@ fn main() {
             commands::get_daemon_status,
             commands::send_to_daemon,
             commands::confirm_action,
+            commands::open_logs_folder,
         ])
         .run(tauri::generate_context!())
         .expect("error while running Heliox OS");

--- a/tauri-app/ui/package-lock.json
+++ b/tauri-app/ui/package-lock.json
@@ -17,6 +17,7 @@
         "marked": "^18.0.3"
       },
       "devDependencies": {
+        "@playwright/test": "^1.44.0",
         "@sveltejs/vite-plugin-svelte": "^5.0.0",
         "@tsconfig/svelte": "^5.0.0",
         "@types/dompurify": "^3.0.5",
@@ -512,6 +513,22 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -1284,6 +1301,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/tauri-app/ui/src/lib/components/ActivityLog.svelte
+++ b/tauri-app/ui/src/lib/components/ActivityLog.svelte
@@ -47,6 +47,7 @@ async function openLogsFolder() {
       📂 Open Logs
     </button>
   </div>
+  </div>
 
 
   {#if loading}
@@ -72,7 +73,7 @@ async function openLogsFolder() {
     </div>
   {/if}
 </div>
-</div>
+
 <style>
   .activity-log {
     height: 100%;

--- a/tauri-app/ui/src/lib/components/ActivityLog.svelte
+++ b/tauri-app/ui/src/lib/components/ActivityLog.svelte
@@ -1,6 +1,11 @@
 <script lang="ts">
   import { onMount } from "svelte";
   import { call } from "../api/daemon";
+  import { invoke } from "@tauri-apps/api/core";
+
+async function openLogsFolder() {
+  await invoke("open_logs_folder");
+}
 
   interface HistoryEntry {
     id: number;
@@ -33,12 +38,16 @@
     }
   }
 </script>
-
 <div class="activity-log">
-  <div class="log-header">
-    <h2>Activity Log</h2>
+<div class="log-header">
+  <h2>Activity Log</h2>
+  <div class="header-right">
     <span class="count">{entries.length} entries</span>
+    <button class="open-logs-btn" onclick={openLogsFolder} title="Open Logs Folder">
+      📂 Open Logs
+    </button>
   </div>
+
 
   {#if loading}
     <div class="empty">Loading...</div>
@@ -63,7 +72,7 @@
     </div>
   {/if}
 </div>
-
+</div>
 <style>
   .activity-log {
     height: 100%;
@@ -152,5 +161,24 @@
     font-size: 12px;
     color: var(--text-secondary);
     margin-top: 4px;
+  }
+  .header-right {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+  }
+  .open-logs-btn {
+    font-size: 11px;
+    padding: 4px 10px;
+    border-radius: 6px;
+    border: 1px solid var(--border);
+    background: var(--bg-secondary);
+    color: var(--text-primary);
+    cursor: pointer;
+    transition: background 0.15s;
+  }
+  .open-logs-btn:hover {
+    background: var(--accent, #38bdf8);
+    color: #000;
   }
 </style>


### PR DESCRIPTION
## Changes
- Added an "Open Logs" button to the Activity Log panel
- Added backend command to open the logs directory using the OS file explorer
- Connected frontend button with Tauri invoke command
Fixes #86

## Result
Users can now instantly open the logs folder directly from the UI.