### PR TITLE
fix(security): move SHELL_COMMAND and CODE_EXECUTE out of ALWAYS_SAFE tier

### DIFF
--- a/daemon/pilot/actions.py
+++ b/daemon/pilot/actions.py
@@ -341,6 +341,8 @@ SYSTEM_MODIFY_ACTIONS = {
     # SSH is always a remote system modification surface
     ActionType.SSH_COMMAND,
     ActionType.SSH_SCRIPT,
+    ActionType.CODE_EXECUTE,
+    ActionType.SHELL_COMMAND,
 }
 
 
@@ -845,10 +847,8 @@ class Action(BaseModel):
             ActionType.FILE_LIST,
             ActionType.FILE_SEARCH,
             ActionType.FILE_COPY,
-            ActionType.CODE_EXECUTE,
             ActionType.CODE_GENERATE_AND_RUN,
             ActionType.SKILL_RUN,
-            ActionType.SHELL_COMMAND,
             ActionType.BROWSER_NAVIGATE,
             ActionType.BROWSER_EXTRACT,
             ActionType.BROWSER_EXTRACT_TABLE,

--- a/daemon/tests/test_action_permissions.py
+++ b/daemon/tests/test_action_permissions.py
@@ -1,0 +1,33 @@
+from pilot.actions import (
+    Action,
+    ActionType,
+    EmptyParams,
+    PermissionTier,
+    SYSTEM_MODIFY_ACTIONS,
+)
+
+
+def test_shell_command_not_in_always_safe():
+    action = Action(
+        action_type=ActionType.SHELL_COMMAND,
+        parameters=EmptyParams(),
+    )
+    assert action.requires_confirmation is True
+    assert action.permission_tier == PermissionTier.SYSTEM_MODIFY
+
+
+def test_code_execute_not_in_always_safe():
+    action = Action(
+        action_type=ActionType.CODE_EXECUTE,
+        parameters=EmptyParams(),
+    )
+    assert action.requires_confirmation is True
+    assert action.permission_tier == PermissionTier.SYSTEM_MODIFY
+
+
+def test_shell_command_in_system_modify():
+    assert ActionType.SHELL_COMMAND in SYSTEM_MODIFY_ACTIONS
+
+
+def test_code_execute_in_system_modify():
+    assert ActionType.CODE_EXECUTE in SYSTEM_MODIFY_ACTIONS

--- a/daemon/tests/test_action_permissions.py
+++ b/daemon/tests/test_action_permissions.py
@@ -1,9 +1,9 @@
 from pilot.actions import (
+    SYSTEM_MODIFY_ACTIONS,
     Action,
     ActionType,
     EmptyParams,
     PermissionTier,
-    SYSTEM_MODIFY_ACTIONS,
 )
 
 


### PR DESCRIPTION

<p>Closes #343</p>
<h2>Summary</h2>
<p><code>SHELL_COMMAND</code> and <code>CODE_EXECUTE</code> were placed in the <code>ALWAYS_SAFE</code> permission set in <code>daemon/pilot/actions.py</code>, meaning they silently bypassed the user confirmation gate. This PR moves both action types into <code>SYSTEM_MODIFY_ACTIONS</code> so that every shell and code execution requires explicit user approval before running.</p>
<hr>
<h2>Changes</h2>

File | Change
-- | --
daemon/pilot/actions.py | Removed CODE_EXECUTE and SHELL_COMMAND from ALWAYS_SAFE, added to SYSTEM_MODIFY_ACTIONS (+2/-2 lines)
daemon/tests/test_action_permissions.py | New test file — 4 tests asserting both action types now require confirmation and are in SYSTEM_MODIFY_ACTIONS


<hr>
<h2>Why this matters</h2>
<p>This was the most direct way to bypass Heliox-OS's entire safety layer. A malformed LLM output, a rogue plugin, or a crafted voice command could silently run <code>rm -rf</code>, exfiltrate files, or install malware — all without the user ever seeing a prompt. The fix is minimal (2 lines in <code>actions.py</code>) but closes a fundamental trust boundary violation.</p>
<hr>
<h2>Checklist</h2>
<ul>
<li>[x] Fix is minimal and surgical — only <code>actions.py</code> and new test file modified</li>
<li>[x] All 4 new tests pass</li>
<li>[x] No existing functionality broken — <code>ALWAYS_SAFE</code> actions (clipboard, notifications) unaffected</li>
<li>[x] Commit message follows conventional commits format</li>
<li>[x] References issue <code>#343</code></li>
</ul>
<hr>
<p><em>Part of NSoC 2026 and GSSoC 2026 contribution — <code>level:intermediate</code> <code>type:security</code></em></p></body></html><!--EndFragment-->
</body>
</html>