### PR TITLE
fix: remove os from eval() namespace in _check_custom() to prevent RCE

### DIFF
--- a/daemon/pilot/system/triggers.py
+++ b/daemon/pilot/system/triggers.py
@@ -297,7 +297,7 @@ class TriggerEngine:
             psutil = None
 
         try:
-            result = eval(expr, {"__builtins__": {}, "psutil": psutil, "os": os, "time": time})
+            result = eval(expr, {"__builtins__": {}, "psutil": psutil, "time": time})
             return bool(result)
         except Exception as e:
             logger.warning("Custom condition eval error: %s", e)


### PR DESCRIPTION
## Summary

Removes `os` from the `eval()` namespace in `_check_custom()` to prevent arbitrary code execution via malicious trigger conditions (CWE-94).

Closes #274

---

## Type of change

- [x] Bug fix
- [ ] New feature / enhancement
- [ ] Documentation update
- [ ] Tests / CI
- [ ] Performance improvement
- [ ] Refactor (no functional change)

---

## Changes made

- `daemon/pilot/system/triggers.py:300` — Removed `os` from the `eval()` globals dict. The expression now only receives `psutil` and `time` in its namespace.

---

## How to test

1. Start the daemon and connect to its WebSocket
2. Send a `trigger_create` with `trigger_type: "custom_condition"` and `condition.expression` set to `os.system('calc.exe') or True`
3. Observe the expression is rejected / fails safely (no calculator opens, trigger returns `False` with a warning log)
4. Send a benign expression like `psutil.cpu_percent() > 80` — it still evaluates normally

---

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My code follows the existing code style
- [x] I have added/updated tests where applicable
- [x] All existing tests pass (`pytest` for backend, `npm run test` for frontend)
- [x] I have updated documentation if needed
- [x] I have tested on at least one platform (Windows / macOS / Linux)

---

## GSSoC declaration

- [x] This contribution is made under the GSSoC 2026 program
- [x] I have not plagiarised code from other repositories