### PR TITLE
Feat: implement Svelte error boundary for Tauri frontend (#69)

### DIFF
--- a/tauri-app/ui/package-lock.json
+++ b/tauri-app/ui/package-lock.json
@@ -956,6 +956,7 @@
       "integrity": "sha512-Y1Cs7hhTc+a5E9Va/xwKlAJoariQyHY+5zBgCZg4PFWNYQ1nMN9sjK1zhw1gK69DuqVP++sht/1GZg1aRwmAXQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@sveltejs/vite-plugin-svelte-inspector": "^4.0.1",
         "debug": "^4.4.1",
@@ -1052,6 +1053,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1082,6 +1084,7 @@
       "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.1.tgz",
       "integrity": "sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@kurkle/color": "^0.3.0"
       },
@@ -1557,6 +1560,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -1726,6 +1730,7 @@
       "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.55.7.tgz",
       "integrity": "sha512-ymI5ykLPwIHW839E053FQbI1G+jnRFJEw3Kv5Y4njixVWywQBx+NUFpkkKyk5LIb36Fg9DVXSYpqiGekLD0hyw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jridgewell/remapping": "^2.3.4",
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -2270,6 +2275,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -2284,6 +2290,7 @@
       "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",

--- a/tauri-app/ui/src/App.svelte
+++ b/tauri-app/ui/src/App.svelte
@@ -22,7 +22,7 @@
   import { session } from "./lib/stores/session";
   import type { Message } from "./lib/stores/session";
   import { settings } from "./lib/stores/settings";
-   import { tick } from "svelte";
+  import { tick, onDestroy } from "svelte";
   import { Copy } from "lucide-svelte";
 
   import ScrollToBottom from "./lib/components/ScrollToBottom.svelte";
@@ -189,86 +189,99 @@
   </header>
 
   <div class="content">
-    {#if activeTab === "chat"}
-      <div class="chat-panel">
-        <NeuralBackground />
+    <svelte:boundary>
+      {#if activeTab === "chat"}
+        <div class="chat-panel">
+          <NeuralBackground />
 
-        <div class="pipeline-container">
-          <ReActPipeline />
-        </div>
-        {#if $session.confirmRequired}
-          <ConfirmDialog
-            actions={$session.confirmActions}
-            onconfirm={() => session.confirm(true)}
-            ondeny={() => session.confirm(false)}
-          />
-        {/if}
-
-        <div class="results">
-          {#if $session.messages.length === 0 && !$session.loading}
-            <div class="empty-state">
-              <div class="empty-logo">C</div>
-              <h2>{$_('chat.empty_title')}</h2>
-              <p>{$_('chat.empty_subtitle')}</p>
-              <div class="suggestions">
-                <button class="suggestion" onclick={() => session.sendCommand("Show system information")}>{$_('chat.suggestion_sysinfo')}</button>
-                <button class="suggestion" onclick={() => session.sendCommand("Take a screenshot and describe it")}>{$_('chat.suggestion_screenshot')}</button>
-                <button class="suggestion" onclick={() => session.sendCommand("What processes are running?")}>{$_('chat.suggestion_processes')}</button>
-              </div>
-            </div>
-          {:else}
-            <VirtualList bind:this={virtualListEl} items={$session.messages} bind:atBottom={isAtBottom}>
-              {#snippet item(msg)}
-                {@render messageBlock(msg)}
-              {/snippet}
-              {#snippet footer()}
-                {#if $session.loading}
-                  <ExecutionGraph />
-                  {#if $session.streamingText}
-                    <div class="message system streaming">
-                      <div class="msg-header">
-                        <span class="msg-label">HELIOX</span>
-                        <span class="phase-badge">{$_('chat.streaming')}</span>
-                      </div>
-                      <span class="msg-text">{$session.streamingText}</span>
-                    </div>
-                  {:else}
-                    <div class="message system">
-                      <div class="msg-header">
-                        <span class="msg-label">HELIOX</span>
-                        <span class="phase-badge">{$session.phase || $_('chat.thinking')}</span>
-                      </div>
-                      <span class="msg-text loading-dots">
-                        {$session.phase ? `${$session.phase}` : $_('chat.thinking')}
-                      </span>
-                    </div>
-                  {/if}
-                {/if}
-              {/snippet}
-            </VirtualList>
+          <div class="pipeline-container">
+            <ReActPipeline />
+          </div>
+          {#if $session.confirmRequired}
+            <ConfirmDialog
+              actions={$session.confirmActions}
+              onconfirm={() => session.confirm(true)}
+              ondeny={() => session.confirm(false)}
+            />
           {/if}
-          <ScrollToBottom show={showScrollFAB} onclick={scrollToBottom} />
+
+          <div class="results">
+            {#if $session.messages.length === 0 && !$session.loading}
+              <div class="empty-state">
+                <div class="empty-logo">C</div>
+                <h2>{$_('chat.empty_title')}</h2>
+                <p>{$_('chat.empty_subtitle')}</p>
+                <div class="suggestions">
+                  <button class="suggestion" onclick={() => session.sendCommand("Show system information")}>{$_('chat.suggestion_sysinfo')}</button>
+                  <button class="suggestion" onclick={() => session.sendCommand("Take a screenshot and describe it")}>{$_('chat.suggestion_screenshot')}</button>
+                  <button class="suggestion" onclick={() => session.sendCommand("What processes are running?")}>{$_('chat.suggestion_processes')}</button>
+                </div>
+              </div>
+            {:else}
+              <VirtualList bind:this={virtualListEl} items={$session.messages} bind:atBottom={isAtBottom}>
+                {#snippet item(msg)}
+                  {@render messageBlock(msg)}
+                {/snippet}
+                {#snippet footer()}
+                  {#if $session.loading}
+                    <ExecutionGraph />
+                    {#if $session.streamingText}
+                      <div class="message system streaming">
+                        <div class="msg-header">
+                          <span class="msg-label">HELIOX</span>
+                          <span class="phase-badge">{$_('chat.streaming')}</span>
+                        </div>
+                        <span class="msg-text">{$session.streamingText}</span>
+                      </div>
+                    {:else}
+                      <div class="message system">
+                        <div class="msg-header">
+                          <span class="msg-label">HELIOX</span>
+                          <span class="phase-badge">{$session.phase || $_('chat.thinking')}</span>
+                        </div>
+                        <span class="msg-text loading-dots">
+                          {$session.phase ? `${$session.phase}` : $_('chat.thinking')}
+                        </span>
+                      </div>
+                    {/if}
+                  {/if}
+                {/snippet}
+              </VirtualList>
+            {/if}
+            <ScrollToBottom show={showScrollFAB} onclick={scrollToBottom} />
+          </div>
+          <div class="input-row">
+            <VoiceControl />
+            <CommandInput />
+            <GestureControl onGesture={onGestureDetected} />
+            <button class="tab" type="button" onclick={() => session.exportChat("json")}>{$_('app.export_json')}</button>
+            <button class="tab" type="button" onclick={() => session.exportChat("csv")}>{$_('app.export_csv')}</button>
+            <button class="tab" type="button" onclick={() => session.exportChat("json")}>Export JSON</button>
+            <button class="tab" type="button" onclick={() => session.exportChat("csv")}>Export CSV</button>
+            <button class="tab" type="button" onclick={exportReActTrace} title="Export ReAct reasoning trace to JSON">Export Trace</button>
+          </div>
         </div>
-        <div class="input-row">
-          <VoiceControl />
-          <CommandInput />
-          <GestureControl onGesture={onGestureDetected} />
-          <button class="tab" type="button" onclick={() => session.exportChat("json")}>{$_('app.export_json')}</button>
-          <button class="tab" type="button" onclick={() => session.exportChat("csv")}>{$_('app.export_csv')}</button>
-          <button class="tab" type="button" onclick={() => session.exportChat("json")}>Export JSON</button>
-          <button class="tab" type="button" onclick={() => session.exportChat("csv")}>Export CSV</button>
-          <button class="tab" type="button" onclick={exportReActTrace} title="Export ReAct reasoning trace to JSON">Export Trace</button>
+      {:else if activeTab === "log"}
+        <ActivityLog />
+      {:else if activeTab === "dashboard"}
+       <Dashboard />
+      {:else if activeTab === "plugins"}
+        <PluginsTab />
+      {:else}
+        <SettingsPanel />
+      {/if}
+      {#snippet failed(error, reset)}
+        <div class="empty-state">
+          <div class="empty-logo" style="background: var(--danger)">!</div>
+          <h2>Something went wrong</h2>
+          <p style="font-family: var(--font-mono); font-size: 11px;">{error instanceof Error ? error.message : String(error)}</p>
+          <div class="suggestions">
+            <button class="suggestion" onclick={reset}>Try Again</button>
+            <button class="suggestion" onclick={() => activeTab = "chat"}>Go to Chat</button>
+          </div>
         </div>
-      </div>
-    {:else if activeTab === "log"}
-      <ActivityLog />
-    {:else if activeTab === "dashboard"}
-     <Dashboard />
-    {:else if activeTab === "plugins"}
-      <PluginsTab />
-    {:else}
-      <SettingsPanel />
-    {/if}
+      {/snippet}
+    </svelte:boundary>
   </div>
   <!-- Particle Burst Overlay -->
   <ParticleBurst bind:this={particleBurst} />


### PR DESCRIPTION
Resolves #69.

**Changes:**
- Wrapped the main dynamic tab routing inside `<div class="content">` with Svelte 5's `<svelte:boundary>`.
- Implemented a clean fallback UI (`failed` snippet) that reuses existing `empty-state` CSS classes.
- Added recovery buttons to retry rendering or navigate back to the safe "Chat" tab.
- Safely stringified the error output.
- Fixed a pre-existing missing `onDestroy` import that was failing `npm run check`.
