### PR TITLE
feat: implement global keyboard shortcuts with configurable hotkey (#88)

### DIFF
--- a/tauri-app/src-tauri/Cargo.lock
+++ b/tauri-app/src-tauri/Cargo.lock
@@ -338,6 +338,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1582,6 +1593,7 @@ version = "0.6.2"
 dependencies = [
  "dirs 5.0.1",
  "futures-util",
+ "opener",
  "serde",
  "serde_json",
  "tauri",
@@ -2078,6 +2090,7 @@ version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "328c4789d42200f1eeec05bd86c9c13c7f091d2ba9a6ea35acdf51f31bc0f043"
 dependencies = [
+ "cc",
  "pkg-config",
 ]
 
@@ -2260,6 +2273,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "normpath"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9985ef7269fa99f3b12437bb698381da2428743ab90f20393f399fa14cab21a"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2526,6 +2548,18 @@ dependencies = [
  "is-wsl",
  "libc",
  "pathdiff",
+]
+
+[[package]]
+name = "opener"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0812e5e4df08da354c851a3376fead46db31c2214f849d3de356d774d057681"
+dependencies = [
+ "bstr",
+ "dbus",
+ "normpath",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/tauri-app/src-tauri/src/commands.rs
+++ b/tauri-app/src-tauri/src/commands.rs
@@ -142,3 +142,14 @@ pub fn open_logs_folder(app: tauri::AppHandle) -> Result<(), String> {
     opener::open(&log_dir).map_err(|e| e.to_string())?;
     Ok(())
 }
+// 5. Get the currently active global shortcut
+#[tauri::command]
+pub fn get_hotkey(app: AppHandle) -> String {
+    crate::hotkey::load_saved_shortcut(&app)
+}
+
+// 6. Update the global shortcut from the frontend settings panel
+#[tauri::command]
+pub fn set_hotkey(app: AppHandle, shortcut: String) -> Result<(), String> {
+    crate::hotkey::update_shortcut(&app, &shortcut)
+}

--- a/tauri-app/src-tauri/src/hotkey.rs
+++ b/tauri-app/src-tauri/src/hotkey.rs
@@ -1,19 +1,73 @@
-use tauri::{App, Manager};
-use tauri_plugin_global_shortcut::GlobalShortcutExt;
+use tauri::{App, AppHandle, Manager};
+use tauri_plugin_global_shortcut::{GlobalShortcutExt, ShortcutState};
+use std::fs;
+
+fn get_shortcut_path(_app: &AppHandle) -> std::path::PathBuf {
+    let home = dirs::home_dir().unwrap_or_else(|| std::path::PathBuf::from("."));
+    home.join(".heliox-os").join("shortcut.txt")
+}
+
+pub fn load_saved_shortcut(app: &AppHandle) -> String {
+    let path = get_shortcut_path(app);
+    let saved = fs::read_to_string(path).unwrap_or_default();
+    let trimmed = saved.trim();
+    if trimmed.is_empty() {
+        // Use platform-appropriate default shortcut
+        #[cfg(target_os = "macos")]
+        return "Cmd+Space".to_string();
+        #[cfg(not(target_os = "macos"))]
+        return "Ctrl+Space".to_string();
+    }
+    trimmed.to_string()
+}
+
+fn save_shortcut(app: &AppHandle, shortcut: &str) {
+    let path = get_shortcut_path(app);
+    if let Some(parent) = path.parent() {
+        let _ = fs::create_dir_all(parent);
+    }
+    let _ = fs::write(path, shortcut);
+}
 
 pub fn register_hotkey(app: &App) -> Result<(), Box<dyn std::error::Error>> {
     let app_handle = app.handle().clone();
+    let shortcut = load_saved_shortcut(&app_handle);
+    do_register(&app_handle, &shortcut)?;
+    Ok(())
+}
 
-    app.global_shortcut().on_shortcut("Super+J", move |_app, _shortcut, _event| {
+pub fn do_register(app: &AppHandle, shortcut: &str) -> Result<(), Box<dyn std::error::Error>> {
+    let _ = app.global_shortcut().unregister_all();
+
+    let app_handle = app.clone();
+
+    app.global_shortcut().on_shortcut(shortcut, move |_app, _shortcut, event| {
+        
+        if event.state != ShortcutState::Pressed {
+            return;
+        }
+
         if let Some(window) = app_handle.get_webview_window("main") {
-            if window.is_visible().unwrap_or(false) {
+            let is_visible = window.is_visible().unwrap_or(false);
+            let is_minimized = window.is_minimized().unwrap_or(false);
+            let is_focused = window.is_focused().unwrap_or(false);
+            if is_visible && !is_minimized && is_focused {
+                // Window is fully visible and focused , hide it completely
                 let _ = window.hide();
             } else {
+                // Window is hidden or minimized , bring it up properly
+                let _ = window.unminimize();
                 let _ = window.show();
                 let _ = window.set_focus();
             }
         }
     })?;
 
+    Ok(())
+}
+
+pub fn update_shortcut(app: &AppHandle, new_shortcut: &str) -> Result<(), String> {
+    do_register(app, new_shortcut).map_err(|e| e.to_string())?;
+    save_shortcut(app, new_shortcut);
     Ok(())
 }

--- a/tauri-app/src-tauri/src/main.rs
+++ b/tauri-app/src-tauri/src/main.rs
@@ -184,6 +184,8 @@ fn main() {
             commands::send_to_daemon,
             commands::confirm_action,
             commands::open_logs_folder,
+            commands::get_hotkey,
+            commands::set_hotkey,
         ])
         .run(tauri::generate_context!())
         .expect("error while running Heliox OS");

--- a/tauri-app/ui/src/lib/components/SettingsPanel.svelte
+++ b/tauri-app/ui/src/lib/components/SettingsPanel.svelte
@@ -2,11 +2,35 @@
   import { settings } from "../stores/settings";
   import { session } from "../stores/session";
   import { call } from "../api/daemon";
+  import { invoke } from "@tauri-apps/api/core";
   import { isPermissionGranted, requestPermission, sendNotification } from "@tauri-apps/plugin-notification";
 
   let apiKeyInput = $state("");
   let apiKeySaved = $state(false);
   let apiKeySaving = $state(false);
+
+  let hotkeyInput = $state("");
+  let hotkeySaved = $state(false);
+  let hotkeyError = $state("");
+
+  // Load the current hotkey when component mounts
+  invoke("get_hotkey").then((val) => {
+    hotkeyInput = val as string;
+  });
+
+  async function saveHotkey() {
+    hotkeyError = "";
+    const trimmed = hotkeyInput.trim();
+    if (!trimmed) return;
+    try {
+      await invoke("set_hotkey", { shortcut: trimmed });
+      settings.updateSection("", { hotkey: trimmed });
+      hotkeySaved = true;
+      setTimeout(() => (hotkeySaved = false), 3000);
+    } catch (err) {
+      hotkeyError = "Invalid shortcut. Try: Ctrl+Space or Alt+H";
+    }
+  }
 
   function toggleRoot() {
     settings.updateSection("security", { root_enabled: !$settings.security.root_enabled });
@@ -77,28 +101,29 @@
   function toggleTheme() {
     const currentTheme = $settings.theme || "dark";
     const nextTheme = currentTheme === "dark" ? "light" : "dark";
-    
+
     // Update the central store root section directly
     // The store's internal side-effects will automatically manage document classes and localStorage synchronization
     settings.updateSection("", { theme: nextTheme });
   }
+
   async function testNotification() {
     try {
       let granted = await isPermissionGranted();
       if (!granted) {
         const permission = await requestPermission();
-        granted = permission === 'granted';
+        granted = permission === "granted";
       }
       if (granted) {
         sendNotification({
-          title: 'Heliox OS',
-          body: 'Test notification — desktop notifications are working! 🚀',
+          title: "Heliox OS",
+          body: "Test notification — desktop notifications are working! 🚀",
         });
       } else {
-        console.warn('Notification permission was denied');
+        console.warn("Notification permission was denied");
       }
     } catch (err) {
-      console.error('Notification test failed:', err);
+      console.error("Notification test failed:", err);
     }
   }
 </script>
@@ -123,6 +148,32 @@
         <span class="toggle-knob"></span>
       </button>
     </div>
+  </section>
+
+  <section class="settings-group">
+    <h3>Keyboard Shortcut</h3>
+    <div class="setting-row">
+      <div class="setting-info">
+        <span class="setting-label">Global Hotkey</span>
+        <span class="setting-desc">Summon Heliox from anywhere (default: Ctrl+Space)</span>
+      </div>
+      <div class="api-key-row">
+        <input
+          type="text"
+          class="input-md"
+          bind:value={hotkeyInput}
+          placeholder="Ctrl+Space"
+        />
+        <button class="btn-save" onclick={saveHotkey}>
+          {hotkeySaved ? "✓ Saved!" : "Save"}
+        </button>
+      </div>
+    </div>
+    {#if hotkeyError}
+      <div style="padding: 6px 14px; font-size: 11px; color: var(--accent);">
+        {hotkeyError}
+      </div>
+    {/if}
   </section>
 
   <section class="settings-group">
@@ -373,7 +424,7 @@
 
 <style>
   .settings-panel {
-    height: 100%; 
+    height: 100%;
     overflow-y: auto;
     padding: 16px;
   }

--- a/tauri-app/ui/src/lib/stores/settings.ts
+++ b/tauri-app/ui/src/lib/stores/settings.ts
@@ -29,7 +29,8 @@ export interface PilotSettings {
     blocked_commands: string[];
   };
   first_run_complete: boolean;
-  theme: "light" | "dark"; // Added tracking for active UI theme mode
+  theme: "light" | "dark";
+  hotkey: string; // Added tracking for active UI theme mode
 }
 
 const defaultSettings: PilotSettings = {
@@ -60,7 +61,10 @@ const defaultSettings: PilotSettings = {
     blocked_commands: [],
   },
   first_run_complete: false,
-  theme: "dark", // Default configuration set to dark mode
+  theme: "dark",
+  hotkey: typeof navigator !== "undefined" && navigator.platform.includes("Mac") 
+    ? "Cmd+Space" 
+    : "Ctrl+Space", // Default configuration set to dark mode
 };
 
 function createSettings() {


### PR DESCRIPTION
## Summary
Closes #88

Implements global keyboard shortcuts so users can summon the Heliox OS 
chat window instantly from anywhere on their desktop using a configurable 
hotkey, making it feel like a true OS assistant.

## Changes

### Rust (src-tauri)
- **hotkey.rs** — Complete rewrite with:
  - Platform-aware default: `Ctrl+Space` on Windows/Linux, `Cmd+Space` on macOS
  - Smart focus detection: hides when focused, summons when behind other windows, restores when minimized
  - Fires only on key press (not hold/release) to prevent rapid toggling
  - Persists custom shortcut to `~/.heliox-os/shortcut.txt`
- **commands.rs** — Added `get_hotkey` and `set_hotkey` Tauri commands
- **main.rs** — Registered new commands in `invoke_handler`

### Frontend (ui)
- **SettingsPanel.svelte** — Added Keyboard Shortcut section with:
  - Text input showing current shortcut
  - Save button with "✓ Saved!" feedback
  - Error message for invalid shortcuts
- **settings.ts** — Added `hotkey` field to `PilotSettings` interface with platform-aware default

## Behavior

| Window State | Shortcut Result |
|---|---|
| Focused and visible | Hides completely |
| Behind other windows | Brings to front and focuses |
| Minimized to taskbar | Restores and focuses |
| Hidden | Shows and focuses |

## Testing
- ✅ Tested on Windows
- ✅ Default `Ctrl+Space` works globally from any app
- ✅ Custom shortcut saved and persists after app restart
- ✅ Settings panel shows and updates current shortcut live
- ✅ Window correctly summoned from behind other windows
- ✅ Window correctly hides when focused

## Screenshots/Demo
Heliox running behind another window 
<img width="1558" height="1278" alt="image" src="https://github.com/user-attachments/assets/cd23dadf-3501-44a1-80b9-a2623a66bfad" />
After pressing ctrl+space in windows and vice versa
<img width="1788" height="1260" alt="image" src="https://github.com/user-attachments/assets/771d26c2-b4b5-433c-a65a-de27e8a5b30a" />
Settings panel showing the Keyboard Shortcut section
<img width="1348" height="550" alt="image" src="https://github.com/user-attachments/assets/15fb33bb-27f0-460d-9aed-1af8c6f670a1" />
After clicking ctrl + Space , Heliox disappears and reappears after pressing ctrl+space again and vice versa
<img width="1524" height="1204" alt="image" src="https://github.com/user-attachments/assets/5ea1bae7-6910-4722-a126-cfccaad60457" />
<img width="1368" height="1112" alt="image" src="https://github.com/user-attachments/assets/c8bfaf8d-5e5d-4edf-9d0f-69214af023f0" />

