### PR TITLE
docs: fix directory path in build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -744,7 +744,7 @@ If you want to contribute or modify Heliox OS, build it from the source code:
 **1. Install the Python daemon:**
 ```bash
 git clone https://github.com/VyomKulshrestha/Heliox-OS.git
-cd Heliox OS/daemon
+cd Heliox-OS/daemon
 pip install -e ".[full,dev]"
 ```
 


### PR DESCRIPTION
## Summary

This PR fixes a typo in the "Build from Source" instructions within the README. Previously, the directory navigation command included a space (`cd Heliox OS/daemon`), which causes a "No such file or directory" error when users try to copy-paste the setup steps. Because the repository is named `Heliox-OS`, `git clone` creates a folder with a hyphen by default. Updating the command to `cd Heliox-OS/daemon` ensures developers can seamlessly navigate into the backend directory and set up the project.

Closes #None (just a documentation fix)

---

## Type of change

- [ ] Bug fix
- [ ] New feature / enhancement
- [x] Documentation update
- [ ] Tests / CI
- [ ] Performance improvement
- [ ] Refactor (no functional change)

---

## Changes made

- Updated `README.md` to correct the directory path (`cd Heliox-OS/daemon`) in the developer setup instructions under the "Option 2: Build from Source (For Developers)" section.

---

## How to test

1. Review the changes made to `README.md` in this PR.
2. Scroll to the "Option 2: Build from Source (For Developers)" section.
3. Verify that the command block now correctly shows `cd Heliox-OS/daemon` instead of `cd Heliox OS/daemon`.

---

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My code follows the existing code style
- [ ] I have added/updated tests where applicable
- [ ] All existing tests pass (`pytest` for backend, `npm run test` for frontend)
- [x] I have updated documentation if needed
- [x] I have tested on at least one platform (Windows / macOS / Linux)

---

## Screenshots / recordings (if UI change)

<!-- Drag and drop a screenshot or screen recording here -->
N/A

---

## GSSoC declaration

- [x] This contribution is made under the GSSoC 2026 program
- [x] I have not plagiarised code from other repositories