### PR TITLE
Feat/command history panel

### DIFF
--- a/tauri-app/ui/src/App.svelte
+++ b/tauri-app/ui/src/App.svelte
@@ -22,7 +22,7 @@
   import { session } from "./lib/stores/session";
   import type { Message } from "./lib/stores/session";
   import { settings } from "./lib/stores/settings";
-  import { tick } from "svelte";
+  import { onDestroy, tick } from "svelte";
   import { Copy } from "lucide-svelte";
   import ScrollToBottom from "./lib/components/ScrollToBottom.svelte";
   import ConnectionStatus from "./lib/components/ConnectionStatus.svelte";

--- a/tauri-app/ui/src/App.svelte
+++ b/tauri-app/ui/src/App.svelte
@@ -22,20 +22,21 @@
   import { session } from "./lib/stores/session";
   import type { Message } from "./lib/stores/session";
   import { settings } from "./lib/stores/settings";
-   import { tick } from "svelte";
+  import { tick } from "svelte";
   import { Copy } from "lucide-svelte";
-
   import ScrollToBottom from "./lib/components/ScrollToBottom.svelte";
   import ConnectionStatus from "./lib/components/ConnectionStatus.svelte";
-  let isDragging = $state(false);
+  import CommandHistory from "./lib/components/CommandHistory.svelte";
   import { _, isLoading } from 'svelte-i18n';
 
+  let isDragging = $state(false);
   let activeTab: "chat" | "log" | "dashboard" | "settings" | "plugins" = $state("chat");
   let showWizard = $derived(
     !$settings.first_run_complete && localStorage.getItem("heliox_first_run_complete") !== "true"
   );
   let showScrollFAB = $state(false);
   let isAtBottom = $state(true);
+  let prefillText = $state("");
   let virtualListEl: VirtualList<Message> | undefined = $state();
   let particleBurst: ParticleBurst | undefined = $state();
   $effect(() => {
@@ -66,6 +67,15 @@
       showScrollFAB = false;
     });
   }
+
+  function handleReplay(command: string) {
+    session.sendCommand(command);
+  }
+
+  function handleReplay(command: string) {
+    prefillText = command; // Prefills input box — user can edit before sending
+  }
+
   $effect(() => {
     $session.messages;
     $session.loading;
@@ -250,8 +260,9 @@
           <ScrollToBottom show={showScrollFAB} onclick={scrollToBottom} />
         </div>
         <div class="input-row">
+          <CommandHistory onReplay={handleReplay} />
           <VoiceControl />
-          <CommandInput />
+          <CommandInput prefill={prefillText} />
           <GestureControl onGesture={onGestureDetected} />
           <button class="tab" type="button" onclick={() => session.exportChat("json")}>{$_('app.export_json')}</button>
           <button class="tab" type="button" onclick={() => session.exportChat("csv")}>{$_('app.export_csv')}</button>

--- a/tauri-app/ui/src/App.svelte
+++ b/tauri-app/ui/src/App.svelte
@@ -68,8 +68,10 @@
     });
   }
 
-  function handleReplay(command: string) {
-    prefillText = command; // Prefills input box — user can edit before sending
+  async function handleReplay(command: string) {
+    prefillText = "";
+    await tick();
+    prefillText = command; // Prefills input box so the user can edit before sending
   }
 
   $effect(() => {

--- a/tauri-app/ui/src/App.svelte
+++ b/tauri-app/ui/src/App.svelte
@@ -69,10 +69,6 @@
   }
 
   function handleReplay(command: string) {
-    session.sendCommand(command);
-  }
-
-  function handleReplay(command: string) {
     prefillText = command; // Prefills input box — user can edit before sending
   }
 

--- a/tauri-app/ui/src/lib/components/CommandHistory.svelte
+++ b/tauri-app/ui/src/lib/components/CommandHistory.svelte
@@ -6,15 +6,21 @@
 
   // State
   let isOpen = $state(false);
-  let history: any[] = $state([]);
+  type HistoryEntry = {
+    raw_input: string;
+    created_at: string;
+    execution_status: string;
+  };
+
+  let history: HistoryEntry[] = $state([]);
   let loading = $state(false);
 
   // Fetch history when panel opens
   async function fetchHistory() {
     loading = true;
     try {
-      const result = await call("get_plan_history", { limit: 30, offset: 0 }) as any[];
-      history = result ?? [];
+      const result = await call<{ plans?: HistoryEntry[] }>("get_plan_history", { limit: 30, offset: 0 });
+      history = result.plans ?? [];
     } catch (e) {
       history = [];
     } finally {
@@ -29,6 +35,7 @@
 
   function formatTime(iso: string): string {
     const d = new Date(iso);
+    if (Number.isNaN(d.getTime())) return "";
     return d.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
   }
 

--- a/tauri-app/ui/src/lib/components/CommandHistory.svelte
+++ b/tauri-app/ui/src/lib/components/CommandHistory.svelte
@@ -1,0 +1,222 @@
+<script lang="ts">
+  import { call } from "../api/daemon";
+
+  // Props
+  let { onReplay }: { onReplay: (command: string) => void } = $props();
+
+  // State
+  let isOpen = $state(false);
+  let history: any[] = $state([]);
+  let loading = $state(false);
+
+  // Fetch history when panel opens
+  async function fetchHistory() {
+    loading = true;
+    try {
+      const result = await call("get_plan_history", { limit: 30, offset: 0 }) as any[];
+      history = result ?? [];
+    } catch (e) {
+      history = [];
+    } finally {
+      loading = false;
+    }
+  }
+
+  function togglePanel() {
+    isOpen = !isOpen;
+    if (isOpen) fetchHistory();
+  }
+
+  function formatTime(iso: string): string {
+    const d = new Date(iso);
+    return d.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+  }
+
+  function statusClass(status: string): string {
+    if (status === "success") return "status-success";
+    if (status === "error" || status === "partial_failure") return "status-error";
+    return "status-other";
+  }
+
+  function statusLabel(status: string): string {
+    if (status === "success") return "✓";
+    if (status === "error") return "✗";
+    if (status === "partial_failure") return "⚠";
+    return "•";
+  }
+</script>
+
+<div class="history-wrapper">
+  <button class="history-toggle" onclick={togglePanel} title="Command History">
+    🕒 History
+  </button>
+
+  {#if isOpen}
+    <div class="history-panel">
+      <div class="history-header">
+        <span class="history-title">Command History</span>
+        <button class="close-btn" onclick={() => isOpen = false}>✕</button>
+      </div>
+
+      {#if loading}
+        <div class="history-loading">Loading...</div>
+      {:else if history.length === 0}
+        <div class="history-empty">No commands yet.</div>
+      {:else}
+        <div class="history-list">
+          {#each history as entry}
+            <div class="history-item">
+              <span class="status-dot {statusClass(entry.execution_status)}">
+                {statusLabel(entry.execution_status)}
+              </span>
+              <div class="entry-info">
+                <span class="entry-cmd">{entry.raw_input}</span>
+                <span class="entry-time">{formatTime(entry.created_at)}</span>
+              </div>
+              <button
+                class="replay-btn"
+                title="Replay this command"
+                onclick={() => { onReplay(entry.raw_input); isOpen = false; }}
+              >
+                ↩ Replay
+              </button>
+            </div>
+          {/each}
+        </div>
+      {/if}
+    </div>
+  {/if}
+</div>
+
+<style>
+  .history-wrapper {
+    position: relative;
+  }
+
+  .history-toggle {
+    padding: 5px 12px;
+    font-size: 12px;
+    color: var(--text-secondary);
+    background: transparent;
+    border-radius: var(--radius-sm);
+    transition: all 0.15s;
+  }
+  .history-toggle:hover {
+    color: var(--text-primary);
+    background: var(--bg-hover);
+  }
+
+  .history-panel {
+    position: absolute;
+    bottom: 110%;
+    left: 0;
+    width: 340px;
+    max-height: 360px;
+    background: var(--bg-secondary);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-md);
+    box-shadow: 0 8px 24px rgba(0,0,0,0.4);
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+    z-index: 100;
+    animation: fadeIn 0.15s ease-out;
+  }
+
+  @keyframes fadeIn {
+    from { opacity: 0; transform: translateY(4px); }
+    to   { opacity: 1; transform: translateY(0); }
+  }
+
+  .history-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 10px 14px;
+    border-bottom: 1px solid var(--border);
+  }
+
+  .history-title {
+    font-size: 12px;
+    font-weight: 600;
+    color: var(--text-primary);
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+  }
+
+  .close-btn {
+    font-size: 12px;
+    color: var(--text-muted);
+    background: none;
+  }
+  .close-btn:hover { color: var(--text-primary); }
+
+  .history-loading,
+  .history-empty {
+    padding: 20px;
+    text-align: center;
+    font-size: 12px;
+    color: var(--text-muted);
+  }
+
+  .history-list {
+    overflow-y: auto;
+    flex: 1;
+  }
+
+  .history-item {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 8px 14px;
+    border-bottom: 1px solid var(--border);
+    transition: background 0.1s;
+  }
+  .history-item:hover { background: var(--bg-hover); }
+
+  .status-dot {
+    font-size: 12px;
+    font-weight: 700;
+    width: 18px;
+    text-align: center;
+    flex-shrink: 0;
+  }
+  .status-success { color: var(--success); }
+  .status-error   { color: var(--danger); }
+  .status-other   { color: var(--text-muted); }
+
+  .entry-info {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+  }
+
+  .entry-cmd {
+    font-size: 12px;
+    color: var(--text-primary);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .entry-time {
+    font-size: 10px;
+    color: var(--text-muted);
+    margin-top: 1px;
+  }
+
+  .replay-btn {
+    font-size: 11px;
+    padding: 3px 10px;
+    border-radius: var(--radius-sm);
+    color: var(--accent);
+    background: var(--accent-muted);
+    flex-shrink: 0;
+    transition: all 0.15s;
+  }
+  .replay-btn:hover {
+    background: var(--accent);
+    color: white;
+  }
+</style>

--- a/tauri-app/ui/src/lib/components/CommandInput.svelte
+++ b/tauri-app/ui/src/lib/components/CommandInput.svelte
@@ -4,6 +4,16 @@
   let input = $state("");
   const MAX_CHARS = 20000;
 
+  // Accept prefill text from parent (e.g. CommandHistory replay)
+  let { prefill = "" }: { prefill?: string } = $props();
+
+  // When prefill changes, populate the input box without running
+  $effect(() => {
+    if (prefill) {
+      input = prefill;
+    }
+  });
+
   type Attachment = {
     name: string;
     type: string;


### PR DESCRIPTION
## Summary

Every time you used Heliox OS, your previous commands were just gone. 
You'd have to remember and retype everything from scratch, even though 
the daemon was silently saving everything to an audit log the whole time. 
This PR finally surfaces that data in the UI.

Closes #281 

---

## Type of change

- [ ] Bug fix
- [x] New feature / enhancement
- [ ] Documentation update
- [ ] Tests / CI
- [ ] Performance improvement
- [ ] Refactor (no functional change)

---

## Changes made

New component CommandHistory.svelte added a collapsible history panel that appears above the input bar when you click the History button. It fetches the last 30 commands from the daemon's existing get_plan_history IPC endpoint. Each entry shows a status indicator for success, error or partial failure, the original command text, the time it was run, and a Replay button.

Modified CommandInput.svelte to accept a prefill prop. When set from the parent, it populates the input box without submitting so the user can review and tweak the command before sending it.

Modified App.svelte to import and place CommandHistory in the input row, added a prefillText state variable, and updated handleReplay to set prefillText instead of auto-running the command so the user has a chance to edit before sending.

## How to test

1. Run a few commands in the chat
2. Click the History button in the input bar
3. You should see your past commands with status indicators and timestamps
4. Click Replay on any entry: it should fill the input box with 
   that command without running it automatically
5. Edit if needed, then press Enter to run

---

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My code follows the existing code style
- [x] I have added/updated tests where applicable
- [x] All existing tests pass (`pytest` for backend, `npm run test` for frontend)
- [x] I have updated documentation if needed
- [x] I have tested on at least one platform (Windows / macOS / Linux)

---

## GSSoC declaration

- [x] This contribution is made under the GSSoC 2026 program
- [x] I have not plagiarised code from other repositories
