### PR TITLE
Fix orchestrator TypeError by adding missing plan_id parameter

### DIFF
--- a/daemon/pilot/agents/orchestrator.py
+++ b/daemon/pilot/agents/orchestrator.py
@@ -157,7 +157,8 @@ class AgentOrchestrator:
         plan: ActionPlan,
         on_action_start: Callable | None = None,
         on_action_complete: Callable | None = None,
-        cancel_event: asyncio.Event | None = None,  # ← add this
+        cancel_event: asyncio.Event | None = None,
+        plan_id: str | None = None,
     ) -> list[ActionResult]:
         """Execute a plan by routing actions to specialist agents.
 


### PR DESCRIPTION
## Summary

This PR fixes a critical showstopper bug in the agent execution pipeline. The `AgentOrchestrator.execute_plan()` method was missing the `plan_id` parameter in its signature, which caused a `TypeError` crash whenever `server.py` attempted to pass it during complex multi-agent tasks.

---

## Type of change

- [x] Bug fix
- [ ] New feature / enhancement
- [ ] Documentation update
- [ ] Tests / CI
- [ ] Performance improvement
- [ ] Refactor (no functional change)

---

## Changes made

- **`daemon/pilot/agents/orchestrator.py`**: Added `plan_id: str | None = None` to the `execute_plan` method signature to match the caller's arguments in `server.py`.

---

## How to test

1. Start the Heliox OS backend daemon.
2. Issue a complex multi-agent command that triggers the orchestrator (e.g., `"Take a screenshot, describe it, and save the description to a text file on my desktop"`).
3. Verify that the task completes successfully without crashing with `TypeError: AgentOrchestrator.execute_plan() got an unexpected keyword argument 'plan_id'`.

---

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My code follows the existing code style
- [ ] I have added/updated tests where applicable
- [x] All existing tests pass (`pytest` for backend, `npm run test` for frontend)
- [ ] I have updated documentation if needed
- [x] I have tested on at least one platform (Windows / macOS / Linux)

---

## Screenshots / recordings (if UI change)

N/A (Backend fix only)

---

## GSSoC declaration

- [x] This contribution is made under the GSSoC 2026 program
- [x] I have not plagiarised code from other repositories
