### PR TITLE
#265 issue - fix(memory): properly accumulate user_input and result tokens in context compression

### DIFF
--- a/daemon/pilot/memory/context_compressor.py
+++ b/daemon/pilot/memory/context_compressor.py
@@ -63,6 +63,8 @@ class ContextCompressor:
         """
         total_tokens = 0
         for item in history:
+            if "user_input" in item and isinstance(item["user_input"], str):
+                total_tokens += self.count_tokens(item["user_input"])
             if "plan" in item and isinstance(item["plan"], dict):
                 total_tokens += self.estimate_plan_tokens(item["plan"])
             if "result" in item and isinstance(item.get("result"), dict):
@@ -79,8 +81,12 @@ class ContextCompressor:
 
         for item in reversed(history):
             item_tokens = 0
+            if "user_input" in item and isinstance(item["user_input"], str):
+                item_tokens += self.count_tokens(item["user_input"])
             if "plan" in item and isinstance(item["plan"], dict):
-                item_tokens = self.estimate_plan_tokens(item["plan"])
+                item_tokens += self.estimate_plan_tokens(item["plan"])
+            if "result" in item and isinstance(item.get("result"), dict):
+                item_tokens += self.estimate_action_tokens(item.get("result", {}))
 
             if running_tokens + item_tokens < self._max_tokens - NUM_RESERVED_TOKENS:
                 recent_items.insert(0, item)


### PR DESCRIPTION
Fixes #265 where context compression failed to compress long histories because it omitted tracking user inputs and results during token budget accumulation in reverse evaluation.
## Summary
This PR fixes a bug in the token counting logic of `compress_conversation` which previously caused it to return the full conversation history uncompressed. By correctly accumulating tokens for `user_input` and `result` during the reverse iteration, the compressor will now accurately trigger and create a summary node once the history exceeds the configured threshold.
Closes #265
---
## Type of change
- [x] Bug fix
- [ ] New feature / enhancement
- [ ] Documentation update
- [ ] Tests / CI
- [ ] Performance improvement
- [ ] Refactor (no functional change)
---
## Changes made
- `daemon/pilot/memory/context_compressor.py`: Updated `compress_conversation` to correctly calculate `total_tokens` and reverse-loop `item_tokens` by explicitly tracking both the `user_input` and `result` dictionaries inside the history items.
---
## How to test
1. Ensure all dependencies (including dev dependencies) are installed using `pip install -e ".[dev]"`.
2. Run the specific unit test for this module using: `pytest daemon/tests/test_context_compressor.py::TestContextCompressor::test_compress_conversation_with_compression`
3. Verify that the test successfully passes, proving the long history is now correctly compressed.
---
## Checklist
- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My code follows the existing code style
- [x] I have added/updated tests where applicable
- [x] All existing tests pass (`pytest` for backend, `npm run test` for frontend)
- [x] I have updated documentation if needed
- [x] I have tested on at least one platform (Windows / macOS / Linux)
---
## Screenshots / recordings (if UI change)
<!-- Drag and drop a screenshot or screen recording here -->
N/A (Backend logic fix only)
---
## GSSoC declaration
- [x] This contribution is made under the GSSoC 2026 program
- [x] I have not plagiarised code from other repositories