### PR TITLE
chore: add Dependabot configuration for Python, npm, Cargo, and GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,46 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/daemon"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "dependabot"
+
+  - package-ecosystem: "pip"
+    directory: "/daemon/pilot/models"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+      - "dependabot"
+
+  - package-ecosystem: "npm"
+    directory: "/tauri-app/ui"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "dependabot"
+
+  - package-ecosystem: "cargo"
+    directory: "/tauri-app/src-tauri"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "dependabot"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "dependabot"


### PR DESCRIPTION
## Summary

Adds a Dependabot configuration to automate dependency updates across the major technology stacks used in Heliox-OS.

Closes #362

---

## Type of change

* [x] New feature / enhancement
* [ ] Bug fix
* [ ] Documentation update
* [ ] Tests / CI
* [ ] Performance improvement
* [ ] Refactor (no functional change)

---

## Changes made

* Added `.github/dependabot.yml`
* Configured weekly Dependabot updates for:

  * Python (`pip`)
  * npm
  * Cargo
  * GitHub Actions
* Added dependency labels for easier maintenance and review
* Configured conservative open PR limits to reduce update noise

---

## How to test

1. Open `.github/dependabot.yml`
2. Verify update entries exist for Python, npm, Cargo, and GitHub Actions
3. Validate the YAML structure using GitHub's Dependabot documentation or repository checks
4. Confirm the configuration targets the correct dependency manifest locations

---

## Checklist

* [x] I have read the [[CONTRIBUTING.md](https://chatgpt.com/CONTRIBUTING.md)](../CONTRIBUTING.md)
* [x] My code follows the existing code style
* [x] I have added/updated tests where applicable
* [x] All existing tests pass (`pytest` for backend, `npm run test` for frontend)
* [x] I have updated documentation if needed
* [x] I have tested on at least one platform (Windows / macOS / Linux)

---

## Screenshots / recordings (if UI change)

N/A

---

## GSSoC declaration

* [x] This contribution is made under the GSSoC 2026 program
* [x] I have not plagiarised code from other repositories