### PR TITLE
fix(executor): attribute parallel-batch exceptions to the correct action (#415)

### DIFF
--- a/daemon/pilot/agents/executor.py
+++ b/daemon/pilot/agents/executor.py
@@ -336,6 +336,40 @@ class Executor:
 
         return batches if batches else [[a] for a in actions]
 
+    def _collect_batch_results(
+        self,
+        batch: list[Action],
+        batch_results: list,
+        results: list[ActionResult],
+    ) -> bool:
+        """Map parallel-batch results back to their actions and append to results.
+
+        asyncio.gather preserves input order, so batch_results[i] corresponds to
+        batch[i]. For a raised exception (which carries no index), the position
+        is the only link back to the action that failed — so attribute it to
+        batch[position] rather than batch[0] (issue #415).
+
+        Returns True if any action in the batch failed.
+        """
+        failed = False
+        for position, item in enumerate(batch_results):
+            if isinstance(item, Exception):
+                results.append(ActionResult(action=batch[position], success=False, error=str(item)))
+                failed = True
+            else:
+                _idx, result = item
+                results.append(result)
+                if result.success:
+                    self._last_output = result.output
+                    if not hasattr(self, "_largest_output") or len(result.output or "") > len(
+                        self._largest_output or ""
+                    ):
+                        self._largest_output = result.output
+                else:
+                    failed = True
+                    logger.error("Action in batch failed: %s", result.error)
+        return failed
+
     async def execute(
         self,
         plan: ActionPlan,
@@ -467,23 +501,7 @@ class Executor:
                 *[execute_single_action(action, i) for i, action in enumerate(batch)], return_exceptions=True
             )
 
-            failed = False
-            for item in batch_results:
-                if isinstance(item, Exception):
-                    results.append(ActionResult(action=batch[0], success=False, error=str(item)))
-                    failed = True
-                else:
-                    idx, result = item
-                    results.append(result)
-                    if result.success:
-                        self._last_output = result.output
-                        if not hasattr(self, "_largest_output") or len(result.output or "") > len(
-                            self._largest_output or ""
-                        ):
-                            self._largest_output = result.output
-                    else:
-                        failed = True
-                        logger.error("Action in batch failed: %s", result.error)
+            failed = self._collect_batch_results(batch, batch_results, results)
 
             if failed and batch_idx < len(batches) - 1:
                 remaining = sum(len(b) for b in batches[batch_idx + 1 :])

--- a/daemon/tests/test_executor_batch_attribution.py
+++ b/daemon/tests/test_executor_batch_attribution.py
@@ -1,0 +1,78 @@
+"""Regression test for batch exception attribution
+
+When an action in a parallel batch raises, the failure must be attributed to
+the action that actually raised — not always batch[0]. asyncio.gather preserves
+input order, so batch_results[i] corresponds to batch[i]; a raised exception
+carries no index, so position is the only link back to the action.
+"""
+
+from pilot.actions import Action, ActionResult, ActionType, EmptyParams
+from pilot.agents.executor import Executor
+
+
+def _make_action(target: str) -> Action:
+    return Action(action_type=ActionType.FILE_READ, target=target, parameters=EmptyParams())
+
+
+def _bare_executor() -> Executor:
+    # Build an Executor without running __init__ (which constructs snapshot
+    # managers, dispatch tables, etc.) — _collect_batch_results only touches
+    # _last_output / _largest_output.
+    ex = object.__new__(Executor)
+    ex._last_output = ""
+    ex._largest_output = ""
+    return ex
+
+
+def test_exception_attributed_to_failing_action_not_first():
+    ex = _bare_executor()
+    batch = [_make_action("action0"), _make_action("action1"), _make_action("action2")]
+    # gather returns positionally: action0 ok, action1 raised, action2 ok.
+    # Success items are (idx, ActionResult) tuples; the exception is the bare exc.
+    batch_results = [
+        (0, ActionResult(action=batch[0], success=True, output="ok0")),
+        ValueError("action1 blew up"),
+        (2, ActionResult(action=batch[2], success=True, output="ok2")),
+    ]
+    results: list[ActionResult] = []
+    failed = ex._collect_batch_results(batch, batch_results, results)
+
+    assert failed is True
+    # The failure must name action1 (the one that raised), not action0 (batch[0]).
+    failures = [r for r in results if not r.success]
+    assert len(failures) == 1
+    assert failures[0].action.target == "action1"
+    assert "action1 blew up" in (failures[0].error or "")
+
+
+def test_first_action_exception_still_correct():
+    # Guard the boundary: when batch[0] is the one that raises, it should still
+    # be attributed to batch[0] (the old code happened to be right only here).
+    ex = _bare_executor()
+    batch = [_make_action("action0"), _make_action("action1")]
+    batch_results = [
+        RuntimeError("action0 failed"),
+        (1, ActionResult(action=batch[1], success=True, output="ok1")),
+    ]
+    results: list[ActionResult] = []
+    failed = ex._collect_batch_results(batch, batch_results, results)
+
+    assert failed is True
+    failures = [r for r in results if not r.success]
+    assert len(failures) == 1
+    assert failures[0].action.target == "action0"
+
+
+def test_all_success_returns_not_failed():
+    ex = _bare_executor()
+    batch = [_make_action("a"), _make_action("b")]
+    batch_results = [
+        (0, ActionResult(action=batch[0], success=True, output="x")),
+        (1, ActionResult(action=batch[1], success=True, output="y")),
+    ]
+    results: list[ActionResult] = []
+    failed = ex._collect_batch_results(batch, batch_results, results)
+
+    assert failed is False
+    assert len(results) == 2
+    assert all(r.success for r in results)


### PR DESCRIPTION
## Summary

In the parallel-batch path of `Executor.execute`, when an action raised an exception, the failure was always recorded against `batch[0]` - the first action in the batch - regardless of which action actually raised. `asyncio.gather` returns results positionally, so the exception's position in `batch_results` corresponds to `batch[position]`, but that position was discarded and `batch[0]` was hardcoded. Since `_analyze_dependencies` groups independent actions into multi-action batches, a non-first action raising would name the wrong action in the resulting `ActionResult` and the audit trail.

This fixes the attribution to use the position, and extracts the batch-result collection into a small testable method so the behavior can be unit-tested.

Closes #415

---

## Type of change
- [x] Bug fix
- [ ] New feature / enhancement
- [ ] Documentation update
- [ ] Tests / CI
- [ ] Performance improvement
- [ ] Refactor (no functional change)

---

## Changes made

- `daemon/pilot/agents/executor.py`: extracted the parallel-batch result handling into `_collect_batch_results(batch, batch_results, results)`, which iterates with `enumerate` and attributes a raised exception to `batch[position]` instead of `batch[0]`. The success branch is unchanged (it already used the `idx` returned by `execute_single_action`).
- `daemon/tests/test_executor_batch_attribution.py`: new unit tests - a non-first action raising is attributed to the correct action, the first-action case still works (guards against simply flipping the bug), and an all-success batch reports no failure.

---

## How to test

1. `pytest daemon/tests/test_executor_batch_attribution.py -v` - the three tests pass.
2. The key test, `test_exception_attributed_to_failing_action_not_first`, fails against the old `batch[0]` code and passes with the fix - it builds a 3-action batch where the second action raises and asserts the failure names that action.
3. `ruff check` and `ruff format --check` on the two files are clean.

---

## Checklist
- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My code follows the existing code style
- [x] I have added/updated tests where applicable
- [ ] All existing tests pass (`pytest` for backend, `npm run test` for frontend)
- [ ] I have updated documentation if needed
- [x] I have tested on at least one platform (Windows / macOS / Linux)

---

## Screenshots / recordings (if UI change)

N/A — no UI change.

---

## GSSoC declaration
- [x] This contribution is made under the GSSoC 2026 program
- [x] I have not plagiarised code from other repositories