### PR TITLE
feat: implement mDNS/ZeroConf peer discovery with VRAM-aware routing

### DIFF
--- a/daemon/pilot/models/gpu_utils.py
+++ b/daemon/pilot/models/gpu_utils.py
@@ -152,6 +152,18 @@ def _free_ram_bytes_psutil() -> int:
         return 0
 
 
+def get_available_vram() -> int:
+    """Return the amount of available VRAM in bytes.
+
+    If an NVIDIA GPU is present, returns free VRAM.
+    Otherwise, falls back to available system RAM.
+    """
+    vram = _free_vram_bytes_nvidia()
+    if vram is not None:
+        return vram
+    return _free_ram_bytes_psutil()
+
+
 def calculate_gpu_layers(
     model_path: Path | None,
     *,

--- a/daemon/pilot/models/gpu_utils.py
+++ b/daemon/pilot/models/gpu_utils.py
@@ -152,16 +152,16 @@ def _free_ram_bytes_psutil() -> int:
         return 0
 
 
-def get_available_vram() -> int:
-    """Return the amount of available VRAM in bytes.
+def get_available_vram() -> tuple[int, bool]:
+    """Return (available_vram_bytes, is_gpu).
 
-    If an NVIDIA GPU is present, returns free VRAM.
-    Otherwise, falls back to available system RAM.
+    If an NVIDIA GPU is present, returns (free_vram, True).
+    Otherwise, falls back to (available_system_ram, False).
     """
     vram = _free_vram_bytes_nvidia()
     if vram is not None:
-        return vram
-    return _free_ram_bytes_psutil()
+        return vram, True
+    return _free_ram_bytes_psutil(), False
 
 
 def calculate_gpu_layers(
@@ -191,8 +191,7 @@ def calculate_gpu_layers(
     """
     n_layers, bytes_per_layer = _gguf_metadata(model_path) if model_path else (32, _FALLBACK_BYTES_PER_LAYER)
 
-    free_bytes = _free_vram_bytes_nvidia()
-    using_gpu = free_bytes is not None
+    free_bytes, using_gpu = get_available_vram()
 
     if not using_gpu:
         # No NVIDIA GPU detected — keep everything on CPU to avoid crashes.

--- a/daemon/pilot/network/collab_executor.py
+++ b/daemon/pilot/network/collab_executor.py
@@ -251,15 +251,16 @@ class CollabExecutor:
         if not available:
             return None
 
-        # Pick peer with lowest reported CPU load
-        best = min(
-            available,
-            key=lambda pid: (
-                self._mesh.get_connection(pid).peer_capabilities.cpu_load
-                if self._mesh.get_connection(pid) and self._mesh.get_connection(pid).peer_capabilities
-                else 1.0
-            ),
-        )
+        # Pick peer with the most available VRAM.
+        # If VRAM is tied, pick the one with the lowest CPU load.
+        def peer_priority(pid: str) -> tuple[int, float]:
+            conn = self._mesh.get_connection(pid)
+            if not conn or not conn.peer_capabilities:
+                return (0, 1.0)
+            caps = conn.peer_capabilities
+            return (caps.vram_free, -caps.cpu_load)
+
+        best = max(available, key=peer_priority)
         return best
 
 

--- a/daemon/pilot/network/collab_executor.py
+++ b/daemon/pilot/network/collab_executor.py
@@ -251,14 +251,16 @@ class CollabExecutor:
         if not available:
             return None
 
-        # Pick peer with the most available VRAM.
-        # If VRAM is tied, pick the one with the lowest CPU load.
-        def peer_priority(pid: str) -> tuple[int, float]:
+        # Priority criteria:
+        # 1. Has NVIDIA GPU (has_gpu=True)
+        # 2. Most available VRAM
+        # 3. Lowest CPU load
+        def peer_priority(pid: str) -> tuple[bool, int, float]:
             conn = self._mesh.get_connection(pid)
             if not conn or not conn.peer_capabilities:
-                return (0, 1.0)
+                return (False, 0, 1.0)
             caps = conn.peer_capabilities
-            return (caps.vram_free, -caps.cpu_load)
+            return (caps.has_gpu, caps.vram_free, -caps.cpu_load)
 
         best = max(available, key=peer_priority)
         return best

--- a/daemon/pilot/network/mesh.py
+++ b/daemon/pilot/network/mesh.py
@@ -36,6 +36,7 @@ import socket
 import uuid
 from typing import TYPE_CHECKING, Any
 
+from pilot.models.gpu_utils import get_available_vram
 from pilot.network.peer_connection import PeerCapabilities, PeerConnection
 
 if TYPE_CHECKING:
@@ -345,5 +346,6 @@ class HelioxMesh:
             hostname=socket.gethostname(),
             can_execute=self._config.collab_exec_enabled,
             cpu_load=cpu_load,
+            vram_free=get_available_vram(),
             plugin_names=plugins,
         )

--- a/daemon/pilot/network/mesh.py
+++ b/daemon/pilot/network/mesh.py
@@ -124,6 +124,9 @@ class HelioxMesh:
         self._discovery.on_peer_lost = self._on_peer_lost
         await self._discovery.start()
 
+        # Start periodic capability updates
+        asyncio.create_task(self._periodic_capability_update())
+
         logger.info(
             "HelioxMesh started (instance=%s, port=%d)",
             self._instance_id,
@@ -201,6 +204,23 @@ class HelioxMesh:
             # Broadcast our loaded plugins to the new peer
             if self._config.skill_sync_enabled and self._skill_sync:
                 asyncio.create_task(self._sync_plugins_to_peer(peer_id))
+
+    async def _periodic_capability_update(self) -> None:
+        """Periodically refresh VRAM/CPU stats and update discovery/peers."""
+        while self._running:
+            await asyncio.sleep(30)  # update every 30 seconds
+            if not self._running:
+                break
+
+            caps = self._build_own_capabilities()
+
+            # 1. Update mDNS (Zeroconf) record
+            if self._discovery:
+                await self._discovery.update_vram(caps.vram_free, caps.has_gpu)
+
+            # 2. Update connected peers via P2P
+            await self.broadcast("peer_info", caps.__dict__)
+            logger.debug("HelioxMesh: broadcasted updated capabilities (VRAM: %.1f MB)", caps.vram_free / 1024**2)
 
     def _on_connection_lost(self, peer_id: str) -> None:
         """Called by PeerConnection when a connection drops unexpectedly."""
@@ -340,12 +360,14 @@ class HelioxMesh:
             cpu_load = 0.0
 
         plugins = [p["name"] for p in self._plugin_manager.list_plugins() if p.get("loaded")]
+        vram_free, has_gpu = get_available_vram()
 
         return PeerCapabilities(
             instance_id=self._instance_id,
             hostname=socket.gethostname(),
             can_execute=self._config.collab_exec_enabled,
             cpu_load=cpu_load,
-            vram_free=get_available_vram(),
+            vram_free=vram_free,
+            has_gpu=has_gpu,
             plugin_names=plugins,
         )

--- a/daemon/pilot/network/peer_connection.py
+++ b/daemon/pilot/network/peer_connection.py
@@ -40,6 +40,7 @@ class PeerCapabilities:
     version: str = "0.7"
     can_execute: bool = True  # can accept delegated tasks
     cpu_load: float = 0.0  # 0.0–1.0, used for load balancing
+    vram_free: int = 0  # available VRAM in bytes
     plugin_names: list[str] = field(default_factory=list)
 
 

--- a/daemon/pilot/network/peer_connection.py
+++ b/daemon/pilot/network/peer_connection.py
@@ -41,6 +41,7 @@ class PeerCapabilities:
     can_execute: bool = True  # can accept delegated tasks
     cpu_load: float = 0.0  # 0.0–1.0, used for load balancing
     vram_free: int = 0  # available VRAM in bytes
+    has_gpu: bool = False  # does the peer have an NVIDIA GPU?
     plugin_names: list[str] = field(default_factory=list)
 
 

--- a/daemon/pilot/network/peer_discovery.py
+++ b/daemon/pilot/network/peer_discovery.py
@@ -27,6 +27,8 @@ import uuid
 from dataclasses import dataclass
 from typing import Callable
 
+from pilot.models.gpu_utils import get_available_vram
+
 logger = logging.getLogger("pilot.network.peer_discovery")
 
 _ZEROCONF_AVAILABLE = False
@@ -49,6 +51,7 @@ class PeerInfo:
     host: str  # IPv4 address
     port: int  # P2P WebSocket port
     hostname: str = ""  # human-readable hostname
+    vram_free: int = 0  # available VRAM in bytes
 
 
 class PeerDiscovery:
@@ -91,6 +94,7 @@ class PeerDiscovery:
         # Register our own service
         hostname = socket.gethostname()
         local_ip = _get_local_ip()
+        vram_free = get_available_vram()
         service_name = f"helioxos-{self._instance_id}.{_SERVICE_TYPE}"
 
         self._service_info = ServiceInfo(
@@ -101,6 +105,7 @@ class PeerDiscovery:
             properties={
                 "id": self._instance_id.encode(),
                 "host": hostname.encode(),
+                "vram": str(vram_free).encode(),
             },
             server=f"{hostname}.local.",
         )
@@ -170,6 +175,8 @@ class PeerDiscovery:
             peer_id = peer_id_bytes.decode() if peer_id_bytes else name
             host_bytes = info.properties.get(b"host", b"")
             hostname = host_bytes.decode() if host_bytes else ""
+            vram_bytes = info.properties.get(b"vram", b"0")
+            vram_free = int(vram_bytes.decode()) if vram_bytes else 0
 
             # Skip ourselves
             if peer_id == self._instance_id:
@@ -181,9 +188,16 @@ class PeerDiscovery:
                 host=host,
                 port=info.port,
                 hostname=hostname,
+                vram_free=vram_free,
             )
             self._known_peers[peer_id] = peer
-            logger.info("PeerDiscovery: found peer %s @ %s:%d", peer_id, host, info.port)
+            logger.info(
+                "PeerDiscovery: found peer %s @ %s:%d (VRAM: %.1f MB)",
+                peer_id,
+                host,
+                info.port,
+                vram_free / 1024**2,
+            )
 
             if self.on_peer_found:
                 self.on_peer_found(peer)

--- a/daemon/pilot/network/peer_discovery.py
+++ b/daemon/pilot/network/peer_discovery.py
@@ -52,6 +52,7 @@ class PeerInfo:
     port: int  # P2P WebSocket port
     hostname: str = ""  # human-readable hostname
     vram_free: int = 0  # available VRAM in bytes
+    has_gpu: bool = False  # True if the peer has an NVIDIA GPU
 
 
 class PeerDiscovery:
@@ -94,7 +95,7 @@ class PeerDiscovery:
         # Register our own service
         hostname = socket.gethostname()
         local_ip = _get_local_ip()
-        vram_free = get_available_vram()
+        vram_free, has_gpu = get_available_vram()
         service_name = f"helioxos-{self._instance_id}.{_SERVICE_TYPE}"
 
         self._service_info = ServiceInfo(
@@ -106,6 +107,7 @@ class PeerDiscovery:
                 "id": self._instance_id.encode(),
                 "host": hostname.encode(),
                 "vram": str(vram_free).encode(),
+                "gpu": str(int(has_gpu)).encode(),
             },
             server=f"{hostname}.local.",
         )
@@ -135,6 +137,38 @@ class PeerDiscovery:
         await self._zc.async_close()
         self._zc = None
         logger.info("PeerDiscovery: stopped")
+
+    async def update_vram(self, vram_free: int, has_gpu: bool) -> None:
+        """Update the VRAM and GPU info in our registered mDNS service record."""
+        if not _ZEROCONF_AVAILABLE or self._zc is None or self._service_info is None:
+            return
+
+        # Check if values actually changed to avoid redundant mDNS traffic
+        current_vram = int(self._service_info.properties.get(b"vram", b"0").decode())
+        current_gpu = bool(int(self._service_info.properties.get(b"gpu", b"0").decode()))
+
+        if vram_free == current_vram and has_gpu == current_gpu:
+            return
+
+        new_properties = dict(self._service_info.properties)
+        new_properties[b"vram"] = str(vram_free).encode()
+        new_properties[b"gpu"] = str(int(has_gpu)).encode()
+
+        updated_info = ServiceInfo(
+            type_=self._service_info.type,
+            name=self._service_info.name,
+            addresses=self._service_info.addresses,
+            port=self._service_info.port,
+            properties=new_properties,
+            server=self._service_info.server,
+        )
+
+        try:
+            await self._zc.async_update_service(updated_info)
+            self._service_info = updated_info
+            logger.debug("PeerDiscovery: updated mDNS VRAM info (%.1f MB)", vram_free / 1024**2)
+        except Exception as exc:
+            logger.warning("PeerDiscovery: failed to update mDNS service: %s", exc)
 
     def _on_service_state_change(
         self,
@@ -177,6 +211,8 @@ class PeerDiscovery:
             hostname = host_bytes.decode() if host_bytes else ""
             vram_bytes = info.properties.get(b"vram", b"0")
             vram_free = int(vram_bytes.decode()) if vram_bytes else 0
+            gpu_bytes = info.properties.get(b"gpu", b"0")
+            has_gpu = bool(int(gpu_bytes.decode())) if gpu_bytes else False
 
             # Skip ourselves
             if peer_id == self._instance_id:
@@ -189,6 +225,7 @@ class PeerDiscovery:
                 port=info.port,
                 hostname=hostname,
                 vram_free=vram_free,
+                has_gpu=has_gpu,
             )
             self._known_peers[peer_id] = peer
             logger.info(

--- a/tauri-app/ui/package-lock.json
+++ b/tauri-app/ui/package-lock.json
@@ -956,7 +956,6 @@
       "integrity": "sha512-Y1Cs7hhTc+a5E9Va/xwKlAJoariQyHY+5zBgCZg4PFWNYQ1nMN9sjK1zhw1gK69DuqVP++sht/1GZg1aRwmAXQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@sveltejs/vite-plugin-svelte-inspector": "^4.0.1",
         "debug": "^4.4.1",
@@ -1053,7 +1052,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1084,7 +1082,6 @@
       "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.1.tgz",
       "integrity": "sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@kurkle/color": "^0.3.0"
       },
@@ -1560,7 +1557,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -1730,7 +1726,6 @@
       "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.55.7.tgz",
       "integrity": "sha512-ymI5ykLPwIHW839E053FQbI1G+jnRFJEw3Kv5Y4njixVWywQBx+NUFpkkKyk5LIb36Fg9DVXSYpqiGekLD0hyw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jridgewell/remapping": "^2.3.4",
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -2275,7 +2270,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -2290,7 +2284,6 @@
       "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",


### PR DESCRIPTION
This PR implements local LAN peer discovery using the mDNS/ZeroConf protocol to enable GPU clustering across multiple Heliox OS instances. Previously, inference was locked to the local machine; this change allows instances on the same network to automatically find each other and prioritize routing heavy tasks to the peer with the most available VRAM.

Closes #167

## Type of change

- New feature / enhancement
- Bug fix
- Documentation update
- Tests / CI
- Performance improvement
- Refactor (no functional change)
## Changes made

- gpu_utils.py : Added get_available_vram() to detect free NVIDIA VRAM (via pynvml) with a fallback to system RAM (via psutil).
- peer_discovery.py : Updated the _helioxos._tcp.local. service record to include a vram property in the TXT records. Discovered peers now report their hardware capacity immediately.
- peer_connection.py : Expanded the PeerCapabilities data class to include vram_free for the initial P2P handshake.
- mesh.py : Integrated local VRAM detection into the capability advertisement sent to the mesh.
- collab_executor.py : Rewrote the peer selection logic ( _pick_peer ) to prioritize nodes with the highest available VRAM, ensuring heavy workloads are routed to the most capable hardware in the cluster.
## How to test

1. Open two terminals in the daemon directory.
2. In Terminal 1, start a test node: python -c "from pilot.network.peer_discovery import PeerDiscovery; import asyncio; d=PeerDiscovery(8786, 'node-A'); d.on_peer_found=lambda p: print(f'Found {p.peer_id} with {p.vram_free/1024**2:.1f}MB VRAM'); asyncio.run(d.start()); asyncio.run(asyncio.sleep(30))"
3. In Terminal 2, start a second test node: python -c "from pilot.network.peer_discovery import PeerDiscovery; import asyncio; d=PeerDiscovery(8787, 'node-B'); asyncio.run(d.start()); asyncio.run(asyncio.sleep(30))"
4. Verify : Terminal 1 should log that it found node-B and correctly display its available VRAM capacity.
## Checklist

- I have read the CONTRIBUTING.md
- My code follows the existing code style
- I have added/updated tests where applicable
- All existing tests pass ( pytest for backend)
- I have updated documentation if needed
- I have tested on at least one platform (Windows)
## GSSoC declaration

- This contribution is made under the GSSoC 2026 program
- I have not plagiarised code from other repositories