### PR TITLE
fix: extend _get_machine_id() to macOS and Windows (#267)

### DIFF
--- a/daemon/pilot/security/vault.py
+++ b/daemon/pilot/security/vault.py
@@ -218,10 +218,65 @@ class KeyVault:
 
     @staticmethod
     def _get_machine_id() -> str:
-        """Read machine-id as a stable per-machine secret."""
+        """Read a stable per-machine identifier used as the KDF passphrase.
+
+        Tries platform-specific sources in order of preference:
+          - Linux: /etc/machine-id or /var/lib/dbus/machine-id
+          - macOS: IOPlatformUUID from ioreg
+          - Windows: MachineGuid from the Cryptography registry key
+
+        Falls back to a hardcoded constant only when no platform source
+        is reachable. The fallback weakens machine-binding (any attacker
+        who obtains the vault file can attempt decryption with the known
+        constant), so users on platforms where the fallback is hit should
+        prefer the system-keyring backend instead.
+        """
+        import platform
+        import subprocess
+
+        # Linux: standard machine-id files written by systemd / D-Bus.
         for path in ("/etc/machine-id", "/var/lib/dbus/machine-id"):
             try:
-                return Path(path).read_text().strip()
+                value = Path(path).read_text().strip()
+                if value:
+                    return value
             except OSError:
                 continue
+
+        system = platform.system()
+
+        # macOS: IOPlatformUUID is stable across reboots and unique per device.
+        if system == "Darwin":
+            try:
+                result = subprocess.run(
+                    ["ioreg", "-rd1", "-c", "IOPlatformExpertDevice"],
+                    capture_output=True,
+                    text=True,
+                    timeout=5,
+                )
+                for line in result.stdout.splitlines():
+                    if "IOPlatformUUID" in line:
+                        parts = line.split('"')
+                        if len(parts) >= 2:
+                            uuid = parts[-2].strip()
+                            if uuid:
+                                return uuid
+            except Exception:
+                pass
+
+        # Windows: MachineGuid written by Windows Setup; unique per installation.
+        if system == "Windows":
+            try:
+                import winreg  # available only on Windows
+
+                with winreg.OpenKey(
+                    winreg.HKEY_LOCAL_MACHINE,
+                    r"SOFTWARE\Microsoft\Cryptography",
+                ) as key:
+                    guid, _ = winreg.QueryValueEx(key, "MachineGuid")
+                    if guid:
+                        return str(guid)
+            except Exception:
+                pass
+
         return "pilot-fallback-id"

--- a/daemon/tests/test_vault_machine_id.py
+++ b/daemon/tests/test_vault_machine_id.py
@@ -1,0 +1,187 @@
+"""Tests for KeyVault._get_machine_id() cross-platform behaviour.
+
+Verifies that the correct platform-specific source is used on each OS and
+that the hardcoded fallback is only reached when every source fails.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import types
+from unittest.mock import MagicMock, patch
+
+from pilot.security.vault import KeyVault
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _linux_path_raises(self, *args, **kwargs):  # noqa: ANN001
+    raise OSError("linux paths not present")
+
+
+def _make_ioreg_output(uuid: str) -> str:
+    return '  "IOPlatformUUID" = "' + uuid + '"\n  "IOPlatformSerialNumber" = "X12345678"\n'
+
+
+def _make_winreg_mock(guid: str) -> types.ModuleType:
+    """Build a minimal winreg stub that returns the given GUID."""
+    winreg = types.ModuleType("winreg")
+    winreg.HKEY_LOCAL_MACHINE = 0x80000002
+
+    mock_key = MagicMock()
+    mock_key.__enter__ = MagicMock(return_value=mock_key)
+    mock_key.__exit__ = MagicMock(return_value=False)
+
+    winreg.OpenKey = MagicMock(return_value=mock_key)
+    winreg.QueryValueEx = MagicMock(return_value=(guid, 1))
+    return winreg
+
+
+# ---------------------------------------------------------------------------
+# Linux
+# ---------------------------------------------------------------------------
+
+
+def test_machine_id_linux_primary():
+    """Returns the content of /etc/machine-id when the file is present."""
+
+    def fake_read_text(self, *args, **kwargs):  # noqa: ANN001
+        if str(self) in ("/etc/machine-id", "/var/lib/dbus/machine-id"):
+            return "abc123linux\n"
+        raise OSError("not found")
+
+    with patch("pilot.security.vault.Path.read_text", fake_read_text):
+        result = KeyVault._get_machine_id()
+
+    assert result == "abc123linux"
+
+
+def test_machine_id_linux_fallback_to_dbus():
+    """/var/lib/dbus/machine-id is used when /etc/machine-id is absent."""
+
+    def fake_read_text(self, *args, **kwargs):  # noqa: ANN001
+        if str(self) == "/etc/machine-id":
+            raise OSError("no such file")
+        if str(self) == "/var/lib/dbus/machine-id":
+            return "dbus999\n"
+        raise OSError("not found")
+
+    with patch("pilot.security.vault.Path.read_text", fake_read_text):
+        result = KeyVault._get_machine_id()
+
+    assert result == "dbus999"
+
+
+# ---------------------------------------------------------------------------
+# macOS
+# ---------------------------------------------------------------------------
+
+
+def test_machine_id_macos(monkeypatch):
+    """IOPlatformUUID is extracted from ioreg output on Darwin."""
+    expected = "AABBCCDD-1122-3344-5566-778899AABBCC"
+
+    monkeypatch.setattr("pilot.security.vault.Path.read_text", _linux_path_raises)
+
+    completed = subprocess.CompletedProcess(
+        args=["ioreg"],
+        returncode=0,
+        stdout=_make_ioreg_output(expected),
+        stderr="",
+    )
+
+    with patch("platform.system", return_value="Darwin"), patch("subprocess.run", return_value=completed):
+        result = KeyVault._get_machine_id()
+
+    assert result == expected
+
+
+def test_machine_id_macos_ioreg_timeout(monkeypatch):
+    """Falls back to hardcoded constant when ioreg times out on Darwin."""
+    monkeypatch.setattr("pilot.security.vault.Path.read_text", _linux_path_raises)
+
+    with (
+        patch("platform.system", return_value="Darwin"),
+        patch("subprocess.run", side_effect=subprocess.TimeoutExpired(cmd="ioreg", timeout=5)),
+    ):
+        result = KeyVault._get_machine_id()
+
+    assert result == "pilot-fallback-id"
+
+
+def test_machine_id_macos_ioreg_missing_uuid(monkeypatch):
+    """Falls back when ioreg output contains no IOPlatformUUID line."""
+    monkeypatch.setattr("pilot.security.vault.Path.read_text", _linux_path_raises)
+
+    completed = subprocess.CompletedProcess(
+        args=["ioreg"],
+        returncode=0,
+        stdout="no uuid here\n",
+        stderr="",
+    )
+
+    with patch("platform.system", return_value="Darwin"), patch("subprocess.run", return_value=completed):
+        result = KeyVault._get_machine_id()
+
+    assert result == "pilot-fallback-id"
+
+
+# ---------------------------------------------------------------------------
+# Windows
+# ---------------------------------------------------------------------------
+
+
+def test_machine_id_windows(monkeypatch):
+    """MachineGuid is read from the registry on Windows."""
+    expected = "11223344-aabb-ccdd-eeff-001122334455"
+
+    monkeypatch.setattr("pilot.security.vault.Path.read_text", _linux_path_raises)
+
+    winreg_stub = _make_winreg_mock(expected)
+
+    with patch("platform.system", return_value="Windows"), patch.dict("sys.modules", {"winreg": winreg_stub}):
+        result = KeyVault._get_machine_id()
+
+    assert result == expected
+
+
+def test_machine_id_windows_registry_error(monkeypatch):
+    """Falls back to hardcoded constant when the registry key is inaccessible."""
+    monkeypatch.setattr("pilot.security.vault.Path.read_text", _linux_path_raises)
+
+    winreg_stub = types.ModuleType("winreg")
+    winreg_stub.HKEY_LOCAL_MACHINE = 0x80000002
+    winreg_stub.OpenKey = MagicMock(side_effect=OSError("access denied"))
+
+    with patch("platform.system", return_value="Windows"), patch.dict("sys.modules", {"winreg": winreg_stub}):
+        result = KeyVault._get_machine_id()
+
+    assert result == "pilot-fallback-id"
+
+
+# ---------------------------------------------------------------------------
+# Fallback
+# ---------------------------------------------------------------------------
+
+
+def test_machine_id_fallback_unknown_platform(monkeypatch):
+    """Returns the hardcoded fallback on an unrecognised platform."""
+    monkeypatch.setattr("pilot.security.vault.Path.read_text", _linux_path_raises)
+
+    with patch("platform.system", return_value="FreeBSD"):
+        result = KeyVault._get_machine_id()
+
+    assert result == "pilot-fallback-id"
+
+
+def test_machine_id_never_returns_empty(monkeypatch):
+    """The returned value is always a non-empty string."""
+    monkeypatch.setattr("pilot.security.vault.Path.read_text", _linux_path_raises)
+
+    with patch("platform.system", return_value="FreeBSD"):
+        result = KeyVault._get_machine_id()
+
+    assert isinstance(result, str)
+    assert len(result) > 0


### PR DESCRIPTION
Fixes #267

## Problem

`KeyVault._get_machine_id()` only checked two Linux-specific paths. On macOS and Windows it always returned the hardcoded constant `"pilot-fallback-id"`. Because this string is publicly known, an attacker who obtains `vault.enc` from any macOS or Windows user can decrypt it offline without any knowledge of the victim's machine -- completely defeating the machine-binding property of the encrypted file vault on two of the three supported platforms.

## Fix

Added platform-specific branches for macOS and Windows, matching the approach described in the issue:

**macOS** -- reads `IOPlatformUUID` from `ioreg -rd1 -c IOPlatformExpertDevice`. This value is stable across reboots and unique per physical device. The subprocess call has a 5-second timeout; any failure (command not found, parse error, empty output) falls through silently.

**Windows** -- reads `MachineGuid` from `HKLM\SOFTWARE\Microsoft\Cryptography` using `winreg` (standard library on Windows only, imported inside the conditional block). This GUID is written by Windows Setup and is unique per OS installation. Any registry access error falls through silently.

**Linux** -- unchanged. The existing `/etc/machine-id` and `/var/lib/dbus/machine-id` paths are still checked first on every platform before the `platform.system()` branch runs, so existing Linux vault files are unaffected.

**Fallback** -- the `"pilot-fallback-id"` constant is retained for platforms where no source is reachable. The docstring now notes that users in this situation should prefer the system-keyring backend.

## Changes

| File | Change |
|------|--------|
| `daemon/pilot/security/vault.py` | Extended `_get_machine_id()` with macOS and Windows branches |
| `daemon/tests/test_vault_machine_id.py` | New test module with 9 tests covering all branches |
| `.gitignore` | Added `!daemon/tests/test_vault_machine_id.py` exception (same pattern as other committed test files) |

## Tests

```
PASSED tests/test_vault_machine_id.py::test_machine_id_linux_primary
PASSED tests/test_vault_machine_id.py::test_machine_id_linux_fallback_to_dbus
PASSED tests/test_vault_machine_id.py::test_machine_id_macos
PASSED tests/test_vault_machine_id.py::test_machine_id_macos_ioreg_timeout
PASSED tests/test_vault_machine_id.py::test_machine_id_macos_ioreg_missing_uuid
PASSED tests/test_vault_machine_id.py::test_machine_id_windows
PASSED tests/test_vault_machine_id.py::test_machine_id_windows_registry_error
PASSED tests/test_vault_machine_id.py::test_machine_id_fallback_unknown_platform
PASSED tests/test_vault_machine_id.py::test_machine_id_never_returns_empty

9 passed in 0.02s
```

Ruff lint passes with zero errors on both changed files.