### PR TITLE
fix(tests): use write_bytes for deterministic file sizes in directory summary test

### DIFF
--- a/daemon/tests/test_directory_summary.py
+++ b/daemon/tests/test_directory_summary.py
@@ -10,13 +10,16 @@ from pilot.system.filesystem import directory_summary
 @pytest.mark.asyncio
 async def test_directory_summary_includes_tree_and_file_sizes(tmp_path):
     (tmp_path / "src").mkdir()
-    (tmp_path / "src" / "main.py").write_text("print('hello')\n", encoding="utf-8")
-    (tmp_path / "README.md").write_text("Project readme", encoding="utf-8")
+    # Use write_bytes to guarantee a deterministic on-disk size across all platforms.
+    # write_text in text mode converts \n to \r\n on Windows, making the file 16 B
+    # there but 15 B on macOS and Linux, causing the assertion to fail on Unix systems.
+    (tmp_path / "src" / "main.py").write_bytes(b"print('hello')\n")
+    (tmp_path / "README.md").write_bytes(b"Project readme")
 
     summary = await directory_summary(str(tmp_path))
 
     assert "src/" in summary
-    assert "main.py (16 B)" in summary
+    assert "main.py (15 B)" in summary
     assert "README.md (14 B)" in summary
 
 


### PR DESCRIPTION
Fixes #283

## Root cause

`test_directory_summary_includes_tree_and_file_sizes` called `write_text("print('hello')\n", encoding="utf-8")` to create `main.py`. Python's `write_text` opens the file in text mode, which on Windows silently translates every `\n` to `\r\n`. This made the file 16 bytes on Windows but 15 bytes on macOS and Linux, so the assertion `'main.py (16 B)'` failed on every non-Windows platform.

`directory_summary` reports size via `os.stat().st_size`, which reflects the actual bytes on disk, so the mismatch was between the test's hardcoded expected size and the real file size.

## Fix

Replace `write_text` with `write_bytes` and use explicit byte literals. `write_bytes` never applies line-ending translation, guaranteeing identical on-disk size on all platforms:

```python
# Before
(tmp_path / "src" / "main.py").write_text("print('hello')\n", encoding="utf-8")
assert "main.py (16 B)" in summary   # passes on Windows, fails on macOS/Linux

# After
(tmp_path / "src" / "main.py").write_bytes(b"print('hello')\n")
assert "main.py (15 B)" in summary   # passes on all platforms
```

`README.md` is switched to `write_bytes` as well for consistency (no assertion change needed there since `"Project readme"` has no newline and was already 14 B everywhere).

## Verification

```
len(b"print('hello')\n")  # 15
len(b"Project readme")     # 14
```

Both match the updated assertions. The other two tests in the file are unaffected.

Could you please add the appropriate labels to this PR when you get a chance? It would really help with tracking the contribution. Thank you!