### PR TITLE
fix : added deallocation of WASM result buffer to prevent memory leak

### DIFF
--- a/daemon/pilot/plugins/wasm_runtime.py
+++ b/daemon/pilot/plugins/wasm_runtime.py
@@ -188,8 +188,9 @@ class WasmPlugin:
                 raise WasmRuntimeError(f"WASM module payload length {payload_len} exceeds linear memory bounds")
             payload = bytes(data[result_ptr + 4 + i] for i in range(payload_len))
 
-            # 5. Free the input buffer (best-effort; module owns result buffer).
+            # 5. Free both the input and output buffers to prevent linear memory leaks.
             dealloc_fn(store, req_ptr, req_len)
+            dealloc_fn(store, result_ptr, 4 + payload_len)
 
         except WasmRuntimeError:
             raise


### PR DESCRIPTION
Closes #301.

Summary of What Has Been Done:
Added a call to dealloc_fn(store, result_ptr, 4 + payload_len) in WasmPlugin.call_tool() immediately after reading the JSON response payload from WASM linear memory, ensuring the result buffer allocated by the WASM module is properly freed.

Changes Made:
- In call_tool(), after reading the payload, added dealloc_fn(store, result_ptr, 4 + payload_len) to free the result buffer
- Updated comment to reflect that both input and output buffers are now freed

Impact it Made:
Prevents linear memory leaks in long-running daemon workloads where WASM tool calls would progressively consume memory by never freeing result buffers.