### PR TITLE
fix: bundled mediapipe gesture assets locally.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,9 @@ jobs:
       - name: Svelte check (type checking)
         run: npx svelte-check --tsconfig ./tsconfig.json || echo "Type check done"
 
+      - name: Static frontend checks
+        run: npm run test:static
+
       - name: Build check
         run: npx vite build
 

--- a/tauri-app/src-tauri/tauri.conf.json
+++ b/tauri-app/src-tauri/tauri.conf.json
@@ -29,7 +29,7 @@
       "iconAsTemplate": true
     },
     "security": {
-      "csp": "default-src 'self'; connect-src 'self' ws://127.0.0.1:* http://127.0.0.1:* ws://localhost:* http://localhost:* https://cdn.jsdelivr.net; script-src 'self' 'unsafe-eval' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; media-src 'self' mediastream:; img-src 'self' blob: data:;"
+      "csp": "default-src 'self'; connect-src 'self' ws://127.0.0.1:* http://127.0.0.1:* ws://localhost:* http://localhost:*; script-src 'self' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; media-src 'self' mediastream:; img-src 'self' blob: data:;"
     }
   },
   "plugins": {

--- a/tauri-app/ui/package-lock.json
+++ b/tauri-app/ui/package-lock.json
@@ -8,6 +8,7 @@
       "name": "pilot-ui",
       "version": "0.6.2",
       "dependencies": {
+        "@mediapipe/hands": "0.4.1675469240",
         "@tauri-apps/api": "^2.0.0",
         "@tauri-apps/plugin-clipboard-manager": "^2.0.0",
         "@tauri-apps/plugin-notification": "^2.0.0",
@@ -574,6 +575,12 @@
       "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
       "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
       "license": "MIT"
+    },
+    "node_modules/@mediapipe/hands": {
+      "version": "0.4.1675469240",
+      "resolved": "https://registry.npmjs.org/@mediapipe/hands/-/hands-0.4.1675469240.tgz",
+      "integrity": "sha512-GxoZvL1mmhJxFxjuyj7vnC++JIuInGznHBin5c7ZSq/RbcnGyfEcJrkM/bMu5K1Mz/2Ko+vEX6/+wewmEHPrHg==",
+      "license": "Apache-2.0"
     },
     "node_modules/@playwright/test": {
       "version": "1.60.0",

--- a/tauri-app/ui/package.json
+++ b/tauri-app/ui/package.json
@@ -8,6 +8,7 @@
     "build": "vite build",
     "preview": "vite preview",
     "check": "svelte-check --tsconfig ./tsconfig.json",
+    "test:static": "node tests/static/no-remote-mediapipe.test.mjs",
     "test:visual": "playwright test",
     "test:visual:update": "playwright test --update-snapshots"
   },
@@ -23,6 +24,7 @@
     "vite": "^6.0.0"
   },
   "dependencies": {
+    "@mediapipe/hands": "0.4.1675469240",
     "@tauri-apps/api": "^2.0.0",
     "@tauri-apps/plugin-clipboard-manager": "^2.0.0",
     "@tauri-apps/plugin-notification": "^2.0.0",

--- a/tauri-app/ui/src/lib/components/GestureControl.svelte
+++ b/tauri-app/ui/src/lib/components/GestureControl.svelte
@@ -41,6 +41,7 @@
 
   import { session } from "../stores/session";
   import { tick } from "svelte";
+  import { Hands, type Results } from "@mediapipe/hands";
 
   // ── Props ──
   let { onGesture = (name: string) => {} }: { onGesture?: (name: string) => void } = $props();
@@ -57,7 +58,7 @@
   let canvasEl: HTMLCanvasElement | undefined = $state();
   let trailCanvas: HTMLCanvasElement | undefined = $state();
   let stream: MediaStream | null = null;
-  let hands: any = null;
+  let hands: Hands | null = null;
   let animFrameId: number = 0;
   let lastGestureTime = 0;
   let candidateGesture = "";
@@ -95,22 +96,16 @@
   // ── MediaPipe Hands Loading ──
   let mpLoaded = $state(false);
   let mpLoading = $state(false);
+  const MEDIAPIPE_HANDS_ASSET_BASE = "/mediapipe/hands";
 
   async function loadMediaPipe() {
     if (mpLoaded && hands) return true;
     mpLoading = true;
 
     try {
-      // @ts-ignore — CDN import has no type declarations
-      const module = await import(
-        /* @ts-ignore */
-        "https://cdn.jsdelivr.net/npm/@mediapipe/hands@0.4.1675469240/hands.js"
-      );
-      const Hands = module.Hands || (window as any).Hands;
-
       hands = new Hands({
         locateFile: (file: string) =>
-          `https://cdn.jsdelivr.net/npm/@mediapipe/hands@0.4.1675469240/${file}`,
+          `${MEDIAPIPE_HANDS_ASSET_BASE}/${file}`,
       });
 
       hands.setOptions({
@@ -121,10 +116,11 @@
       });
 
       hands.onResults(onHandResults);
+      await hands.initialize();
       mpLoaded = true;
       return true;
     } catch (e) {
-      cameraError = "Failed to load gesture detection. Check internet connection.";
+      cameraError = "Failed to load gesture detection assets.";
       console.error("MediaPipe load error:", e);
       return false;
     } finally {
@@ -219,7 +215,7 @@
     }
   }
 
-  function onHandResults(results: any) {
+  function onHandResults(results: Results) {
     if (!results.multiHandLandmarks || results.multiHandLandmarks.length === 0) {
       currentGesture = "";
       confidence = 0;

--- a/tauri-app/ui/tests/static/no-remote-mediapipe.test.mjs
+++ b/tauri-app/ui/tests/static/no-remote-mediapipe.test.mjs
@@ -1,0 +1,17 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const root = process.cwd();
+const gestureControl = readFileSync(
+  join(root, "src", "lib", "components", "GestureControl.svelte"),
+  "utf8",
+);
+const tauriConfig = readFileSync(
+  join(root, "..", "src-tauri", "tauri.conf.json"),
+  "utf8",
+);
+
+assert(!gestureControl.includes("cdn.jsdelivr.net"));
+assert(!gestureControl.includes("https://"));
+assert(!tauriConfig.includes("cdn.jsdelivr.net"));

--- a/tauri-app/ui/vite.config.ts
+++ b/tauri-app/ui/vite.config.ts
@@ -1,8 +1,75 @@
 import { defineConfig } from "vite";
 import { svelte } from "@sveltejs/vite-plugin-svelte";
+import type { Plugin, ResolvedConfig } from "vite";
+import {
+  mkdirSync,
+  readdirSync,
+  copyFileSync,
+  existsSync,
+  createReadStream,
+} from "node:fs";
+import { join, basename, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const MEDIAPIPE_HANDS_ROUTE = "/mediapipe/hands";
+const MEDIAPIPE_HANDS_ASSET_DIR = "mediapipe/hands";
+const CONFIG_DIR = dirname(fileURLToPath(import.meta.url));
+const MEDIAPIPE_HANDS_DIR = join(CONFIG_DIR, "node_modules", "@mediapipe", "hands");
+
+function contentType(file: string) {
+  if (file.endsWith(".js")) return "text/javascript";
+  if (file.endsWith(".wasm")) return "application/wasm";
+  return "application/octet-stream";
+}
+
+function mediapipeHandsAssets(): Plugin {
+  let config: ResolvedConfig;
+
+  const assetFiles = () =>
+    readdirSync(MEDIAPIPE_HANDS_DIR).filter((file) =>
+      /\.(binarypb|data|js|tflite|wasm)$/.test(file),
+    );
+
+  return {
+    name: "mediapipe-hands-assets",
+    configResolved(resolvedConfig) {
+      config = resolvedConfig;
+    },
+    configureServer(server) {
+      server.middlewares.use((req, res, next) => {
+        const pathname = new URL(req.url ?? "", "http://localhost").pathname;
+        if (!pathname.startsWith(`${MEDIAPIPE_HANDS_ROUTE}/`)) {
+          next();
+          return;
+        }
+
+        const file = basename(
+          decodeURIComponent(pathname.slice(MEDIAPIPE_HANDS_ROUTE.length + 1)),
+        );
+        const source = join(MEDIAPIPE_HANDS_DIR, file);
+        if (!existsSync(source)) {
+          next();
+          return;
+        }
+
+        res.setHeader("Content-Type", contentType(file));
+        res.setHeader("Access-Control-Allow-Origin", "*");
+        res.setHeader("Cross-Origin-Resource-Policy", "cross-origin");
+        createReadStream(source).pipe(res);
+      });
+    },
+    writeBundle() {
+      const targetDir = join(config.build.outDir, MEDIAPIPE_HANDS_ASSET_DIR);
+      mkdirSync(targetDir, { recursive: true });
+      for (const file of assetFiles()) {
+        copyFileSync(join(MEDIAPIPE_HANDS_DIR, file), join(targetDir, file));
+      }
+    },
+  };
+}
 
 export default defineConfig({
-  plugins: [svelte()],
+  plugins: [svelte(), mediapipeHandsAssets()],
   clearScreen: false,
   server: {
     port: 1420,


### PR DESCRIPTION
## Summary

Bundles MediaPipe Hands locally for gesture control so the Tauri app no longer loads gesture runtime code or model assets from jsDelivr at runtime. This fixes offline/restricted-network gesture initialization and lets the CSP remove the external CDN allowance.

Closes #347 

---

## Type of change

- [x] Bug fix
- [ ] New feature / enhancement
- [ ] Documentation update
- [x] Tests / CI
- [ ] Performance improvement
- [ ] Refactor (no functional change)

---

## Changes made

- Added exact-pinned `@mediapipe/hands@0.4.1675469240` to the frontend dependencies.
- Updated `GestureControl.svelte` to import MediaPipe locally and load assets from `/mediapipe/hands`.
- Added Vite asset handling to serve MediaPipe files in dev and copy them into `dist/mediapipe/hands` during production builds.
- Removed `cdn.jsdelivr.net` from the Tauri CSP.
- Added `npm run test:static` to prevent remote MediaPipe CDN usage from being reintroduced.
- Added the static frontend check to CI.

---

## How to test

1. Run the static regression check:
   ```bash
   cd tauri-app/ui
   npm run test:static
   ```
   Result: passed.

2. Run Svelte/type checking:
   ```bash
   npm run check
   ```
   Result: passed with 0 errors and 10 existing warnings.

3. Run the production build:
   ```bash
   npm run build
   ```
   Result: passed. Vite built successfully and copied MediaPipe assets into `dist/mediapipe/hands`.

4. Verify the local dev asset route:
   ```bash
   npm run dev -- --host 127.0.0.1
   ```
   Then request:
   ```text
   http://127.0.0.1:1420/mediapipe/hands/hands.binarypb
   ```
   Result: returned `200` with `application/octet-stream`.

---

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My code follows the existing code style
- [x] I have added/updated tests where applicable
- [x] All existing tests pass (`pytest` for backend, `npm run test` for frontend)
- [ ] I have updated documentation if needed
- [x] I have tested on at least one platform (Windows)

---

## Screenshots / recordings (if UI change)

No visual UI change.

---

## GSSoC declaration

- [x] This contribution is made under the GSSoC 2026 program
- [x] I have not plagiarised code from other repositories
