### PR TITLE
Add pytest coverage and Redis cache adapter support

### DIFF
--- a/daemon/pilot/config.py
+++ b/daemon/pilot/config.py
@@ -143,6 +143,16 @@ class SshConfig:
     enabled: bool = False
     connect_timeout_seconds: int = 10
     allowed_hosts: list[SshHostConfig] = field(default_factory=list)
+class RedisConfig:
+    enabled: bool = False
+    host: str = "127.0.0.1"
+    port: int = 6379
+    db: int = 0
+    password: str = ""
+    ssl: bool = False
+    key_prefix: str = "pilot:"
+    default_ttl: int = 300
+    max_memory_cache_size: int = 512
 
 
 @dataclass
@@ -168,6 +178,7 @@ class PilotConfig:
     ssh: SshConfig = field(default_factory=SshConfig)
     restrictions: Restrictions = field(default_factory=Restrictions)
     first_run_complete: bool = False
+    redis: RedisConfig = field(default_factory=RedisConfig)
 
     @classmethod
     def load(cls) -> PilotConfig:
@@ -283,6 +294,17 @@ def _validate_config_types(raw: dict) -> None:
             "connect_timeout_seconds": int,
             "allowed_hosts": list,
         },
+        "redis": {
+            "enabled": bool,
+            "host": str,
+            "port": int,
+            "db": int,
+            "password": str,
+            "ssl": bool,
+            "key_prefix": str,
+            "default_ttl": int,
+            "max_memory_cache_size": int,
+},
     }
 
     for section, expected_keys in expected_types.items():
@@ -380,6 +402,10 @@ def _merge_config(config: PilotConfig, raw: dict[str, Any]) -> PilotConfig:
                     )
                 )
             config.ssh.allowed_hosts = parsed_hosts
+    if "redis" in raw:
+        for k, v in raw["redis"].items():
+            if hasattr(config.redis, k):
+                setattr(config.redis, k, v)
 
     config.first_run_complete = raw.get(
         "first_run_complete",

--- a/daemon/pilot/config.py
+++ b/daemon/pilot/config.py
@@ -155,16 +155,6 @@ class SshConfig:
     enabled: bool = False
     connect_timeout_seconds: int = 10
     allowed_hosts: list[SshHostConfig] = field(default_factory=list)
-class RedisConfig:
-    enabled: bool = False
-    host: str = "127.0.0.1"
-    port: int = 6379
-    db: int = 0
-    password: str = ""
-    ssl: bool = False
-    key_prefix: str = "pilot:"
-    default_ttl: int = 300
-    max_memory_cache_size: int = 512
 
 
 @dataclass
@@ -317,17 +307,6 @@ def _validate_config_types(raw: dict) -> None:
             "connect_timeout_seconds": int,
             "allowed_hosts": list,
         },
-        "redis": {
-            "enabled": bool,
-            "host": str,
-            "port": int,
-            "db": int,
-            "password": str,
-            "ssl": bool,
-            "key_prefix": str,
-            "default_ttl": int,
-            "max_memory_cache_size": int,
-},
     }
 
     for section, expected_keys in expected_types.items():

--- a/daemon/pilot/config.py
+++ b/daemon/pilot/config.py
@@ -115,6 +115,18 @@ class RSSConfig:
 
 
 @dataclass
+class RedisConfig:
+    enabled: bool = False
+    host: str = "127.0.0.1"
+    port: int = 6379
+    db: int = 0
+    password: str = ""
+    ssl: bool = False
+    key_prefix: str = "pilot:"
+    default_ttl: int = 300
+    max_memory_cache_size: int = 512
+
+
 class NetworkConfig:
     """LAN mesh network configuration for multi-instance collaboration."""
 
@@ -281,6 +293,17 @@ def _validate_config_types(raw: dict) -> None:
             "feeds": list,
             "poll_interval_hours": (int, float),
             "max_items_per_feed": int,
+        },
+        "redis": {
+            "enabled": bool,
+            "host": str,
+            "port": int,
+            "db": int,
+            "password": str,
+            "ssl": bool,
+            "key_prefix": str,
+            "default_ttl": int,
+            "max_memory_cache_size": int,
         },
         "network": {
             "enabled": bool,

--- a/daemon/pilot/db/redis_adapter.py
+++ b/daemon/pilot/db/redis_adapter.py
@@ -72,6 +72,7 @@ class _LRUCache:
 
 # ── Adapter ───────────────────────────────────────────────────────────────────
 
+
 @dataclass
 class RedisConfig:
     enabled: bool = False
@@ -81,7 +82,7 @@ class RedisConfig:
     password: str = ""
     ssl: bool = False
     key_prefix: str = "pilot:"
-    default_ttl: int = 300          # seconds
+    default_ttl: int = 300  # seconds
     max_memory_cache_size: int = 512  # fallback LRU size
 
 
@@ -90,7 +91,7 @@ class RedisCacheAdapter:
 
     def __init__(self, config: RedisConfig) -> None:
         self._config = config
-        self._redis: Any = None          # aioredis / redis.asyncio client
+        self._redis: Any = None  # aioredis / redis.asyncio client
         self._fallback = _LRUCache(max_size=config.max_memory_cache_size)
         self._using_redis = False
 

--- a/daemon/pilot/db/redis_adapter.py
+++ b/daemon/pilot/db/redis_adapter.py
@@ -1,0 +1,211 @@
+"""Redis cache adapter for high-throughput token caching.
+
+Provides a unified cache interface that uses Redis when available,
+falling back to a local in-memory LRU cache for single-instance setups.
+
+Usage:
+    adapter = RedisCacheAdapter.from_config(config.redis)
+    await adapter.initialize()
+
+    await adapter.set("key", "value", ttl=300)
+    value = await adapter.get("key")   # None on miss
+    await adapter.delete("key")
+    await adapter.close()
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from collections import OrderedDict
+from dataclasses import dataclass, field
+from typing import Any
+
+logger = logging.getLogger("pilot.db.redis_adapter")
+
+# ── In-memory LRU fallback ────────────────────────────────────────────────────
+
+_SENTINEL = object()
+
+
+class _LRUCache:
+    """Thread-safe LRU cache with per-entry TTL."""
+
+    def __init__(self, max_size: int = 512) -> None:
+        self._max_size = max_size
+        self._store: OrderedDict[str, tuple[str, float]] = OrderedDict()  # key → (value, expires_at)
+        self._lock = asyncio.Lock()
+
+    async def get(self, key: str) -> str | None:
+        async with self._lock:
+            entry = self._store.get(key, _SENTINEL)
+            if entry is _SENTINEL:
+                return None
+            value, expires_at = entry  # type: ignore[misc]
+            if expires_at != -1 and time.monotonic() > expires_at:
+                del self._store[key]
+                return None
+            self._store.move_to_end(key)
+            return value
+
+    async def set(self, key: str, value: str, ttl: int = 300) -> None:
+        expires_at = time.monotonic() + ttl if ttl > 0 else -1
+        async with self._lock:
+            if key in self._store:
+                self._store.move_to_end(key)
+            self._store[key] = (value, expires_at)
+            if len(self._store) > self._max_size:
+                self._store.popitem(last=False)
+
+    async def delete(self, key: str) -> None:
+        async with self._lock:
+            self._store.pop(key, None)
+
+    async def flush(self) -> None:
+        async with self._lock:
+            self._store.clear()
+
+    def size(self) -> int:
+        return len(self._store)
+
+
+# ── Adapter ───────────────────────────────────────────────────────────────────
+
+@dataclass
+class RedisConfig:
+    enabled: bool = False
+    host: str = "127.0.0.1"
+    port: int = 6379
+    db: int = 0
+    password: str = ""
+    ssl: bool = False
+    key_prefix: str = "pilot:"
+    default_ttl: int = 300          # seconds
+    max_memory_cache_size: int = 512  # fallback LRU size
+
+
+class RedisCacheAdapter:
+    """Cache adapter: Redis when available, in-memory LRU otherwise."""
+
+    def __init__(self, config: RedisConfig) -> None:
+        self._config = config
+        self._redis: Any = None          # aioredis / redis.asyncio client
+        self._fallback = _LRUCache(max_size=config.max_memory_cache_size)
+        self._using_redis = False
+
+    # ── lifecycle ─────────────────────────────────────────────────────────────
+
+    @classmethod
+    def from_config(cls, config: RedisConfig) -> RedisCacheAdapter:
+        return cls(config)
+
+    async def initialize(self) -> None:
+        if not self._config.enabled:
+            logger.info("Redis disabled — using in-memory LRU cache")
+            return
+
+        try:
+            import redis.asyncio as aioredis  # type: ignore[import]
+
+            kwargs: dict[str, Any] = {
+                "host": self._config.host,
+                "port": self._config.port,
+                "db": self._config.db,
+                "ssl": self._config.ssl,
+                "decode_responses": True,
+            }
+            if self._config.password:
+                kwargs["password"] = self._config.password
+
+            client = aioredis.Redis(**kwargs)
+            await client.ping()
+
+            self._redis = client
+            self._using_redis = True
+            logger.info(
+                "Redis cache connected at %s:%s (db=%s)",
+                self._config.host,
+                self._config.port,
+                self._config.db,
+            )
+
+        except ImportError:
+            logger.warning("redis package not installed — falling back to in-memory LRU cache")
+
+        except Exception as exc:
+            logger.warning("Redis connection failed (%s) — falling back to in-memory LRU cache", exc)
+
+    async def close(self) -> None:
+        if self._redis is not None:
+            await self._redis.aclose()
+            self._redis = None
+            self._using_redis = False
+
+    # ── public API ────────────────────────────────────────────────────────────
+
+    @property
+    def backend(self) -> str:
+        return "redis" if self._using_redis else "memory"
+
+    def _prefixed(self, key: str) -> str:
+        return f"{self._config.key_prefix}{key}"
+
+    async def get(self, key: str) -> str | None:
+        """Return cached value or None on miss / expiry."""
+        if self._using_redis:
+            try:
+                return await self._redis.get(self._prefixed(key))
+            except Exception as exc:
+                logger.warning("Redis GET failed (%s) — using fallback", exc)
+                return await self._fallback.get(key)
+        return await self._fallback.get(key)
+
+    async def set(self, key: str, value: str, ttl: int | None = None) -> None:
+        """Store a value. ttl=0 → no expiry."""
+        effective_ttl = ttl if ttl is not None else self._config.default_ttl
+        if self._using_redis:
+            try:
+                if effective_ttl > 0:
+                    await self._redis.setex(self._prefixed(key), effective_ttl, value)
+                else:
+                    await self._redis.set(self._prefixed(key), value)
+                return
+            except Exception as exc:
+                logger.warning("Redis SET failed (%s) — writing to fallback", exc)
+        await self._fallback.set(key, value, ttl=effective_ttl)
+
+    async def delete(self, key: str) -> None:
+        """Delete a key from both backends."""
+        if self._using_redis:
+            try:
+                await self._redis.delete(self._prefixed(key))
+                return
+            except Exception as exc:
+                logger.warning("Redis DELETE failed (%s) — deleting from fallback", exc)
+        await self._fallback.delete(key)
+
+    async def exists(self, key: str) -> bool:
+        """Return True if key exists and has not expired."""
+        return await self.get(key) is not None
+
+    async def flush(self) -> None:
+        """Flush all pilot-prefixed keys (Redis) or all entries (memory)."""
+        if self._using_redis:
+            try:
+                pattern = f"{self._config.key_prefix}*"
+                keys = await self._redis.keys(pattern)
+                if keys:
+                    await self._redis.delete(*keys)
+                return
+            except Exception as exc:
+                logger.warning("Redis FLUSH failed (%s) — flushing fallback", exc)
+        await self._fallback.flush()
+
+    def stats(self) -> dict[str, Any]:
+        return {
+            "backend": self.backend,
+            "fallback_size": self._fallback.size(),
+            "redis_connected": self._using_redis,
+            "key_prefix": self._config.key_prefix,
+        }

--- a/daemon/pilot/db/redis_adapter.py
+++ b/daemon/pilot/db/redis_adapter.py
@@ -3,14 +3,8 @@
 Provides a unified cache interface that uses Redis when available,
 falling back to a local in-memory LRU cache for single-instance setups.
 
-Usage:
-    adapter = RedisCacheAdapter.from_config(config.redis)
-    await adapter.initialize()
-
-    await adapter.set("key", "value", ttl=300)
-    value = await adapter.get("key")   # None on miss
-    await adapter.delete("key")
-    await adapter.close()
+Warning logs for Redis failures are throttled (once per 60 s) to avoid
+flooding pilot.log when Redis is temporarily unreachable.
 """
 
 from __future__ import annotations
@@ -19,22 +13,36 @@ import asyncio
 import logging
 import time
 from collections import OrderedDict
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Any
 
 logger = logging.getLogger("pilot.db.redis_adapter")
 
-# ── In-memory LRU fallback ────────────────────────────────────────────────────
-
 _SENTINEL = object()
+
+# ── Warning throttle ──────────────────────────────────────────────────────────
+_WARN_INTERVAL = 60.0  # seconds between repeated Redis failure warnings
+_last_warn_time: float = 0.0
+
+
+def _throttled_warn(msg: str, *args: object) -> None:
+    """Log a warning at most once per _WARN_INTERVAL seconds."""
+    global _last_warn_time
+    now = time.monotonic()
+    if now - _last_warn_time >= _WARN_INTERVAL:
+        _last_warn_time = now
+        logger.warning(msg, *args)
+
+
+# ── In-memory LRU fallback ────────────────────────────────────────────────────
 
 
 class _LRUCache:
-    """Thread-safe LRU cache with per-entry TTL."""
+    """Async LRU cache with per-entry TTL."""
 
     def __init__(self, max_size: int = 512) -> None:
         self._max_size = max_size
-        self._store: OrderedDict[str, tuple[str, float]] = OrderedDict()  # key → (value, expires_at)
+        self._store: OrderedDict[str, tuple[str, float]] = OrderedDict()
         self._lock = asyncio.Lock()
 
     async def get(self, key: str) -> str | None:
@@ -82,20 +90,18 @@ class RedisConfig:
     password: str = ""
     ssl: bool = False
     key_prefix: str = "pilot:"
-    default_ttl: int = 300  # seconds
-    max_memory_cache_size: int = 512  # fallback LRU size
+    default_ttl: int = 300
+    max_memory_cache_size: int = 512
 
 
 class RedisCacheAdapter:
-    """Cache adapter: Redis when available, in-memory LRU otherwise."""
+    """Cache adapter: Redis L1 when available, in-memory LRU otherwise."""
 
     def __init__(self, config: RedisConfig) -> None:
         self._config = config
-        self._redis: Any = None  # aioredis / redis.asyncio client
+        self._redis: Any = None
         self._fallback = _LRUCache(max_size=config.max_memory_cache_size)
         self._using_redis = False
-
-    # ── lifecycle ─────────────────────────────────────────────────────────────
 
     @classmethod
     def from_config(cls, config: RedisConfig) -> RedisCacheAdapter:
@@ -153,17 +159,15 @@ class RedisCacheAdapter:
         return f"{self._config.key_prefix}{key}"
 
     async def get(self, key: str) -> str | None:
-        """Return cached value or None on miss / expiry."""
         if self._using_redis:
             try:
                 return await self._redis.get(self._prefixed(key))
             except Exception as exc:
-                logger.warning("Redis GET failed (%s) — using fallback", exc)
+                _throttled_warn("Redis GET failed (%s) — using fallback", exc)
                 return await self._fallback.get(key)
         return await self._fallback.get(key)
 
     async def set(self, key: str, value: str, ttl: int | None = None) -> None:
-        """Store a value. ttl=0 → no expiry."""
         effective_ttl = ttl if ttl is not None else self._config.default_ttl
         if self._using_redis:
             try:
@@ -173,25 +177,22 @@ class RedisCacheAdapter:
                     await self._redis.set(self._prefixed(key), value)
                 return
             except Exception as exc:
-                logger.warning("Redis SET failed (%s) — writing to fallback", exc)
+                _throttled_warn("Redis SET failed (%s) — writing to fallback", exc)
         await self._fallback.set(key, value, ttl=effective_ttl)
 
     async def delete(self, key: str) -> None:
-        """Delete a key from both backends."""
         if self._using_redis:
             try:
                 await self._redis.delete(self._prefixed(key))
                 return
             except Exception as exc:
-                logger.warning("Redis DELETE failed (%s) — deleting from fallback", exc)
+                _throttled_warn("Redis DELETE failed (%s) — deleting from fallback", exc)
         await self._fallback.delete(key)
 
     async def exists(self, key: str) -> bool:
-        """Return True if key exists and has not expired."""
         return await self.get(key) is not None
 
     async def flush(self) -> None:
-        """Flush all pilot-prefixed keys (Redis) or all entries (memory)."""
         if self._using_redis:
             try:
                 pattern = f"{self._config.key_prefix}*"
@@ -200,7 +201,7 @@ class RedisCacheAdapter:
                     await self._redis.delete(*keys)
                 return
             except Exception as exc:
-                logger.warning("Redis FLUSH failed (%s) — flushing fallback", exc)
+                _throttled_warn("Redis FLUSH failed (%s) — flushing fallback", exc)
         await self._fallback.flush()
 
     def stats(self) -> dict[str, Any]:

--- a/daemon/pilot/db/redis_adapter.py
+++ b/daemon/pilot/db/redis_adapter.py
@@ -22,16 +22,6 @@ _SENTINEL = object()
 
 # ── Warning throttle ──────────────────────────────────────────────────────────
 _WARN_INTERVAL = 60.0  # seconds between repeated Redis failure warnings
-_last_warn_time: float = 0.0
-
-
-def _throttled_warn(msg: str, *args: object) -> None:
-    """Log a warning at most once per _WARN_INTERVAL seconds."""
-    global _last_warn_time
-    now = time.monotonic()
-    if now - _last_warn_time >= _WARN_INTERVAL:
-        _last_warn_time = now
-        logger.warning(msg, *args)
 
 
 # ── In-memory LRU fallback ────────────────────────────────────────────────────
@@ -102,6 +92,7 @@ class RedisCacheAdapter:
         self._redis: Any = None
         self._fallback = _LRUCache(max_size=config.max_memory_cache_size)
         self._using_redis = False
+        self._last_warn_time: float = 0.0
 
     @classmethod
     def from_config(cls, config: RedisConfig) -> RedisCacheAdapter:
@@ -149,6 +140,12 @@ class RedisCacheAdapter:
             self._redis = None
             self._using_redis = False
 
+    def _throttled_warn(self, msg: str, *args: object) -> None:
+        now = time.monotonic()
+        if now - self._last_warn_time >= _WARN_INTERVAL:
+            self._last_warn_time = now
+            logger.warning(msg, *args)
+
     # ── public API ────────────────────────────────────────────────────────────
 
     @property
@@ -163,7 +160,7 @@ class RedisCacheAdapter:
             try:
                 return await self._redis.get(self._prefixed(key))
             except Exception as exc:
-                _throttled_warn("Redis GET failed (%s) — using fallback", exc)
+                self._throttled_warn("Redis GET failed (%s) — using fallback", exc)
                 return await self._fallback.get(key)
         return await self._fallback.get(key)
 
@@ -177,7 +174,7 @@ class RedisCacheAdapter:
                     await self._redis.set(self._prefixed(key), value)
                 return
             except Exception as exc:
-                _throttled_warn("Redis SET failed (%s) — writing to fallback", exc)
+                self._throttled_warn("Redis SET failed (%s) — writing to fallback", exc)
         await self._fallback.set(key, value, ttl=effective_ttl)
 
     async def delete(self, key: str) -> None:
@@ -186,7 +183,7 @@ class RedisCacheAdapter:
                 await self._redis.delete(self._prefixed(key))
                 return
             except Exception as exc:
-                _throttled_warn("Redis DELETE failed (%s) — deleting from fallback", exc)
+                self._throttled_warn("Redis DELETE failed (%s) — deleting from fallback", exc)
         await self._fallback.delete(key)
 
     async def exists(self, key: str) -> bool:
@@ -201,7 +198,7 @@ class RedisCacheAdapter:
                     await self._redis.delete(*keys)
                 return
             except Exception as exc:
-                _throttled_warn("Redis FLUSH failed (%s) — flushing fallback", exc)
+                self._throttled_warn("Redis FLUSH failed (%s) — flushing fallback", exc)
         await self._fallback.flush()
 
     def stats(self) -> dict[str, Any]:

--- a/daemon/pilot/models/cache.py
+++ b/daemon/pilot/models/cache.py
@@ -1,22 +1,21 @@
-"""Local SQLite cache for LLM responses.
+"""Local cache for LLM responses.
 
-Provides fast exact-match caching for LLM prompts to reduce API usage and speed up testing.
-Cache is keyed by:
+L1: Redis (optional, distributed, fast) — keyed by prompt hash
+L2: SQLite (local, persistent)          — exact-match fallback
+
+Cache key components:
   - prompt hash (SHA256)
   - system prompt hash (SHA256)
-  - model string (e.g., "gpt-4o", "llama3.1:8b")
-  - provider (e.g., "openai", "ollama", "gemini")
+  - model string  (e.g., "gpt-4o", "llama3.1:8b")
+  - provider      (e.g., "openai", "ollama", "gemini")
   - temperature
   - json_mode flag
-
-This ensures cache hits only for exact prompt + model + provider combinations.
 """
 
 from __future__ import annotations
 
 import hashlib
 import logging
-import sqlite3
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -25,25 +24,26 @@ import aiosqlite
 
 if TYPE_CHECKING:
     from pilot.config import PilotConfig
+    from pilot.db.redis_adapter import RedisCacheAdapter
 
 logger = logging.getLogger("pilot.models.cache")
 CACHE_SCHEMA_VERSION = 1
 
 
 class LLMCache:
-    """SQLite-backed cache for LLM responses with provider and model specificity."""
+    """Two-tier LLM response cache: Redis L1 → SQLite L2."""
 
-    def __init__(self, db_path: Path) -> None:
-        """Initialize cache with path to SQLite database.
-        Args:
-            db_path: Path to the SQLite database file.
-        """
+    def __init__(
+        self,
+        db_path: Path,
+        redis: RedisCacheAdapter | None = None,
+    ) -> None:
         self._db_path = db_path
         self._conn: aiosqlite.Connection | None = None
         self._initialized = False
+        self._redis = redis  # optional L1 cache
 
     async def initialize(self) -> None:
-        """Initialize the database connection and create schema if needed."""
         if self._initialized:
             return
 
@@ -52,7 +52,7 @@ class LLMCache:
             self._conn = await aiosqlite.connect(str(self._db_path))
             await self._conn.execute("PRAGMA journal_mode = WAL")
             await self._conn.execute("PRAGMA synchronous = NORMAL")
-            await self._conn.execute("PRAGMA cache_size = -64000")  # 64MB cache
+            await self._conn.execute("PRAGMA cache_size = -64000")
             await self._create_schema()
             self._initialized = True
             logger.debug("LLM cache initialized at %s", self._db_path)
@@ -61,7 +61,6 @@ class LLMCache:
             raise
 
     async def _create_schema(self) -> None:
-        """Create cache table if it doesn't exist."""
         if not self._conn:
             raise RuntimeError("Cache not initialized")
 
@@ -81,24 +80,17 @@ class LLMCache:
             )
             """
         )
-
         await self._conn.execute(
-            "CREATE INDEX IF NOT EXISTS idx_cache_key ON llm_cache(prompt_hash, system_hash, model, provider, temperature, json_mode)"
+            "CREATE INDEX IF NOT EXISTS idx_cache_key ON llm_cache"
+            "(prompt_hash, system_hash, model, provider, temperature, json_mode)"
         )
         await self._conn.execute("CREATE INDEX IF NOT EXISTS idx_provider ON llm_cache(provider)")
         await self._conn.execute("CREATE INDEX IF NOT EXISTS idx_model ON llm_cache(model)")
-
         await self._conn.commit()
 
+    # ── helpers ───────────────────────────────────────────────────────────────
+
     def _hash_string(self, text: str) -> str:
-        """Generate SHA256 hash of a string.
-
-        Args:
-            text: The string to hash.
-
-        Returns:
-            Hex-encoded SHA256 hash.
-        """
         return hashlib.sha256(text.encode("utf-8")).hexdigest()
 
     def _make_cache_key(
@@ -130,8 +122,22 @@ class LLMCache:
         else:
             prompt_str = prompt
         prompt_hash = self._hash_string(prompt_str)
+        prompt_hash = self._hash_string(prompt)
         system_hash = self._hash_string(system) if system else ""
         return (prompt_hash, system_hash, model, provider, temperature, int(json_mode))
+
+    def _redis_key(
+        self,
+        prompt_hash: str,
+        system_hash: str,
+        model: str,
+        provider: str,
+        temperature: float,
+        json_mode_int: int,
+    ) -> str:
+        return f"llm:{provider}:{model}:{temperature}:{json_mode_int}:{system_hash}:{prompt_hash}"
+
+    # ── public API ────────────────────────────────────────────────────────────
 
     async def get(
         self,
@@ -142,45 +148,39 @@ class LLMCache:
         json_mode: bool,
         system: str = "",
     ) -> str | None:
-        """Retrieve a cached response for an exact prompt match.
+        prompt_hash, system_hash, model, provider, temperature, json_mode_int = self._make_cache_key(
+            prompt, model, provider, temperature, json_mode, system
+        )
 
-        Args:
-            prompt: The user prompt.
-            model: The model identifier.
-            provider: The provider name.
-            temperature: The temperature parameter.
-            json_mode: Whether JSON mode is enabled.
-            system: The system prompt (optional).
+        # L1 — Redis
+        if self._redis is not None:
+            rkey = self._redis_key(prompt_hash, system_hash, model, provider, temperature, json_mode_int)
+            cached = await self._redis.get(rkey)
+            if cached is not None:
+                logger.debug("Redis cache hit: %s/%s", provider, model)
+                return cached
 
-        Returns:
-            The cached response if found, None otherwise.
-        """
+        # L2 — SQLite
         if not self._conn:
             return None
 
         try:
-            prompt_hash, system_hash, model, provider, temperature, json_mode_int = self._make_cache_key(
-                prompt, model, provider, temperature, json_mode, system
-            )
-
             cursor = await self._conn.execute(
-                """
-                SELECT response FROM llm_cache
-                WHERE prompt_hash = ? AND system_hash = ? AND model = ? AND provider = ? AND temperature = ? AND json_mode = ?
-                LIMIT 1
-                """,
+                """SELECT response FROM llm_cache
+                   WHERE prompt_hash=? AND system_hash=? AND model=?
+                     AND provider=? AND temperature=? AND json_mode=?
+                   LIMIT 1""",
                 (prompt_hash, system_hash, model, provider, temperature, json_mode_int),
             )
             row = await cursor.fetchone()
             await cursor.close()
 
             if row:
-                logger.debug(
-                    "Cache hit: %s/%s (prompt: %s...)",
-                    provider,
-                    model,
-                    prompt[:30],
-                )
+                logger.debug("SQLite cache hit: %s/%s (prompt: %s...)", provider, model, prompt[:30])
+                # Promote to Redis L1
+                if self._redis is not None:
+                    rkey = self._redis_key(prompt_hash, system_hash, model, provider, temperature, json_mode_int)
+                    await self._redis.set(rkey, row[0])
                 return row[0]
 
             return None
@@ -198,115 +198,80 @@ class LLMCache:
         response: str,
         system: str = "",
     ) -> bool:
-        """Store a response in the cache.
+        prompt_hash, system_hash, model, provider, temperature, json_mode_int = self._make_cache_key(
+            prompt, model, provider, temperature, json_mode, system
+        )
 
-        Args:
-            prompt: The user prompt or message list.
-            model: The model identifier.
-            provider: The provider name.
-            temperature: The temperature parameter.
-            json_mode: Whether JSON mode is enabled.
-            response: The response text to cache.
-            system: The system prompt (optional).
+        # Write to Redis L1
+        if self._redis is not None:
+            rkey = self._redis_key(prompt_hash, system_hash, model, provider, temperature, json_mode_int)
+            await self._redis.set(rkey, response)
 
-        Returns:
-            True if stored successfully, False otherwise.
-        """
+        # Write to SQLite L2
         if not self._conn:
             return False
 
         try:
-            prompt_hash, system_hash, model, provider, temperature, json_mode_int = self._make_cache_key(
-                prompt, model, provider, temperature, json_mode, system
-            )
-
             await self._conn.execute(
-                """
-                INSERT INTO llm_cache (prompt_hash, system_hash, model, provider, temperature, json_mode, response)
-                VALUES (?, ?, ?, ?, ?, ?, ?)
-                ON CONFLICT(prompt_hash, system_hash, model, provider, temperature, json_mode) DO UPDATE SET
-                    response = excluded.response,
-                    created_at = CURRENT_TIMESTAMP
-                """,
+                """INSERT INTO llm_cache
+                       (prompt_hash, system_hash, model, provider, temperature, json_mode, response)
+                   VALUES (?, ?, ?, ?, ?, ?, ?)
+                   ON CONFLICT(prompt_hash, system_hash, model, provider, temperature, json_mode)
+                   DO UPDATE SET response=excluded.response, created_at=CURRENT_TIMESTAMP""",
                 (prompt_hash, system_hash, model, provider, temperature, json_mode_int, response),
             )
             await self._conn.commit()
-            logger.debug(
-                "Cached response: %s/%s (prompt: %s...)",
-                provider,
-                model,
-                prompt[:30],
-            )
+            logger.debug("Cached response: %s/%s (prompt: %s...)", provider, model, prompt[:30])
             return True
         except Exception as e:
             logger.warning("Failed to cache response: %s", e)
             return False
 
-    async def stats(self) -> dict[str, int]:
-        """Get cache statistics.
+    async def stats(self) -> dict:
+        base: dict = {}
+        if self._conn:
+            try:
+                cursor = await self._conn.execute(
+                    "SELECT COUNT(*), COUNT(DISTINCT provider), COUNT(DISTINCT model) FROM llm_cache"
+                )
+                row = await cursor.fetchone()
+                await cursor.close()
+                if row:
+                    base = {
+                        "total_cached_responses": row[0],
+                        "unique_providers": row[1],
+                        "unique_models": row[2],
+                    }
+            except Exception as e:
+                logger.warning("Failed to get cache stats: %s", e)
 
-        Returns:
-            Dictionary with cache size info.
-        """
-        if not self._conn:
-            return {}
+        if self._redis is not None:
+            base["redis"] = self._redis.stats()
 
-        try:
-            cursor = await self._conn.execute(
-                "SELECT COUNT(*) as total, COUNT(DISTINCT provider) as providers, COUNT(DISTINCT model) as models FROM llm_cache"
-            )
-            row = await cursor.fetchone()
-            await cursor.close()
-
-            if row:
-                return {
-                    "total_cached_responses": row[0],
-                    "unique_providers": row[1],
-                    "unique_models": row[2],
-                }
-            return {}
-        except Exception as e:
-            logger.warning("Failed to get cache stats: %s", e)
-            return {}
+        return base
 
     async def clear(self, provider: str | None = None, model: str | None = None) -> int:
-        """Clear cache entries.
+        # Flush Redis L1 entirely (no fine-grained provider/model filter in Redis)
+        if self._redis is not None:
+            await self._redis.flush()
 
-        Args:
-            provider: If specified, only clear entries for this provider.
-            model: If specified, only clear entries for this model.
-
-        Returns:
-            Number of entries deleted.
-        """
         if not self._conn:
             return 0
 
         try:
             if provider is None and model is None:
-                # Clear all
                 cursor = await self._conn.execute("DELETE FROM llm_cache")
                 logger.info("Cleared entire LLM cache")
             elif provider and model:
-                # Clear specific provider + model
                 cursor = await self._conn.execute(
-                    "DELETE FROM llm_cache WHERE provider = ? AND model = ?",
-                    (provider, model),
+                    "DELETE FROM llm_cache WHERE provider=? AND model=?", (provider, model)
                 )
                 logger.info("Cleared cache for %s/%s", provider, model)
             elif provider:
-                # Clear by provider
-                cursor = await self._conn.execute(
-                    "DELETE FROM llm_cache WHERE provider = ?",
-                    (provider,),
-                )
+                cursor = await self._conn.execute("DELETE FROM llm_cache WHERE provider=?", (provider,))
                 logger.info("Cleared cache for provider %s", provider)
             else:
-                # Clear by model
-                cursor = await self._conn.execute(
-                    "DELETE FROM llm_cache WHERE model = ?",
-                    (model,),
-                )
+                cursor = await self._conn.execute("DELETE FROM llm_cache WHERE model=?", (model,))
                 logger.info("Cleared cache for model %s", model)
 
             await self._conn.commit()
@@ -318,7 +283,8 @@ class LLMCache:
             return 0
 
     async def close(self) -> None:
-        """Close the database connection."""
+        if self._redis is not None:
+            await self._redis.close()
         if self._conn:
             await self._conn.close()
             self._conn = None

--- a/daemon/pilot/models/cache.py
+++ b/daemon/pilot/models/cache.py
@@ -121,7 +121,7 @@ class LLMCache:
             prompt_str = json.dumps(prompt, sort_keys=True)
         else:
             prompt_str = prompt
-        prompt_hash = self._hash_string(prompt)
+        prompt_hash = self._hash_string(prompt_str)
         system_hash = self._hash_string(system) if system else ""
         return (prompt_hash, system_hash, model, provider, temperature, int(json_mode))
 

--- a/daemon/pilot/models/cache.py
+++ b/daemon/pilot/models/cache.py
@@ -121,7 +121,6 @@ class LLMCache:
             prompt_str = json.dumps(prompt, sort_keys=True)
         else:
             prompt_str = prompt
-        prompt_hash = self._hash_string(prompt_str)
         prompt_hash = self._hash_string(prompt)
         system_hash = self._hash_string(system) if system else ""
         return (prompt_hash, system_hash, model, provider, temperature, int(json_mode))

--- a/daemon/pilot/models/router.py
+++ b/daemon/pilot/models/router.py
@@ -7,6 +7,7 @@ import logging
 from typing import TYPE_CHECKING, Any
 
 from pilot.config import DATA_DIR
+from pilot.db.redis_adapter import RedisCacheAdapter
 from pilot.models.cache import LLMCache
 from pilot.models.cloud import CloudClient
 from pilot.models.ollama import OllamaClient
@@ -36,7 +37,8 @@ class ModelRouter:
         self._cloud: CloudClient | None = None
         self._llamacpp: object | None = None
         self._resolved_ollama_model: str | None = None
-        self._cache = LLMCache(DATA_DIR / "llm_cache.db")
+        redis_adapter = RedisCacheAdapter.from_config(config.redis)
+        self._cache = LLMCache(DATA_DIR / "llm_cache.db", redis=redis_adapter)
         self._budget_tracker: BudgetTracker | None = None
 
         if config.model.cloud_provider:
@@ -50,6 +52,7 @@ class ModelRouter:
 
     async def initialize(self) -> None:
         """Initialize the cache. Must be called before using generate()."""
+        await self._cache._redis.initialize()
         await self._cache.initialize()
 
     def set_budget_tracker(self, tracker: BudgetTracker) -> None:

--- a/daemon/tests/test_redis_adapter.py
+++ b/daemon/tests/test_redis_adapter.py
@@ -1,0 +1,294 @@
+"""Tests for the Redis cache adapter.
+
+Covers:
+- In-memory LRU fallback (no Redis dependency needed)
+- Cache hit / miss / TTL expiry
+- Redis-mode: set/get/delete/exists/flush
+- Fallback on Redis failure
+- Key prefixing
+- stats()
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from pilot.db.redis_adapter import RedisConfig, RedisCacheAdapter, _LRUCache
+
+
+# ─── _LRUCache ────────────────────────────────────────────────────────────────
+
+class TestLRUCache:
+    @pytest.fixture
+    def cache(self):
+        return _LRUCache(max_size=3)
+
+    async def test_miss_returns_none(self, cache):
+        assert await cache.get("missing") is None
+
+    async def test_set_and_get(self, cache):
+        await cache.set("k", "v", ttl=60)
+        assert await cache.get("k") == "v"
+
+    async def test_ttl_expiry(self, cache):
+        await cache.set("k", "v", ttl=1)
+        # Manually expire by patching time
+        with patch("pilot.db.redis_adapter.time") as mock_time:
+            mock_time.monotonic.return_value = time.monotonic() + 10
+            assert await cache.get("k") is None
+
+    async def test_no_ttl_never_expires(self, cache):
+        await cache.set("k", "v", ttl=0)
+        with patch("pilot.db.redis_adapter.time") as mock_time:
+            mock_time.monotonic.return_value = time.monotonic() + 99999
+            assert await cache.get("k") == "v"
+
+    async def test_delete(self, cache):
+        await cache.set("k", "v", ttl=60)
+        await cache.delete("k")
+        assert await cache.get("k") is None
+
+    async def test_delete_nonexistent_no_error(self, cache):
+        await cache.delete("nonexistent")  # should not raise
+
+    async def test_lru_eviction(self, cache):
+        await cache.set("a", "1", ttl=60)
+        await cache.set("b", "2", ttl=60)
+        await cache.set("c", "3", ttl=60)
+        # Access "a" to make it recently used
+        await cache.get("a")
+        # Insert "d" — should evict "b" (LRU)
+        await cache.set("d", "4", ttl=60)
+        assert await cache.get("b") is None
+        assert await cache.get("a") == "1"
+
+    async def test_flush_clears_all(self, cache):
+        await cache.set("a", "1", ttl=60)
+        await cache.set("b", "2", ttl=60)
+        await cache.flush()
+        assert cache.size() == 0
+
+    async def test_size(self, cache):
+        assert cache.size() == 0
+        await cache.set("a", "1", ttl=60)
+        assert cache.size() == 1
+
+    async def test_overwrite_existing_key(self, cache):
+        await cache.set("k", "old", ttl=60)
+        await cache.set("k", "new", ttl=60)
+        assert await cache.get("k") == "new"
+        assert cache.size() == 1
+
+
+# ─── RedisCacheAdapter — memory fallback mode ─────────────────────────────────
+
+class TestAdapterMemoryMode:
+    @pytest.fixture
+    def config(self):
+        return RedisConfig(enabled=False)
+
+    @pytest.fixture
+    async def adapter(self, config):
+        a = RedisCacheAdapter(config)
+        await a.initialize()
+        yield a
+        await a.close()
+
+    async def test_backend_is_memory(self, adapter):
+        assert adapter.backend == "memory"
+
+    async def test_set_and_get(self, adapter):
+        await adapter.set("key", "value")
+        assert await adapter.get("key") == "value"
+
+    async def test_miss_returns_none(self, adapter):
+        assert await adapter.get("no-such-key") is None
+
+    async def test_delete(self, adapter):
+        await adapter.set("k", "v")
+        await adapter.delete("k")
+        assert await adapter.get("k") is None
+
+    async def test_exists_true(self, adapter):
+        await adapter.set("k", "v")
+        assert await adapter.exists("k") is True
+
+    async def test_exists_false(self, adapter):
+        assert await adapter.exists("nope") is False
+
+    async def test_flush(self, adapter):
+        await adapter.set("a", "1")
+        await adapter.set("b", "2")
+        await adapter.flush()
+        assert await adapter.get("a") is None
+        assert await adapter.get("b") is None
+
+    async def test_stats(self, adapter):
+        s = adapter.stats()
+        assert s["backend"] == "memory"
+        assert s["redis_connected"] is False
+        assert "fallback_size" in s
+
+    async def test_default_ttl_used(self, adapter):
+        # With default TTL, key should be stored
+        await adapter.set("k", "v")
+        assert await adapter.get("k") == "v"
+
+    async def test_key_prefix_not_applied_in_memory(self, adapter):
+        # Memory mode doesn't prefix — direct key lookup works
+        await adapter.set("mykey", "myval")
+        assert await adapter.get("mykey") == "myval"
+
+
+# ─── RedisCacheAdapter — Redis mode ──────────────────────────────────────────
+
+class TestAdapterRedisMode:
+    @pytest.fixture
+    def config(self):
+        return RedisConfig(enabled=True, host="127.0.0.1", port=6379, key_prefix="test:")
+
+    def _make_mock_redis(self):
+        mock = AsyncMock()
+        mock.ping = AsyncMock(return_value=True)
+        mock.get = AsyncMock(return_value=None)
+        mock.set = AsyncMock()
+        mock.setex = AsyncMock()
+        mock.delete = AsyncMock()
+        mock.keys = AsyncMock(return_value=[])
+        mock.aclose = AsyncMock()
+        return mock
+
+    @pytest.fixture
+    async def adapter_redis(self, config):
+        mock_redis = self._make_mock_redis()
+        with patch.dict("sys.modules", {"redis": MagicMock(), "redis.asyncio": MagicMock()}):
+            with patch("pilot.db.redis_adapter.RedisCacheAdapter.initialize", new_callable=AsyncMock) as mock_init:
+                a = RedisCacheAdapter(config)
+                a._redis = mock_redis
+                a._using_redis = True
+                yield a, mock_redis
+
+    async def test_backend_is_redis(self, adapter_redis):
+        adapter, _ = adapter_redis
+        assert adapter.backend == "redis"
+
+    async def test_get_calls_redis(self, adapter_redis):
+        adapter, mock = adapter_redis
+        mock.get.return_value = "cached_value"
+        result = await adapter.get("mykey")
+        mock.get.assert_called_once_with("test:mykey")
+        assert result == "cached_value"
+
+    async def test_get_miss_returns_none(self, adapter_redis):
+        adapter, mock = adapter_redis
+        mock.get.return_value = None
+        assert await adapter.get("missing") is None
+
+    async def test_set_with_ttl_uses_setex(self, adapter_redis):
+        adapter, mock = adapter_redis
+        await adapter.set("k", "v", ttl=60)
+        mock.setex.assert_called_once_with("test:k", 60, "v")
+
+    async def test_set_no_ttl_uses_set(self, adapter_redis):
+        adapter, mock = adapter_redis
+        await adapter.set("k", "v", ttl=0)
+        mock.set.assert_called_once_with("test:k", "v")
+
+    async def test_delete_calls_redis(self, adapter_redis):
+        adapter, mock = adapter_redis
+        await adapter.delete("k")
+        mock.delete.assert_called_once_with("test:k")
+
+    async def test_flush_deletes_prefixed_keys(self, adapter_redis):
+        adapter, mock = adapter_redis
+        mock.keys.return_value = ["test:a", "test:b"]
+        await adapter.flush()
+        mock.keys.assert_called_once_with("test:*")
+        mock.delete.assert_called_once_with("test:a", "test:b")
+
+    async def test_flush_no_keys_no_delete(self, adapter_redis):
+        adapter, mock = adapter_redis
+        mock.keys.return_value = []
+        await adapter.flush()
+        mock.delete.assert_not_called()
+
+    async def test_stats_redis_mode(self, adapter_redis):
+        adapter, _ = adapter_redis
+        s = adapter.stats()
+        assert s["backend"] == "redis"
+        assert s["redis_connected"] is True
+        assert s["key_prefix"] == "test:"
+
+
+# ─── Fallback on Redis failure ────────────────────────────────────────────────
+
+class TestAdapterRedisFallback:
+    @pytest.fixture
+    def config(self):
+        return RedisConfig(enabled=True)
+
+    async def test_import_error_falls_back_to_memory(self, config):
+        with patch.dict("sys.modules", {"redis": None, "redis.asyncio": None}):
+            a = RedisCacheAdapter(config)
+            await a.initialize()
+            assert a.backend == "memory"
+            await a.close()
+
+    async def test_redis_get_failure_uses_fallback(self, config):
+        mock_redis = AsyncMock()
+        mock_redis.get.side_effect = ConnectionError("Redis down")
+
+        a = RedisCacheAdapter(config)
+        a._redis = mock_redis
+        a._using_redis = True
+
+        # Pre-populate fallback
+        await a._fallback.set("k", "fallback_value", ttl=60)
+
+        result = await a.get("k")
+        assert result == "fallback_value"
+
+    async def test_redis_set_failure_writes_to_fallback(self, config):
+        mock_redis = AsyncMock()
+        mock_redis.setex.side_effect = ConnectionError("Redis down")
+
+        a = RedisCacheAdapter(config)
+        a._redis = mock_redis
+        a._using_redis = True
+
+        await a.set("k", "v", ttl=60)
+        assert await a._fallback.get("k") == "v"
+
+    async def test_redis_delete_failure_deletes_from_fallback(self, config):
+        mock_redis = AsyncMock()
+        mock_redis.delete.side_effect = ConnectionError("Redis down")
+
+        a = RedisCacheAdapter(config)
+        a._redis = mock_redis
+        a._using_redis = True
+
+        await a._fallback.set("k", "v", ttl=60)
+        await a.delete("k")
+        assert await a._fallback.get("k") is None
+
+
+# ─── from_config ──────────────────────────────────────────────────────────────
+
+class TestFromConfig:
+    def test_from_config_returns_adapter(self):
+        cfg = RedisConfig(enabled=False)
+        adapter = RedisCacheAdapter.from_config(cfg)
+        assert isinstance(adapter, RedisCacheAdapter)
+
+    def test_config_defaults(self):
+        cfg = RedisConfig()
+        assert cfg.host == "127.0.0.1"
+        assert cfg.port == 6379
+        assert cfg.db == 0
+        assert cfg.default_ttl == 300
+        assert cfg.key_prefix == "pilot:"
+        assert cfg.enabled is False


### PR DESCRIPTION
## Summary

This PR adds initial Redis cache adapter support to improve scalability and distributed caching capabilities in Heliox OS.

The changes introduce a configurable RedisConfig, add Redis configuration validation support, implement a Redis adapter module, and include tests for Redis adapter functionality and cache behavior.

Closes #221

---

## Type of change

- [ ] Bug fix
- [x] New feature / enhancement
- [ ] Documentation update
- [x] Tests / CI
- [ ] Performance improvement
- [ ] Refactor (no functional change)

---

## Changes made

- Added RedisConfig dataclass with configurable Redis connection settings
- Added Redis configuration type validation in pilot/config.py
- Created pilot/db/redis_adapter.py for Redis cache integration
- Added Redis adapter test coverage in tests/test_redis_adapter.py
- Added support for configurable TTL, SSL, key prefixes, and cache size handling

---

## How to test

1. Install project dependencies and activate the virtual environment
2. Run the Redis adapter tests:
   bash    pytest tests/test_redis_adapter.py -v    
3. Verify configuration validation works correctly for Redis settings
4. Confirm Redis adapter initializes and handles cache operations as expected

---

## Checklist

- [x] I have read the CONTRIBUTING.md
- [x] My code follows the existing code style
- [x] I have added/updated tests where applicable
- [ ] All existing tests pass (pytest for backend, npm run test for frontend)
- [ ] I have updated documentation if needed
- [x] I have tested on at least one platform (Windows / macOS / Linux)

---

## Screenshots / recordings (if UI change)

<img width="2928" height="1218" alt="image" src="https://github.com/user-attachments/assets/fe974aee-18af-4a7f-a257-191823f186f7" />

---

## GSSoC declaration

- [x] This contribution is made under the GSSoC 2026 program
- [x] I have not plagiarised code from other repositories