### PR TITLE
fix: context compressor test, token counting, ordering, and compression logic

### DIFF
--- a/daemon/pilot/memory/context_compressor.py
+++ b/daemon/pilot/memory/context_compressor.py
@@ -21,10 +21,12 @@ class ContextCompressor:
         self,
         model_router: ModelRouter,
         max_tokens: int = DEFAULT_MAX_TOKENS,
+        compression_threshold: int | None = None,
     ):
         self._model = model_router
         self._max_tokens = max_tokens
-        self._threshold = COMPRESSION_THRESHOLD
+        available_budget = max_tokens - NUM_RESERVED_TOKENS
+        self._threshold = compression_threshold if compression_threshold is not None else int(available_budget * 0.6)
         self._enc = tiktoken.get_encoding("cl100k_base")
 
     def count_tokens(self, text: str) -> int:
@@ -63,6 +65,7 @@ class ContextCompressor:
         """
         total_tokens = 0
         for item in history:
+            total_tokens += self.count_tokens(item.get("user_input", ""))
             if "plan" in item and isinstance(item["plan"], dict):
                 total_tokens += self.estimate_plan_tokens(item["plan"])
             if "result" in item and isinstance(item.get("result"), dict):
@@ -76,17 +79,20 @@ class ContextCompressor:
         recent_items = []
         compressed_items = []
         running_tokens = 0
+        max_recent_tokens = self._threshold // 2
 
         for item in reversed(history):
-            item_tokens = 0
+            item_tokens = self.count_tokens(item.get("user_input", ""))
             if "plan" in item and isinstance(item["plan"], dict):
-                item_tokens = self.estimate_plan_tokens(item["plan"])
+                item_tokens += self.estimate_plan_tokens(item["plan"])
+            if "result" in item and isinstance(item.get("result"), dict):
+                item_tokens += self.estimate_action_tokens(item.get("result", {}))
 
-            if running_tokens + item_tokens < self._max_tokens - NUM_RESERVED_TOKENS:
+            if running_tokens + item_tokens <= max_recent_tokens:
                 recent_items.insert(0, item)
                 running_tokens += item_tokens
             else:
-                compressed_items.append(item)
+                compressed_items.insert(0, item)
 
         if compressed_items:
             summary = await self._summarize_items(compressed_items)

--- a/daemon/tests/test_context_compressor.py
+++ b/daemon/tests/test_context_compressor.py
@@ -10,10 +10,9 @@ import pytest
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from pilot.memory.context_compressor import (
-    COMPRESSION_THRESHOLD,
-    DEFAULT_MAX_TOKENS,
     ContextCompressor,
     RollingContextWindow,
+    NUM_RESERVED_TOKENS
 )
 
 
@@ -34,7 +33,7 @@ class TestContextCompressor:
     def test_initial_state(self, compressor):
         """Test compressor initializes with correct defaults."""
         assert compressor._max_tokens == 8000
-        assert compressor._threshold == 6000
+        assert compressor._threshold == int((compressor._max_tokens - NUM_RESERVED_TOKENS) * 0.6)
 
     def test_count_tokens_empty(self, compressor):
         """Test token count for empty string."""


### PR DESCRIPTION
## Summary

This PR fixes inconsistent token accounting and ordering in the rolling context compressor to ensure reliable compression behavior for a history larger than the threshold

Closes #265 

---

## Type of change

- [x] Bug fix
- [ ] New feature / enhancement
- [ ] Documentation update
- [ ] Tests / CI
- [ ] Performance improvement
- [ ] Refactor (no functional change)

---

## Changes made

Changes made in files: `context_compressor.py`, `test_context_compressor.py`

- made changes to make sure that the compressor to ensure the test passes with proper token counting and chronological ordering.

---

## How to test

<!-- Step-by-step instructions to verify this PR works correctly -->

1. `python -m pytest -q`
2. `python -m pytest daemon/tests/test_context_compressor.py::TestContextCompressor::test_compress_conversation_with_compression -q`

---

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My code follows the existing code style
- [x] I have added/updated tests where applicable
- [x] All existing tests pass (`pytest` for backend, `npm run test` for frontend)
- [ ] I have updated documentation if needed
- [x] I have tested on at least one platform (Windows / macOS / Linux)

---

## Screenshots / recordings (if UI change)

<img width="1610" height="145" alt="image" src="https://github.com/user-attachments/assets/a07b8a6f-94be-4b02-b266-bd3e7e999781" />


---

## GSSoC declaration

- [x] This contribution is made under the GSSoC 2026 program
- [x] I have not plagiarised code from other repositories
