### PR TITLE
Feat(daemon): Add WebAssembly action type and fix execution timeouts

### DIFF
--- a/daemon/pilot/actions.py
+++ b/daemon/pilot/actions.py
@@ -7,7 +7,7 @@ validated Action objects ΓÇö there is no path from raw LLM text to system cal
 from __future__ import annotations
 
 from enum import Enum, StrEnum
-from typing import Literal
+from typing import Any, Literal
 
 from pydantic import BaseModel, Field
 
@@ -223,6 +223,9 @@ class ActionType(StrEnum):
 
     # -- VLM zero-shot element detection --
     SCREEN_DETECT_ELEMENTS = "screen_detect_elements"
+
+    # -- WebAssembly Plugin execution --
+    WASM_CALL = "wasm_call"
 
 
 class PermissionTier(int, Enum):
@@ -719,6 +722,13 @@ class SshScriptParams(BaseModel):
     timeout_seconds: int = 300
 
 
+class WasmCallParams(BaseModel):
+    """Parameters for wasm_call action."""
+
+    tool: str = ""
+    args: dict[str, Any] = Field(default_factory=dict)
+
+
 class EmptyParams(BaseModel):
     """For actions that need no parameters."""
 
@@ -766,6 +776,7 @@ ActionParameters = (
     | SshCommandParams
     | SshScriptParams
     | ElementDetectionParams
+    | WasmCallParams
     | EmptyParams
 )
 
@@ -831,6 +842,7 @@ class Action(BaseModel):
             ActionType.API_REQUEST,
             ActionType.API_SCRAPE,
             ActionType.DOWNLOAD_FILE,
+            ActionType.WASM_CALL,
         }
         if self.action_type in ALWAYS_SAFE:
             return PermissionTier.USER_WRITE

--- a/daemon/pilot/agents/executor.py
+++ b/daemon/pilot/agents/executor.py
@@ -51,6 +51,7 @@ from pilot.actions import (
     SystemInfoParams,
     TriggerParams,
     VolumeParams,
+    WasmCallParams,
     WifiParams,
     WindowParams,
     WorkspaceParams,
@@ -82,9 +83,10 @@ class Executor:
         self._permissions = permissions
         self._audit = audit
         self._snapshot_mgr = SnapshotManager(config)
+        self._plugin_registry = None
         self._simulation_sandbox = SimulationSandbox(allowed_commands=config.restrictions.sandbox_allowed_commands)
-        self._last_output: str = ""  # For output chaining between steps
-        self._largest_output: str = ""  # Largest output from any step in the pipeline
+        self._last_output = ""  # For output chaining between steps
+        self._largest_output = ""  # Largest output from any step in the pipeline
 
         self._dispatch_table: dict[ActionType, callable] = {
             # -- File operations --
@@ -251,7 +253,11 @@ class Executor:
             ActionType.API_SCRAPE: self._exec_api_scrape,
             ActionType.WORKSPACE_INDEX: self._exec_workspace_index,
             ActionType.WORKSPACE_SEARCH: self._exec_workspace_search,
+            ActionType.WASM_CALL: self._exec_wasm_call,
         }
+
+    def set_plugin_registry(self, plugin_registry) -> None:
+        self._plugin_registry = plugin_registry
 
     def _analyze_dependencies(self, actions: list[Action]) -> list[list[Action]]:
         """Analyze action dependencies and return batches that can run in parallel.
@@ -1826,3 +1832,16 @@ class Executor:
             lines.append(r["text"])
             lines.append("---")
         return "\n".join(lines)
+
+    async def _exec_wasm_call(self, action: Action) -> str:
+        import json
+        params: WasmCallParams = action.parameters  # type: ignore[assignment]
+        tool_name = params.tool or action.target
+        if not tool_name:
+            raise ValueError("wasm_call requires a tool name (either in target or parameters)")
+        if self._plugin_registry is None:
+            raise RuntimeError("Plugin registry not initialized in Executor")
+        result = self._plugin_registry.call_wasm_tool(tool_name, params.args)
+        if "error" in result:
+            raise RuntimeError(f"WASM tool execution failed: {result['error']}")
+        return json.dumps(result)

--- a/daemon/pilot/plugins/wasm_runtime.py
+++ b/daemon/pilot/plugins/wasm_runtime.py
@@ -50,6 +50,7 @@ from __future__ import annotations
 import json
 import logging
 import struct
+import threading
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
@@ -162,6 +163,9 @@ class WasmPlugin:
                 f"WASM module is missing required exports (alloc/dealloc/call_tool/memory): {exc}"
             ) from exc
 
+        timer = threading.Timer(self._config.timeout_secs, self._engine.increment_epoch)
+        timer.daemon = True
+        timer.start()
         try:
             # 1. Allocate input buffer inside WASM linear memory.
             req_ptr = alloc_fn(store, req_len)
@@ -191,6 +195,8 @@ class WasmPlugin:
             raise
         except Exception as exc:
             raise WasmRuntimeError(f"WASM tool call trapped or failed: {exc}") from exc
+        finally:
+            timer.cancel()
 
         try:
             return json.loads(payload)

--- a/daemon/pilot/security/validator.py
+++ b/daemon/pilot/security/validator.py
@@ -29,6 +29,7 @@ from pilot.actions import (
     ShellScriptParams,
     SshCommandParams,
     SshScriptParams,
+    WasmCallParams,
 )
 from pilot.security.sanitizer import SanitizationError, Sanitizer
 
@@ -155,6 +156,7 @@ NO_TARGET_REQUIRED = {
     # SSH remote exec is parameter-driven (host alias)
     ActionType.SSH_COMMAND,
     ActionType.SSH_SCRIPT,
+    ActionType.WASM_CALL,
 }
 
 # File action types
@@ -251,6 +253,10 @@ class ActionValidator:
 
         elif isinstance(params, (OpenApplicationParams, NotifyParams)):
             pass
+
+        elif isinstance(params, WasmCallParams):
+            if not params.tool and not action.target:
+                raise ValidationError(idx, "WASM call requires a tool name")
 
     def _validate_root_requirement(self, action: Action, idx: int) -> None:
         if action.requires_root and not self._config.security.root_enabled:

--- a/daemon/pilot/server.py
+++ b/daemon/pilot/server.py
@@ -263,6 +263,7 @@ class PilotServer:
         self._plugin_registry = PluginRegistry()
         plugin_count = self._plugin_registry.discover()
         logger.info("Plugins loaded: %d", plugin_count)
+        self._executor.set_plugin_registry(self._plugin_registry)
 
         # Subconscious Agent — long-term memory consolidation (lazy start)
         try:

--- a/daemon/tests/test_wasm_plugin.py
+++ b/daemon/tests/test_wasm_plugin.py
@@ -357,3 +357,157 @@ def test_get_stats_includes_wasm_count():
     stats = registry.get_stats()
     assert "wasm_plugins" in stats
     assert stats["wasm_plugins"] == 0
+
+
+def test_wasm_plugin_timeout(tmp_path: Path):
+    """Verify that a loop-heavy WAT module times out and raises WasmRuntimeError."""
+    try:
+        import wasmtime  # noqa: F401
+    except ImportError:
+        pytest.skip("wasmtime not installed")
+
+    looping_wat = """
+    (module
+      (memory (export "memory") 2)
+      (func (export "alloc") (param $size i32) (result i32)
+        (i32.const 16)
+      )
+      (func (export "dealloc") (param $ptr i32) (param $size i32))
+      (func (export "call_tool") (param $ptr i32) (param $len i32) (result i32)
+        (loop $infinite
+          (br $infinite)
+        )
+        (i32.const 0)
+      )
+    )
+    """
+    wasm_path = tmp_path / "timeout_plugin.wasm"
+    wasm_path.write_bytes(looping_wat.strip().encode())
+
+    # Configure a short timeout (e.g. 0.1 seconds)
+    config = WasmConfig(timeout_secs=0.1)
+    with WasmPlugin(wasm_path, config) as plugin, pytest.raises(WasmRuntimeError, match="trapped or failed"):
+        plugin.call_tool("any_tool", {})
+
+
+async def test_wasm_executor_integration(default_config, tmp_path: Path):
+    """Verify that ActionType.WASM_CALL is correctly routed by Executor to PluginRegistry."""
+    from pilot.actions import Action, ActionPlan, ActionType, WasmCallParams
+    from pilot.agents.executor import Executor
+    from pilot.security.audit import AuditLogger
+    from pilot.security.permissions import PermissionChecker
+    from pilot.security.validator import ActionValidator
+
+    # Set up executor
+    validator = ActionValidator(default_config)
+    permissions = PermissionChecker(default_config)
+    audit = AuditLogger(audit_file=tmp_path / "audit.log")
+    executor = Executor(default_config, validator, permissions, audit)
+
+    # Mock plugin registry
+    mock_registry = MagicMock()
+    mock_registry.call_wasm_tool.return_value = {"status": "success", "result": 123}
+    executor.set_plugin_registry(mock_registry)
+
+    # 1. Success case
+    plan = ActionPlan(
+        actions=[
+            Action(
+                action_type=ActionType.WASM_CALL,
+                target="my_wasm_tool",
+                parameters=WasmCallParams(tool="my_wasm_tool", args={"x": 42}),
+            )
+        ]
+    )
+
+    results = await executor.execute(plan)
+    assert len(results) == 1
+    assert results[0].success is True
+    assert json.loads(results[0].output) == {"status": "success", "result": 123}
+    mock_registry.call_wasm_tool.assert_called_once_with("my_wasm_tool", {"x": 42})
+
+    # 2. Failure case (registry returns error)
+    mock_registry.reset_mock()
+    mock_registry.call_wasm_tool.return_value = {"error": "Some WASM trap/panic"}
+
+    results = await executor.execute(plan)
+    assert len(results) == 1
+    assert results[0].success is False
+    assert "WASM tool execution failed: Some WASM trap/panic" in results[0].error
+    mock_registry.call_wasm_tool.assert_called_once_with("my_wasm_tool", {"x": 42})
+
+
+async def test_wasm_executor_integration_uninitialized(default_config, tmp_path: Path):
+    """Verify that Executor raises RuntimeError if PluginRegistry is not set."""
+    from pilot.actions import Action, ActionPlan, ActionType, WasmCallParams
+    from pilot.agents.executor import Executor
+    from pilot.security.audit import AuditLogger
+    from pilot.security.permissions import PermissionChecker
+    from pilot.security.validator import ActionValidator
+
+    validator = ActionValidator(default_config)
+    permissions = PermissionChecker(default_config)
+    audit = AuditLogger(audit_file=tmp_path / "audit.log")
+    executor = Executor(default_config, validator, permissions, audit)
+    # do NOT set plugin registry
+
+    plan = ActionPlan(
+        actions=[
+            Action(
+                action_type=ActionType.WASM_CALL,
+                target="my_wasm_tool",
+                parameters=WasmCallParams(tool="my_wasm_tool", args={"x": 42}),
+            )
+        ]
+    )
+
+    results = await executor.execute(plan)
+    assert len(results) == 1
+    assert results[0].success is False
+    assert "Plugin registry not initialized in Executor" in results[0].error
+
+
+def test_wasm_validator_checks(default_config):
+    """Verify that ActionValidator rejects WASM call actions without a tool name."""
+    from pilot.actions import Action, ActionPlan, ActionType, WasmCallParams
+    from pilot.security.validator import ActionValidator
+
+    validator = ActionValidator(default_config)
+
+    # 1. Invalid: both empty
+    plan_invalid = ActionPlan(
+        actions=[
+            Action(
+                action_type=ActionType.WASM_CALL,
+                target="",
+                parameters=WasmCallParams(tool="", args={}),
+            )
+        ]
+    )
+    errors = validator.validate_plan(plan_invalid)
+    assert any("WASM call requires a tool name" in e for e in errors)
+
+    # 2. Valid: target provided
+    plan_target = ActionPlan(
+        actions=[
+            Action(
+                action_type=ActionType.WASM_CALL,
+                target="my_tool",
+                parameters=WasmCallParams(tool="", args={}),
+            )
+        ]
+    )
+    assert len(validator.validate_plan(plan_target)) == 0
+
+    # 3. Valid: parameters.tool provided
+    plan_param = ActionPlan(
+        actions=[
+            Action(
+                action_type=ActionType.WASM_CALL,
+                target="",
+                parameters=WasmCallParams(tool="my_tool", args={}),
+            )
+        ]
+    )
+    assert len(validator.validate_plan(plan_param)) == 0
+


### PR DESCRIPTION
## Description
This PR integrates the WebAssembly (`wasm_call`) action execution runtime into the Heliox OS Daemon.

- Registers the `wasm_call` action type, configuration parameters, and maps its permission level.
- Routes `wasm_call` actions inside the `Executor` dispatch table to the `PluginRegistry`.
- Fixes the epoch-interruption deadline bug in `wasm_runtime.py` by launching a daemonized `threading.Timer` thread to increment the engine's epoch counter on timeout, and guarantees cleanup inside a `finally` block.
- Adjusts target requirements in the validator to bypass the target field checks when `parameters.tool` is provided, ensuring that a tool name is supplied.
- Adds unit and integration tests covering the new validation logic, executor integration, and infinite-loop timeout constraints.

### Closes #166 