### PR TITLE
feat: add tamper-evident permission audit trail

### DIFF
--- a/daemon/pilot/agents/executor.py
+++ b/daemon/pilot/agents/executor.py
@@ -406,6 +406,8 @@ class Executor:
 
             await self._audit.log_action_start(action, plan_id)
 
+        batches = self._analyze_dependencies(plan.actions)
+
         for batch_idx, batch in enumerate(batches):
             if not batch:
                 continue

--- a/daemon/pilot/config.py
+++ b/daemon/pilot/config.py
@@ -35,6 +35,8 @@ CONFIG_FILE = CONFIG_DIR / "config.toml"
 RESTRICTIONS_FILE = CONFIG_DIR / "restrictions.toml"
 DB_FILE = DATA_DIR / "pilot.db"
 AUDIT_FILE = DATA_DIR / "audit.jsonl"
+PERMISSION_AUDIT_DB_FILE = DATA_DIR / "permission_audit.db"
+PERMISSION_AUDIT_KEY_FILE = DATA_DIR / "permission_audit.key"
 LOG_FILE = STATE_DIR / "pilot.log"
 
 

--- a/daemon/pilot/security/permission_audit.py
+++ b/daemon/pilot/security/permission_audit.py
@@ -1,0 +1,269 @@
+"""Tamper-evident audit store for permission escalation events."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import json
+import logging
+import os
+import secrets
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import aiosqlite
+
+from pilot.config import PERMISSION_AUDIT_DB_FILE, PERMISSION_AUDIT_KEY_FILE
+
+logger = logging.getLogger("pilot.security.permission_audit")
+
+
+@dataclass(frozen=True)
+class ChainVerificationResult:
+    valid: bool
+    checked_entries: int
+    error: str = ""
+
+
+class PermissionEscalationAuditStore:
+    """Append-only SQLite audit log with an HMAC chain.
+
+    The database stores high-risk permission events separately from the general
+    JSONL audit log. Every row commits to the previous row's HMAC, so deleting,
+    reordering, or modifying any prior record is detectable by ``verify_chain``.
+    """
+
+    def __init__(
+        self,
+        db_file: Path | None = None,
+        key_file: Path | None = None,
+        key: bytes | None = None,
+    ) -> None:
+        self._db_file = db_file or PERMISSION_AUDIT_DB_FILE
+        self._key_file = key_file or PERMISSION_AUDIT_KEY_FILE
+        self._key = key
+
+    async def initialize(self) -> None:
+        self._db_file.parent.mkdir(parents=True, exist_ok=True)
+        self._key = self._key or self._load_or_create_key()
+        async with aiosqlite.connect(self._db_file) as db:
+            await db.execute(
+                """
+                CREATE TABLE IF NOT EXISTS permission_escalation_audit (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    timestamp TEXT NOT NULL,
+                    plan_id TEXT NOT NULL,
+                    action_index INTEGER NOT NULL,
+                    action_type TEXT NOT NULL,
+                    target TEXT NOT NULL,
+                    permission_tier TEXT NOT NULL,
+                    requires_root INTEGER NOT NULL,
+                    destructive INTEGER NOT NULL,
+                    confirmation_decision TEXT NOT NULL,
+                    critic_verdict TEXT NOT NULL,
+                    execution_success INTEGER,
+                    execution_error TEXT NOT NULL,
+                    previous_hmac TEXT NOT NULL,
+                    entry_hmac TEXT NOT NULL
+                )
+                """
+            )
+            await db.execute(
+                """
+                CREATE INDEX IF NOT EXISTS idx_permission_audit_plan_id
+                ON permission_escalation_audit(plan_id)
+                """
+            )
+            await db.commit()
+
+    async def record_event(
+        self,
+        *,
+        plan_id: str,
+        action_index: int,
+        action_type: str,
+        target: str,
+        permission_tier: str,
+        requires_root: bool,
+        destructive: bool,
+        confirmation_decision: str,
+        critic_verdict: dict[str, Any] | None = None,
+        execution_success: bool | None = None,
+        execution_error: str = "",
+    ) -> str:
+        await self.initialize()
+        async with aiosqlite.connect(self._db_file) as db:
+            previous_hmac = await self._last_hmac(db)
+            payload = {
+                "timestamp": datetime.now(UTC).isoformat(),
+                "plan_id": plan_id,
+                "action_index": action_index,
+                "action_type": action_type,
+                "target": target,
+                "permission_tier": permission_tier,
+                "requires_root": bool(requires_root),
+                "destructive": bool(destructive),
+                "confirmation_decision": confirmation_decision,
+                "critic_verdict": critic_verdict or {},
+                "execution_success": execution_success,
+                "execution_error": execution_error,
+                "previous_hmac": previous_hmac,
+            }
+            entry_hmac = self._sign_payload(payload)
+            await db.execute(
+                """
+                INSERT INTO permission_escalation_audit (
+                    timestamp,
+                    plan_id,
+                    action_index,
+                    action_type,
+                    target,
+                    permission_tier,
+                    requires_root,
+                    destructive,
+                    confirmation_decision,
+                    critic_verdict,
+                    execution_success,
+                    execution_error,
+                    previous_hmac,
+                    entry_hmac
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    payload["timestamp"],
+                    plan_id,
+                    action_index,
+                    action_type,
+                    target,
+                    permission_tier,
+                    int(requires_root),
+                    int(destructive),
+                    confirmation_decision,
+                    self._json_dumps(critic_verdict or {}),
+                    None if execution_success is None else int(execution_success),
+                    execution_error,
+                    previous_hmac,
+                    entry_hmac,
+                ),
+            )
+            await db.commit()
+            return entry_hmac
+
+    async def verify_chain(self) -> ChainVerificationResult:
+        await self.initialize()
+        expected_previous = ""
+        checked = 0
+        async with (
+            aiosqlite.connect(self._db_file) as db,
+            db.execute(
+                """
+                SELECT
+                    id,
+                    timestamp,
+                    plan_id,
+                    action_index,
+                    action_type,
+                    target,
+                    permission_tier,
+                    requires_root,
+                    destructive,
+                    confirmation_decision,
+                    critic_verdict,
+                    execution_success,
+                    execution_error,
+                    previous_hmac,
+                    entry_hmac
+                FROM permission_escalation_audit
+                ORDER BY id ASC
+                """
+            ) as cursor,
+        ):
+            async for row in cursor:
+                checked += 1
+                (
+                    row_id,
+                    timestamp,
+                    plan_id,
+                    action_index,
+                    action_type,
+                    target,
+                    permission_tier,
+                    requires_root,
+                    destructive,
+                    confirmation_decision,
+                    critic_verdict,
+                    execution_success,
+                    execution_error,
+                    previous_hmac,
+                    entry_hmac,
+                ) = row
+                if previous_hmac != expected_previous:
+                    return ChainVerificationResult(
+                        valid=False,
+                        checked_entries=checked,
+                        error=f"Row {row_id} previous_hmac mismatch",
+                    )
+
+                payload = {
+                    "timestamp": timestamp,
+                    "plan_id": plan_id,
+                    "action_index": action_index,
+                    "action_type": action_type,
+                    "target": target,
+                    "permission_tier": permission_tier,
+                    "requires_root": bool(requires_root),
+                    "destructive": bool(destructive),
+                    "confirmation_decision": confirmation_decision,
+                    "critic_verdict": json.loads(critic_verdict),
+                    "execution_success": None
+                    if execution_success is None
+                    else bool(execution_success),
+                    "execution_error": execution_error,
+                    "previous_hmac": previous_hmac,
+                }
+                expected_hmac = self._sign_payload(payload)
+                if not hmac.compare_digest(entry_hmac, expected_hmac):
+                    return ChainVerificationResult(
+                        valid=False,
+                        checked_entries=checked,
+                        error=f"Row {row_id} entry_hmac mismatch",
+                    )
+                expected_previous = entry_hmac
+
+        return ChainVerificationResult(valid=True, checked_entries=checked)
+
+    async def _last_hmac(self, db: aiosqlite.Connection) -> str:
+        async with db.execute(
+            """
+            SELECT entry_hmac FROM permission_escalation_audit
+            ORDER BY id DESC
+            LIMIT 1
+            """
+        ) as cursor:
+            row = await cursor.fetchone()
+        return str(row[0]) if row else ""
+
+    def _load_or_create_key(self) -> bytes:
+        self._key_file.parent.mkdir(parents=True, exist_ok=True)
+        if self._key_file.exists():
+            return base64.b64decode(self._key_file.read_text(encoding="utf-8"))
+
+        key = secrets.token_bytes(32)
+        self._key_file.write_text(base64.b64encode(key).decode("ascii"), encoding="utf-8")
+        try:
+            os.chmod(self._key_file, 0o600)
+        except OSError:
+            logger.warning("Unable to restrict permission audit key file permissions", exc_info=True)
+        return key
+
+    def _sign_payload(self, payload: dict[str, Any]) -> str:
+        if self._key is None:
+            self._key = self._load_or_create_key()
+        return hmac.new(self._key, self._json_dumps(payload).encode("utf-8"), hashlib.sha256).hexdigest()
+
+    @staticmethod
+    def _json_dumps(payload: dict[str, Any]) -> str:
+        return json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False)

--- a/daemon/pilot/server.py
+++ b/daemon/pilot/server.py
@@ -108,6 +108,7 @@ class PilotServer:
         self._screen_vision: Any = None
         self._memory: Any = None
         self._vault: Any = None
+        self._permission_audit: Any = None
         # Cognitive intelligence (TRIBE v2)
         self._tribe_engine: Any = None
         self._attention_ui: Any = None
@@ -144,6 +145,7 @@ class PilotServer:
         from pilot.memory.store import MemoryStore
         from pilot.models.router import ModelRouter
         from pilot.security.audit import AuditLogger
+        from pilot.security.permission_audit import PermissionEscalationAuditStore
         from pilot.security.permissions import PermissionChecker
         from pilot.security.validator import ActionValidator
         from pilot.security.vault import KeyVault
@@ -159,6 +161,8 @@ class PilotServer:
         model_router.set_budget_tracker(self._budget_tracker)
 
         audit = AuditLogger()
+        self._permission_audit = PermissionEscalationAuditStore()
+        await self._permission_audit.initialize()
         validator = ActionValidator(self.config)
         permissions = PermissionChecker(self.config)
         self._memory = MemoryStore()
@@ -695,6 +699,7 @@ class PilotServer:
 
             from pilot.actions import PermissionTier
 
+            critic_verdict_payload: dict[str, Any] | None = None
             plan_has_tier4 = any(a.permission_tier == PermissionTier.ROOT_CRITICAL for a in plan.actions)
             if plan_has_tier4 and self._destructive_critic and not dry_run:
                 critic_phase = ""
@@ -712,9 +717,18 @@ class PilotServer:
                     )
 
                 verdict = await self._destructive_critic.review(user_input, plan)
+                critic_verdict_payload = verdict.to_dict()
                 await ws.send(_notification("critic_verdict", verdict.to_dict()))
 
                 if verdict.is_blocked:
+                    await self._record_permission_escalations(
+                        plan_id=plan_id,
+                        plan=plan,
+                        confirmation_decision="blocked_by_critic",
+                        critic_verdict=critic_verdict_payload,
+                        results=[],
+                        execution_error=verdict.recommendation,
+                    )
                     if emit:
                         await emit.phase_error(
                             "critic_review",
@@ -762,6 +776,14 @@ class PilotServer:
                         )
 
                 if not confirmed:
+                    await self._record_permission_escalations(
+                        plan_id=plan_id,
+                        plan=plan,
+                        confirmation_decision="denied",
+                        critic_verdict=critic_verdict_payload,
+                        results=[],
+                        execution_error="Plan was denied by user.",
+                    )
                     await _emit_task_complete("cancelled", "Plan was denied by user.")
                     return {
                         "status": "cancelled",
@@ -841,6 +863,14 @@ class PilotServer:
                     cancel_event=cancel_event,  # ── Cancel Token (Issue #92) ──
                 )
             all_results = results
+            if needs_confirm and not dry_run:
+                await self._record_permission_escalations(
+                    plan_id=plan_id,
+                    plan=plan,
+                    confirmation_decision="approved",
+                    critic_verdict=critic_verdict_payload,
+                    results=results,
+                )
 
             # ── Cancel Token: if aborted mid-execution, return immediately ──
             if cancel_event.is_set():
@@ -983,6 +1013,61 @@ class PilotServer:
                 else last_explanation
             ),
         }
+
+    async def _record_permission_escalations(
+        self,
+        *,
+        plan_id: str,
+        plan: Any,
+        confirmation_decision: str,
+        critic_verdict: dict[str, Any] | None,
+        results: list[Any],
+        execution_error: str = "",
+    ) -> None:
+        """Persist tamper-evident records for elevated permission decisions."""
+        if not self._permission_audit:
+            return
+
+        from pilot.actions import PermissionTier
+
+        result_by_action: dict[str, list[Any]] = {}
+        for result in results:
+            action_key = self._action_signature(result.action)
+            result_by_action.setdefault(action_key, []).append(result)
+
+        for index, action in enumerate(plan.actions):
+            if action.permission_tier < PermissionTier.SYSTEM_MODIFY:
+                continue
+
+            matched_result = None
+            matches = result_by_action.get(self._action_signature(action))
+            if matches:
+                matched_result = matches.pop(0)
+
+            if matched_result is None:
+                execution_success = None
+                action_error = execution_error
+            else:
+                execution_success = bool(matched_result.success)
+                action_error = matched_result.error or ""
+
+            await self._permission_audit.record_event(
+                plan_id=plan_id,
+                action_index=index,
+                action_type=action.action_type.value,
+                target=action.target,
+                permission_tier=action.permission_tier.name,
+                requires_root=action.requires_root,
+                destructive=action.destructive,
+                confirmation_decision=confirmation_decision,
+                critic_verdict=critic_verdict,
+                execution_success=execution_success,
+                execution_error=action_error,
+            )
+
+    @staticmethod
+    def _action_signature(action: Any) -> str:
+        return json.dumps(action.model_dump(mode="json"), sort_keys=True, separators=(",", ":"))
 
     async def _wait_for_confirmation(self, plan_id: str, plan: Any, ws: ServerConnection) -> bool:
         """Send a confirmation request and block until the user responds or timeout.

--- a/daemon/tests/test_permission_escalation_audit.py
+++ b/daemon/tests/test_permission_escalation_audit.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import aiosqlite
+import pytest
+
+from pilot.security.permission_audit import PermissionEscalationAuditStore
+
+
+async def _store(tmp_path):
+    store = PermissionEscalationAuditStore(
+        db_file=tmp_path / "permission_audit.db",
+        key_file=tmp_path / "permission_audit.key",
+        key=b"0" * 32,
+    )
+    await store.initialize()
+    return store
+
+
+@pytest.mark.asyncio
+async def test_permission_audit_records_and_verifies_hmac_chain(tmp_path):
+    store = await _store(tmp_path)
+
+    first_hmac = await store.record_event(
+        plan_id="plan-1",
+        action_index=0,
+        action_type="service_restart",
+        target="nginx",
+        permission_tier="SYSTEM_MODIFY",
+        requires_root=False,
+        destructive=False,
+        confirmation_decision="approved",
+        critic_verdict={"verdict": "APPROVE", "risk_score": 0.2},
+        execution_success=True,
+    )
+    second_hmac = await store.record_event(
+        plan_id="plan-1",
+        action_index=1,
+        action_type="file_delete",
+        target="/tmp/demo",
+        permission_tier="DESTRUCTIVE",
+        requires_root=False,
+        destructive=True,
+        confirmation_decision="approved",
+        critic_verdict={"verdict": "WARN", "risk_score": 0.5},
+        execution_success=False,
+        execution_error="permission denied",
+    )
+
+    assert first_hmac != second_hmac
+    verification = await store.verify_chain()
+    assert verification.valid is True
+    assert verification.checked_entries == 2
+
+
+@pytest.mark.asyncio
+async def test_permission_audit_detects_tampered_rows(tmp_path):
+    store = await _store(tmp_path)
+    await store.record_event(
+        plan_id="plan-2",
+        action_index=0,
+        action_type="package_remove",
+        target="openssl",
+        permission_tier="DESTRUCTIVE",
+        requires_root=True,
+        destructive=True,
+        confirmation_decision="denied",
+        critic_verdict={"verdict": "BLOCK", "risk_score": 0.9},
+        execution_success=None,
+        execution_error="Plan was denied by user.",
+    )
+
+    async with aiosqlite.connect(tmp_path / "permission_audit.db") as db:
+        await db.execute(
+            """
+            UPDATE permission_escalation_audit
+            SET target = ?
+            WHERE id = 1
+            """,
+            ("/etc/passwd",),
+        )
+        await db.commit()
+
+    verification = await store.verify_chain()
+    assert verification.valid is False
+    assert verification.checked_entries == 1
+    assert "entry_hmac mismatch" in verification.error


### PR DESCRIPTION
## Summary\n- add a tamper-evident audit trail for permission escalations\n- persist the audit data through the daemon and server flow\n\n## Validation\n- reviewed the security and daemon diff\n- no unrelated UI changes