### PR TITLE
fix : added Path.resolve() and parent boundary checks for directory protection

### DIFF
--- a/daemon/pilot/security/validator.py
+++ b/daemon/pilot/security/validator.py
@@ -9,6 +9,7 @@ Updated for the expanded action set with cross-platform support.
 from __future__ import annotations
 
 import logging
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from pilot.actions import (
@@ -280,10 +281,11 @@ class ActionValidator:
         restrictions = self._config.restrictions
 
         if isinstance(action.parameters, (FileParams, GitResolveParams)):
-            path_str = action.parameters.path
+            path_obj = Path(action.parameters.path).resolve()
             for protected in restrictions.protected_folders:
-                if path_str.startswith(protected):
-                    raise ValidationError(idx, f"Path {path_str} is in protected folder {protected}")
+                protected_obj = Path(protected).resolve()
+                if protected_obj == path_obj or protected_obj in path_obj.parents:
+                    raise ValidationError(idx, f"Path {action.parameters.path} resolves inside protected folder {protected}")
 
         if isinstance(action.parameters, PackageParams) and action.action_type == ActionType.PACKAGE_REMOVE:
             if action.parameters.name in restrictions.protected_packages:


### PR DESCRIPTION
Closes #302.

Summary of What Has Been Done:
Refactored _validate_restrictions in ActionValidator to use Path.resolve() for canonicalizing paths and exact parent-child relationship checks instead of insecure startswith substring matching.

Changes Made:
- Added from pathlib import Path
- Changed path validation to resolve paths using Path.resolve() before checking
- Used protected_obj == path_obj or protected_obj in path_obj.parents for exact boundary checking
- Updated error message to reference the original path parameter

Impact it Made:
Prevents security bypasses via path traversal (/etc/./passwd), trailing slashes (/etc vs /etc/), and symlinks, ensuring protected folder restrictions actually protect sensitive directories.