### PR TITLE
Bug fix: consolidate config/data directory paths across all modules

### DIFF
--- a/daemon/pilot/agents/code_agent.py
+++ b/daemon/pilot/agents/code_agent.py
@@ -48,7 +48,7 @@ class CodeAgent(BaseAgent):
             ),
             AgentCapability(
                 action_type=ActionType.SKILL_RUN,
-                description="Run a Python skill from ~/.config/pilot/skills (skill_id + arguments)",
+                description="Run a Python skill from the config skills directory (skill_id + arguments)",
             ),
             AgentCapability(
                 action_type=ActionType.SHELL_COMMAND,

--- a/daemon/pilot/agents/screen_vision.py
+++ b/daemon/pilot/agents/screen_vision.py
@@ -33,6 +33,8 @@ from io import BytesIO
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from pilot.config import SCREENSHOTS_DIR
+
 if TYPE_CHECKING:
     from pilot.models.router import ModelRouter
 
@@ -135,7 +137,7 @@ class ScreenVisionAgent:
         self._running = False
         self._interval_seconds: float = 3.0
         self._last_hash: str = ""
-        self._screenshot_dir = Path.home() / ".heliox" / "screenshots"
+        self._screenshot_dir = SCREENSHOTS_DIR
         self._enable_llm_describe = False  # Disabled by default (expensive)
 
     def set_interval(self, interval_seconds: float) -> None:

--- a/daemon/pilot/agents/subconscious.py
+++ b/daemon/pilot/agents/subconscious.py
@@ -9,7 +9,7 @@ Architecture:
   2. Clustering:    Groups recent actions by category (file, code, web, media)
   3. Preference:    Extracts user habits ("always uses Python 3.11", "prefers dark mode")
   4. Rule Writing:  Generates system-prompt rules from patterns
-  5. Persona:       Maintains a ~/.heliox/persona.md that is injected into planner context
+   5. Persona:       Maintains a persona.md (in DATA_DIR) that is injected into planner context
 
 Schema (in pilot.db):
   user_persona:
@@ -32,6 +32,8 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 import aiosqlite
+
+from pilot.config import PERSONA_FILE
 
 if TYPE_CHECKING:
     from pilot.models.router import ModelRouter
@@ -108,8 +110,6 @@ Rules should be:
 
 Categories: preference, habit, constraint, style
 """
-
-PERSONA_FILE = Path.home() / ".heliox" / "persona.md"
 
 
 class SubconsciousAgent:

--- a/daemon/pilot/config.py
+++ b/daemon/pilot/config.py
@@ -43,10 +43,12 @@ def _default_runtime_dir() -> Path:
     return Path(tmp) / f"pilot-runtime-{uid}"
 
 
-CONFIG_DIR = _xdg("XDG_CONFIG_HOME", ".config") / "pilot"
-DATA_DIR = _xdg("XDG_DATA_HOME", ".local/share") / "pilot"
-STATE_DIR = _xdg("XDG_STATE_HOME", ".local/state") / "pilot"
-RUNTIME_DIR = _default_runtime_dir()
+CONFIG_DIR = _xdg("XDG_CONFIG_HOME", ".config") / "heliox-os"
+DATA_DIR = _xdg("XDG_DATA_HOME", ".local/share") / "heliox-os"
+STATE_DIR = _xdg("XDG_STATE_HOME", ".local/state") / "heliox-os"
+RUNTIME_DIR = (
+    Path(os.environ.get("XDG_RUNTIME_DIR", f"/run/user/{os.getuid() if hasattr(os, 'getuid') else 1000}")) / "heliox-os"
+)
 CONFIG_FILE = CONFIG_DIR / "config.toml"
 RESTRICTIONS_FILE = CONFIG_DIR / "restrictions.toml"
 DB_FILE = DATA_DIR / "pilot.db"
@@ -54,6 +56,11 @@ AUDIT_FILE = DATA_DIR / "audit.jsonl"
 PERMISSION_AUDIT_DB_FILE = DATA_DIR / "permission_audit.db"
 PERMISSION_AUDIT_KEY_FILE = DATA_DIR / "permission_audit.key"
 LOG_FILE = STATE_DIR / "pilot.log"
+
+# Derived directories shared across modules — use these instead of hardcoded paths
+PLUGINS_DIR = CONFIG_DIR / "plugins"
+SCREENSHOTS_DIR = DATA_DIR / "screenshots"
+PERSONA_FILE = DATA_DIR / "persona.md"
 
 
 @dataclass
@@ -501,7 +508,7 @@ def _config_to_dict(config: PilotConfig) -> dict[str, Any]:
 
 def ensure_dirs() -> None:
     """Create all required XDG directories and validate write access."""
-    for d in (CONFIG_DIR, DATA_DIR, STATE_DIR, RUNTIME_DIR):
+    for d in (CONFIG_DIR, DATA_DIR, STATE_DIR, RUNTIME_DIR, PLUGINS_DIR, SCREENSHOTS_DIR):
         d.mkdir(parents=True, exist_ok=True)
 
     test_file = DATA_DIR / ".write_test"
@@ -512,3 +519,51 @@ def ensure_dirs() -> None:
     except Exception as e:
         logger.error(f"DATA_DIR is not writable: {DATA_DIR}")
         raise RuntimeError(f"DATA_DIR is not writable: {DATA_DIR}") from e
+
+
+def migrate_old_paths() -> None:
+    """Migrate data from old hardcoded path conventions to the new canonical layout.
+
+    Old paths migrated:
+      ~/.heliox/plugins/       → PLUGINS_DIR
+      ~/.heliox/screenshots/   → SCREENSHOTS_DIR
+      ~/.heliox/persona.md     → PERSONA_FILE
+      ~/.config/pilot/         → CONFIG_DIR (config only, non-destructive)
+    """
+    home = Path.home()
+    old_pairs: list[tuple[Path, Path]] = []
+
+    old_heliox_plugins = home / ".heliox" / "plugins"
+    if old_heliox_plugins.exists() and old_heliox_plugins.is_dir():
+        old_pairs.append((old_heliox_plugins, PLUGINS_DIR))
+
+    old_heliox_screenshots = home / ".heliox" / "screenshots"
+    if old_heliox_screenshots.exists() and old_heliox_screenshots.is_dir():
+        old_pairs.append((old_heliox_screenshots, SCREENSHOTS_DIR))
+
+    old_persona = home / ".heliox" / "persona.md"
+    if old_persona.exists() and old_persona.is_file():
+        old_pairs.append((old_persona, PERSONA_FILE))
+
+    old_config_pilot = home / ".config" / "pilot"
+    if old_config_pilot.exists() and old_config_pilot.is_dir():
+        old_pairs.append((old_config_pilot, CONFIG_DIR))
+
+    for src, dst in old_pairs:
+        if dst.exists():
+            logger.info("Migration: skipping %s → %s (destination already exists)", src, dst)
+            continue
+        try:
+            dst.parent.mkdir(parents=True, exist_ok=True)
+            if src.is_file():
+                src.rename(dst)
+            else:
+                dst.mkdir(parents=True, exist_ok=True)
+                for item in src.iterdir():
+                    target = dst / item.name
+                    if not target.exists():
+                        item.rename(target)
+                src.rmdir()
+            logger.info("Migration: moved %s → %s", src, dst)
+        except OSError as exc:
+            logger.warning("Migration: could not move %s → %s: %s", src, dst, exc)

--- a/daemon/pilot/export_logs.py
+++ b/daemon/pilot/export_logs.py
@@ -7,6 +7,8 @@ import zipfile
 from datetime import datetime
 from pathlib import Path
 
+from pilot.config import CONFIG_FILE, LOG_FILE, STATE_DIR
+
 
 def _redact_config(config_text: str) -> str:
     """Redact API keys and secrets from config before including in zip."""
@@ -25,8 +27,8 @@ def export_logs() -> Path:
     desktop.mkdir(parents=True, exist_ok=True)
     zip_path = desktop / f"heliox_bugreport_{timestamp}.zip"
 
-    log_dir = Path.home() / ".local" / "share" / "heliox" / "logs"
-    config_file = Path.home() / ".config" / "pilot" / "config.toml"
+    log_dir = STATE_DIR
+    config_file = CONFIG_FILE
 
     files_added = 0
 

--- a/daemon/pilot/network/skill_sync.py
+++ b/daemon/pilot/network/skill_sync.py
@@ -2,7 +2,7 @@
 
 When a plugin is loaded locally it is broadcast to all connected peers.
 When a peer sends a plugin payload it is validated and installed into
-``~/.config/heliox-os/plugins/`` via the existing ``PluginManager``.
+``PLUGINS_DIR`` (from ``pilot.config``) via the existing ``PluginManager``.
 
 Security model
 --------------
@@ -24,6 +24,8 @@ import re
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from pilot.config import PLUGINS_DIR
+
 if TYPE_CHECKING:
     from pilot.network.mesh import HelioxMesh
 
@@ -40,12 +42,12 @@ class SkillSync:
     mesh:
         The ``HelioxMesh`` instance used to broadcast to peers.
     plugin_base_dir:
-        Base directory for plugins (default: ``~/.config/heliox-os/plugins``).
+        Base directory for plugins (default: ``PLUGINS_DIR`` from ``pilot.config``).
     """
 
     def __init__(self, mesh: HelioxMesh, plugin_base_dir: str | None = None) -> None:
         self._mesh = mesh
-        base = Path(plugin_base_dir or Path.home() / ".config" / "heliox-os" / "plugins")
+        base = Path(plugin_base_dir or PLUGINS_DIR)
         self._peer_dir = base / _PEER_PLUGIN_SUBDIR
         self._peer_dir.mkdir(parents=True, exist_ok=True)
 

--- a/daemon/pilot/plugins/__init__.py
+++ b/daemon/pilot/plugins/__init__.py
@@ -45,7 +45,7 @@ WASM plugin manifest (JSON):
 }
 
 Plugin directory structure:
-  ~/.heliox/plugins/
+  ~/.config/heliox-os/plugins/
     docker-agent/
       manifest.json
       plugin.ed25519.pub
@@ -80,6 +80,8 @@ from typing import Any
 from cryptography.exceptions import InvalidSignature
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+
+from pilot.config import PLUGINS_DIR
 
 logger = logging.getLogger("pilot.plugins")
 
@@ -246,8 +248,8 @@ class PluginRegistry:
     """Discovers, loads, and manages Heliox OS plugins.
 
     Plugins are discovered from:
-      1. ~/.heliox/plugins/     (user plugins)
-      2. <data_dir>/plugins/    (system plugins)
+      1. <config_dir>/plugins/     (user plugins, from PLUGINS_DIR)
+      2. <data_dir>/plugins/       (system plugins)
 
     Both Python and WASM plugins are supported. WASM plugins require the
     optional `wasmtime` package (pip install pilot-daemon[wasm]).
@@ -268,9 +270,8 @@ class PluginRegistry:
         self._wasm_plugins: dict[str, Any] = {}  # name -> WasmPlugin
 
         # Add default plugin directories
-        home_plugins = Path.home() / ".heliox" / "plugins"
-        if home_plugins not in self._plugin_dirs:
-            self._plugin_dirs.insert(0, home_plugins)
+        if PLUGINS_DIR not in self._plugin_dirs:
+            self._plugin_dirs.insert(0, PLUGINS_DIR)
 
     def discover(self) -> int:
         """Scan plugin directories and load manifests. Returns count of loaded plugins."""

--- a/daemon/pilot/server.py
+++ b/daemon/pilot/server.py
@@ -22,7 +22,7 @@ import aiosqlite
 import websockets
 from websockets.asyncio.server import Server, ServerConnection
 
-from pilot.config import DATA_DIR, DB_FILE, LOG_FILE, STATE_DIR, PilotConfig, ensure_dirs
+from pilot.config import DATA_DIR, DB_FILE, LOG_FILE, PLUGINS_DIR, STATE_DIR, PilotConfig, ensure_dirs
 from pilot.export_logs import export_logs
 
 logger = logging.getLogger("pilot.server")
@@ -652,7 +652,7 @@ class PilotServer:
             "plugin_market_list": self._handle_plugin_market_list,
             "plugin_install": self._handle_plugin_install,
             "plugin_uninstall": self._handle_plugin_uninstall,
-            # Dynamic Python skills (pilot/skills + ~/.config/pilot/skills)
+            # Dynamic Python skills (pilot/skills + config skills dir)
             "skills_list": self._handle_skills_list,
             "skills_reload": self._handle_skills_reload,
             "skills_load_report": self._handle_skills_load_report,
@@ -2570,7 +2570,7 @@ class PilotServer:
         if not plugin_name:
             return {"error": "plugin_name is required"}
 
-        plugin_dir = Path.home() / ".heliox" / "plugins" / plugin_name
+        plugin_dir = PLUGINS_DIR / plugin_name
         plugin_dir.mkdir(parents=True, exist_ok=True)
 
         manifest_path = plugin_dir / "manifest.json"
@@ -2605,7 +2605,7 @@ class PilotServer:
         if not plugin_name:
             return {"error": "plugin_name is required"}
 
-        plugin_dir = Path.home() / ".heliox" / "plugins" / plugin_name
+        plugin_dir = PLUGINS_DIR / plugin_name
         if not plugin_dir.exists():
             return {"error": f"Plugin not found: {plugin_name}"}
 

--- a/daemon/pilot/skills/bundled/example_echo.py
+++ b/daemon/pilot/skills/bundled/example_echo.py
@@ -1,6 +1,6 @@
 """Example skill — uppercase a string parameter.
 
-Copy this file to ~/.config/pilot/skills/ and modify to experiment.
+Copy this file to the configured skills directory and modify to experiment.
 """
 
 from __future__ import annotations

--- a/daemon/pilot/system/plugins.py
+++ b/daemon/pilot/system/plugins.py
@@ -19,6 +19,8 @@ from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Any
 
+from pilot.config import PLUGINS_DIR
+
 logger = logging.getLogger("pilot.system.plugins")
 
 
@@ -50,7 +52,7 @@ class PluginAction:
 class PluginManager:
     """Manages plugin discovery, loading, and execution."""
 
-    DEFAULT_PLUGIN_DIR = os.path.expanduser("~/.config/heliox-os/plugins")
+    DEFAULT_PLUGIN_DIR = str(PLUGINS_DIR)
 
     def __init__(self, plugin_dirs: list[str] | None = None):
         self._plugin_dirs = plugin_dirs or [self.DEFAULT_PLUGIN_DIR]
@@ -238,7 +240,7 @@ class PluginManager:
         example.write_text('''"""Example Pilot Plugin — Hello World.
 
 This shows how to create a custom plugin for Pilot.
-Place .py files in ~/.pilot/plugins/ and they'll be auto-discovered.
+Place .py files in the configured plugins directory and they'll be auto-discovered.
 
 Functions prefixed with 'action_' automatically become available actions.
 """
@@ -290,7 +292,7 @@ async def plugin_list() -> str:
         _manager.load_all()
         plugins = _manager.list_plugins()
     if not plugins:
-        return "No plugins found. Place .py files in ~/.pilot/plugins/"
+        return f"No plugins found. Place .py files in {PLUGINS_DIR}/"
     return json.dumps(plugins, indent=2)
 
 

--- a/daemon/tests/test_config_paths.py
+++ b/daemon/tests/test_config_paths.py
@@ -1,0 +1,174 @@
+"""Tests for consistent config/data directory path consolidation.
+
+Verifies that all modules use the centralized constants from ``pilot.config``
+instead of hardcoded path strings.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from pilot.config import (
+    CONFIG_DIR,
+    CONFIG_FILE,
+    DATA_DIR,
+    DB_FILE,
+    LOG_FILE,
+    PERSONA_FILE,
+    PLUGINS_DIR,
+    SCREENSHOTS_DIR,
+    STATE_DIR,
+    ensure_dirs,
+    migrate_old_paths,
+)
+
+
+class TestConfigConstants:
+    """All path constants must be consistent and predictable."""
+
+    def test_config_dir_is_heliox_os(self):
+        assert CONFIG_DIR.name == "heliox-os"
+        assert ".config" in str(CONFIG_DIR)
+
+    def test_data_dir_is_heliox_os(self):
+        assert DATA_DIR.name == "heliox-os"
+        assert ".local" in str(DATA_DIR)
+
+    def test_state_dir_is_heliox_os(self):
+        assert STATE_DIR.name == "heliox-os"
+
+    def test_plugins_dir_under_config_dir(self):
+        assert PLUGINS_DIR.parent == CONFIG_DIR
+        assert PLUGINS_DIR.name == "plugins"
+
+    def test_screenshots_dir_under_data_dir(self):
+        assert SCREENSHOTS_DIR.parent == DATA_DIR
+        assert SCREENSHOTS_DIR.name == "screenshots"
+
+    def test_persona_file_under_data_dir(self):
+        assert PERSONA_FILE.parent == DATA_DIR
+        assert PERSONA_FILE.name == "persona.md"
+
+    def test_config_file_under_config_dir(self):
+        assert CONFIG_FILE.parent == CONFIG_DIR
+        assert CONFIG_FILE.name == "config.toml"
+
+    def test_db_file_under_data_dir(self):
+        assert DB_FILE.parent == DATA_DIR
+        assert DB_FILE.name == "pilot.db"
+
+    def test_log_file_under_state_dir(self):
+        assert LOG_FILE.parent == STATE_DIR
+        assert LOG_FILE.name == "pilot.log"
+
+    def test_all_dirs_are_under_home(self):
+        home = Path.home()
+        assert str(CONFIG_DIR).startswith(str(home))
+        assert str(DATA_DIR).startswith(str(home))
+        assert str(STATE_DIR).startswith(str(home))
+        assert str(PLUGINS_DIR).startswith(str(home))
+        assert str(SCREENSHOTS_DIR).startswith(str(home))
+
+
+class TestEnsureDirs:
+    """ensure_dirs() must create all required directories."""
+
+    def test_creates_all_dirs(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("pilot.config.CONFIG_DIR", tmp_path / "config")
+        monkeypatch.setattr("pilot.config.DATA_DIR", tmp_path / "data")
+        monkeypatch.setattr("pilot.config.STATE_DIR", tmp_path / "state")
+        monkeypatch.setattr("pilot.config.RUNTIME_DIR", tmp_path / "runtime")
+        monkeypatch.setattr("pilot.config.PLUGINS_DIR", tmp_path / "config" / "plugins")
+        monkeypatch.setattr("pilot.config.SCREENSHOTS_DIR", tmp_path / "data" / "screenshots")
+
+        ensure_dirs()
+
+        assert (tmp_path / "config").is_dir()
+        assert (tmp_path / "data").is_dir()
+        assert (tmp_path / "state").is_dir()
+        assert (tmp_path / "runtime").is_dir()
+        assert (tmp_path / "config" / "plugins").is_dir()
+        assert (tmp_path / "data" / "screenshots").is_dir()
+
+
+class TestMigrateOldPaths:
+    """Old hardcoded paths must be migrated to the new layout."""
+
+    def test_migrates_old_heliox_plugins(self, tmp_path, monkeypatch):
+        plugins_dir = tmp_path / "config" / "plugins"
+        monkeypatch.setattr("pilot.config.PLUGINS_DIR", plugins_dir)
+
+        old_plugins = tmp_path / ".heliox" / "plugins"
+        old_plugins.mkdir(parents=True)
+        (old_plugins / "my_plugin.py").write_text("# test")
+
+        with monkeypatch.context() as m:
+            m.setattr(Path, "home", lambda: tmp_path)
+            migrate_old_paths()
+
+        assert (plugins_dir / "my_plugin.py").exists()
+        assert not old_plugins.exists()
+
+    def test_migrates_old_persona(self, tmp_path, monkeypatch):
+        persona_file = tmp_path / "data" / "persona.md"
+        monkeypatch.setattr("pilot.config.PERSONA_FILE", persona_file)
+
+        old_persona = tmp_path / ".heliox" / "persona.md"
+        old_persona.parent.mkdir(parents=True)
+        old_persona.write_text("# Persona")
+
+        with monkeypatch.context() as m:
+            m.setattr(Path, "home", lambda: tmp_path)
+            migrate_old_paths()
+
+        assert persona_file.exists()
+        assert persona_file.read_text() == "# Persona"
+        assert not old_persona.exists()
+
+    def test_migrates_old_screenshots(self, tmp_path, monkeypatch):
+        screenshots_dir = tmp_path / "data" / "screenshots"
+        monkeypatch.setattr("pilot.config.SCREENSHOTS_DIR", screenshots_dir)
+
+        old_screenshots = tmp_path / ".heliox" / "screenshots"
+        old_screenshots.mkdir(parents=True)
+        (old_screenshots / "shot1.png").write_text("data")
+
+        with monkeypatch.context() as m:
+            m.setattr(Path, "home", lambda: tmp_path)
+            migrate_old_paths()
+
+        assert (screenshots_dir / "shot1.png").exists()
+        assert not old_screenshots.exists()
+
+    def test_migrates_old_config_pilot(self, tmp_path, monkeypatch):
+        config_dir = tmp_path / "config"
+        monkeypatch.setattr("pilot.config.CONFIG_DIR", config_dir)
+
+        old_config = tmp_path / ".config" / "pilot"
+        old_config.mkdir(parents=True)
+        (old_config / "config.toml").write_text("key = 'val'")
+
+        with monkeypatch.context() as m:
+            m.setattr(Path, "home", lambda: tmp_path)
+            migrate_old_paths()
+
+        assert (config_dir / "config.toml").exists()
+        assert not old_config.exists()
+
+    def test_skips_migration_when_destination_exists(self, tmp_path, monkeypatch):
+        plugins_dir = tmp_path / "config" / "plugins"
+        plugins_dir.mkdir(parents=True)
+        (plugins_dir / "existing.py").write_text("# existing")
+        monkeypatch.setattr("pilot.config.PLUGINS_DIR", plugins_dir)
+
+        old_plugins = tmp_path / ".heliox" / "plugins"
+        old_plugins.mkdir(parents=True)
+        (old_plugins / "old.py").write_text("# old")
+
+        with monkeypatch.context() as m:
+            m.setattr(Path, "home", lambda: tmp_path)
+            migrate_old_paths()
+
+        assert (plugins_dir / "existing.py").exists()
+        assert not (plugins_dir / "old.py").exists(), "should not overwrite"
+        assert old_plugins.exists(), "old dir should remain unmoved"

--- a/tauri-app/src-tauri/src/hotkey.rs
+++ b/tauri-app/src-tauri/src/hotkey.rs
@@ -4,7 +4,7 @@ use std::fs;
 
 fn get_shortcut_path(_app: &AppHandle) -> std::path::PathBuf {
     let home = dirs::home_dir().unwrap_or_else(|| std::path::PathBuf::from("."));
-    home.join(".heliox-os").join("shortcut.txt")
+    home.join(".config").join("heliox-os").join("shortcut.txt")
 }
 
 pub fn load_saved_shortcut(app: &AppHandle) -> String {

--- a/tauri-app/src-tauri/src/main.rs
+++ b/tauri-app/src-tauri/src/main.rs
@@ -18,7 +18,7 @@ use battery::Manager as BatteryManager;
 struct DaemonProcess(Mutex<Option<Child>>);
 fn get_app_data_dir() -> std::path::PathBuf {
     let home = dirs::home_dir().unwrap_or_else(|| std::path::PathBuf::from("."));
-    home.join(".heliox-os")
+    home.join(".config").join("heliox-os")
 }
 fn get_venv_python() -> std::path::PathBuf {
     let venv_dir = get_app_data_dir().join("env");


### PR DESCRIPTION
## Summary #285 

The codebase used 4 different directory conventions (`~/.heliox/`, `~/.config/pilot/`, `~/.config/heliox-os/`, `~/.heliox-os/`), causing plugins and config to be invisible across modules. This PR consolidates everything under `~/.config/heliox-os/` using centralized constants from `pilot.config`.

## Changes

| What | Where |
|---|---|
| Centralized `PLUGINS_DIR`, `SCREENSHOTS_DIR`, `PERSONA_FILE` | `config.py` |
| Replaced `~/.heliox/plugins/` → `PLUGINS_DIR` | `plugins/__init__.py`, `server.py` |
| Replaced `~/.config/heliox-os/plugins/` → `PLUGINS_DIR` | `skill_sync.py`, `system/plugins.py` |
| Replaced `~/.heliox/screenshots/` → `SCREENSHOTS_DIR` | `screen_vision.py` |
| Replaced `~/.heliox/persona.md` → `PERSONA_FILE` | `subconscious.py` |
| Replaced hardcoded log/config paths | `export_logs.py` |
| `~/.heliox-os` → `~/.config/heliox-os` | `main.rs`, `hotkey.rs` |
| Auto-migration from old paths | `migrate_old_paths()` in `config.py` |
| 16 tests verifying everything | `tests/test_config_paths.py` |

## Test

```bash
cd daemon && python -m pytest tests/test_config_paths.py -v